### PR TITLE
Migrate redux

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Your app is ready to be deployed!
 See the section about [deployment](https://facebook.github.io/create-react-app/docs/deployment) for more information.
 
 ## Future Features
-- [ ] Migrate the annotation visit logic to Redux
+- [x] Migrate the annotation visit logic to Redux
 - [ ] Store opened note history in browser storage to allow users to close tab and return later
 - [ ] Add user generated content - voting on notes, adding new notes
 - [ ] Allow users to persist their reading history between browser data deletion with accounts

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Ulysses Companion
 
-[Ulysses Companion](https://camin.xyz/ulysses-companion) is an interactive ebook, with reading notes for Jame Joyce's modern classic Ulysses. This site is a port of www.joyceproject.com that improves on the UX by allowing users to open annotations while reading the text and tracks which notes have already been read (as the notes are often repeated where relevant in the text).
+[Ulysses Companion](https://camin.xyz/ulysses-companion) is an interactive ebook, with reading notes for James Joyce's modern classic Ulysses. This site is a port of www.joyceproject.com that improves on the UX by allowing users to open annotations while reading the text and tracks which notes have already been read (as the notes are often repeated where relevant in the text).
 
 PRs are welcome to extend the notes - a contribution guide is coming soon.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@craco/craco": "^6.3.0",
+        "@reduxjs/toolkit": "^1.6.1",
         "@testing-library/jest-dom": "^5.14.1",
         "@testing-library/react": "^11.2.7",
         "@testing-library/user-event": "^12.8.3",
@@ -2745,6 +2746,38 @@
       "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-1.6.1.tgz",
+      "integrity": "sha512-pa3nqclCJaZPAyBhruQtiRwtTjottRrVJqziVZcWzI73i6L3miLTtUyWfauwv08HWtiXLx1xGyGt+yLFfW/d0A==",
+      "dependencies": {
+        "immer": "^9.0.1",
+        "redux": "^4.1.0",
+        "redux-thunk": "^2.3.0",
+        "reselect": "^4.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.14.0 || ^17.0.0",
+        "react-redux": "^7.2.1"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reduxjs/toolkit/node_modules/immer": {
+      "version": "9.0.6",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.6.tgz",
+      "integrity": "sha512-G95ivKpy+EvVAnAab4fVa4YGYn24J1SpEktnJX7JJ45Bd7xqME/SCplFzYFmTbrkwZbQ4xJK1xMTUYBkN6pWsQ==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
       }
     },
     "node_modules/@rollup/plugin-node-resolve": {
@@ -17304,6 +17337,19 @@
       "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
       "dev": true
     },
+    "node_modules/redux": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.1.1.tgz",
+      "integrity": "sha512-hZQZdDEM25UY2P493kPYuKqviVwZ58lEmGQNeQ+gXa+U0gYPUBf7NKYazbe3m+bs/DzM/ahN12DbF+NG8i0CWw==",
+      "dependencies": {
+        "@babel/runtime": "^7.9.2"
+      }
+    },
+    "node_modules/redux-thunk": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.3.0.tgz",
+      "integrity": "sha512-km6dclyFnmcvxhAcrQV2AkZmPQjzPDjgVlQtR0EQjxZPyJ0BnMf3in1ryuR8A2qU0HldVRfxYXbFSKlI3N7Slw=="
+    },
     "node_modules/regenerate": {
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.2.tgz",
@@ -17501,6 +17547,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
+    },
+    "node_modules/reselect": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.0.0.tgz",
+      "integrity": "sha512-qUgANli03jjAyGlnbYVAV5vvnOmJnODyABz51RdBN7M4WaVu8mecZWgyQNkG8Yqe3KRGRt0l4K4B3XVEULC4CA=="
     },
     "node_modules/resolve": {
       "version": "1.18.1",
@@ -24434,6 +24485,24 @@
           "version": "0.7.3",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
           "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ=="
+        }
+      }
+    },
+    "@reduxjs/toolkit": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-1.6.1.tgz",
+      "integrity": "sha512-pa3nqclCJaZPAyBhruQtiRwtTjottRrVJqziVZcWzI73i6L3miLTtUyWfauwv08HWtiXLx1xGyGt+yLFfW/d0A==",
+      "requires": {
+        "immer": "^9.0.1",
+        "redux": "^4.1.0",
+        "redux-thunk": "^2.3.0",
+        "reselect": "^4.0.0"
+      },
+      "dependencies": {
+        "immer": {
+          "version": "9.0.6",
+          "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.6.tgz",
+          "integrity": "sha512-G95ivKpy+EvVAnAab4fVa4YGYn24J1SpEktnJX7JJ45Bd7xqME/SCplFzYFmTbrkwZbQ4xJK1xMTUYBkN6pWsQ=="
         }
       }
     },
@@ -35651,6 +35720,19 @@
         }
       }
     },
+    "redux": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.1.1.tgz",
+      "integrity": "sha512-hZQZdDEM25UY2P493kPYuKqviVwZ58lEmGQNeQ+gXa+U0gYPUBf7NKYazbe3m+bs/DzM/ahN12DbF+NG8i0CWw==",
+      "requires": {
+        "@babel/runtime": "^7.9.2"
+      }
+    },
+    "redux-thunk": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.3.0.tgz",
+      "integrity": "sha512-km6dclyFnmcvxhAcrQV2AkZmPQjzPDjgVlQtR0EQjxZPyJ0BnMf3in1ryuR8A2qU0HldVRfxYXbFSKlI3N7Slw=="
+    },
     "regenerate": {
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.2.tgz",
@@ -35804,6 +35886,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
+    },
+    "reselect": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.0.0.tgz",
+      "integrity": "sha512-qUgANli03jjAyGlnbYVAV5vvnOmJnODyABz51RdBN7M4WaVu8mecZWgyQNkG8Yqe3KRGRt0l4K4B3XVEULC4CA=="
     },
     "resolve": {
       "version": "1.18.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@testing-library/user-event": "^12.8.3",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
+        "react-redux": "^7.2.5",
         "react-scripts": "4.0.3",
         "web-vitals": "^1.1.2"
       },
@@ -3541,6 +3542,15 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/hoist-non-react-statics": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
+      "integrity": "sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==",
+      "dependencies": {
+        "@types/react": "*",
+        "hoist-non-react-statics": "^3.3.0"
+      }
+    },
     "node_modules/@types/html-minifier-terser": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/@types/html-minifier-terser/-/html-minifier-terser-5.1.2.tgz",
@@ -3753,10 +3763,36 @@
       "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.3.2.tgz",
       "integrity": "sha512-eI5Yrz3Qv4KPUa/nSIAi0h+qX0XyewOliug5F2QAtuRg6Kjg6jfmxe1GIwoIRhZspD1A0RP8ANrPwvEXXtRFog=="
     },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.4",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.4.tgz",
+      "integrity": "sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ=="
+    },
     "node_modules/@types/q": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.5.tgz",
       "integrity": "sha512-L28j2FcJfSZOnL1WBjDYp2vUHCeIFlyYI/53EwD/rKUBQ7MtUUfbQWiyKJGpcnv4/WgrhWsFKrcPstcAt/J0tQ=="
+    },
+    "node_modules/@types/react": {
+      "version": "17.0.24",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.24.tgz",
+      "integrity": "sha512-eIpyco99gTH+FTI3J7Oi/OH8MZoFMJuztNRimDOJwH4iGIsKV2qkGnk4M9VzlaVWeEEWLWSQRy0FEA0Kz218cg==",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "@types/scheduler": "*",
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@types/react-redux": {
+      "version": "7.1.18",
+      "resolved": "https://registry.npmjs.org/@types/react-redux/-/react-redux-7.1.18.tgz",
+      "integrity": "sha512-9iwAsPyJ9DLTRH+OFeIrm9cAbIj1i2ANL3sKQFATqnPWRbg+jEFXyZOKHiQK/N86pNRXbb4HRxAxo0SIX1XwzQ==",
+      "dependencies": {
+        "@types/hoist-non-react-statics": "^3.3.0",
+        "@types/react": "*",
+        "hoist-non-react-statics": "^3.3.0",
+        "redux": "^4.0.0"
+      }
     },
     "node_modules/@types/resolve": {
       "version": "0.0.8",
@@ -3765,6 +3801,11 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/scheduler": {
+      "version": "0.16.2",
+      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
+      "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew=="
     },
     "node_modules/@types/source-list-map": {
       "version": "0.1.2",
@@ -6883,6 +6924,11 @@
       "version": "0.3.8",
       "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
       "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg=="
+    },
+    "node_modules/csstype": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.9.tgz",
+      "integrity": "sha512-rpw6JPxK6Rfg1zLOYCSwle2GFOOsnjmDYDaBwEcwoOg4qlsIVCN789VkBZDJAGi4T07gI4YSutR43t9Zz4Lzuw=="
     },
     "node_modules/cyclist": {
       "version": "1.0.1",
@@ -10151,6 +10197,19 @@
         "minimalistic-assert": "^1.0.0",
         "minimalistic-crypto-utils": "^1.0.1"
       }
+    },
+    "node_modules/hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "dependencies": {
+        "react-is": "^16.7.0"
+      }
+    },
+    "node_modules/hoist-non-react-statics/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/hoopy": {
       "version": "0.1.4",
@@ -17029,6 +17088,35 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
+    },
+    "node_modules/react-redux": {
+      "version": "7.2.5",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.2.5.tgz",
+      "integrity": "sha512-Dt29bNyBsbQaysp6s/dN0gUodcq+dVKKER8Qv82UrpeygwYeX1raTtil7O/fftw/rFqzaf6gJhDZRkkZnn6bjg==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.1",
+        "@types/react-redux": "^7.1.16",
+        "hoist-non-react-statics": "^3.3.2",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.7.2",
+        "react-is": "^16.13.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8.3 || ^17"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-redux/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/react-refresh": {
       "version": "0.8.3",
@@ -25054,6 +25142,15 @@
         "@types/node": "*"
       }
     },
+    "@types/hoist-non-react-statics": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
+      "integrity": "sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==",
+      "requires": {
+        "@types/react": "*",
+        "hoist-non-react-statics": "^3.3.0"
+      }
+    },
     "@types/html-minifier-terser": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/@types/html-minifier-terser/-/html-minifier-terser-5.1.2.tgz",
@@ -25228,10 +25325,36 @@
       "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.3.2.tgz",
       "integrity": "sha512-eI5Yrz3Qv4KPUa/nSIAi0h+qX0XyewOliug5F2QAtuRg6Kjg6jfmxe1GIwoIRhZspD1A0RP8ANrPwvEXXtRFog=="
     },
+    "@types/prop-types": {
+      "version": "15.7.4",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.4.tgz",
+      "integrity": "sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ=="
+    },
     "@types/q": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.5.tgz",
       "integrity": "sha512-L28j2FcJfSZOnL1WBjDYp2vUHCeIFlyYI/53EwD/rKUBQ7MtUUfbQWiyKJGpcnv4/WgrhWsFKrcPstcAt/J0tQ=="
+    },
+    "@types/react": {
+      "version": "17.0.24",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.24.tgz",
+      "integrity": "sha512-eIpyco99gTH+FTI3J7Oi/OH8MZoFMJuztNRimDOJwH4iGIsKV2qkGnk4M9VzlaVWeEEWLWSQRy0FEA0Kz218cg==",
+      "requires": {
+        "@types/prop-types": "*",
+        "@types/scheduler": "*",
+        "csstype": "^3.0.2"
+      }
+    },
+    "@types/react-redux": {
+      "version": "7.1.18",
+      "resolved": "https://registry.npmjs.org/@types/react-redux/-/react-redux-7.1.18.tgz",
+      "integrity": "sha512-9iwAsPyJ9DLTRH+OFeIrm9cAbIj1i2ANL3sKQFATqnPWRbg+jEFXyZOKHiQK/N86pNRXbb4HRxAxo0SIX1XwzQ==",
+      "requires": {
+        "@types/hoist-non-react-statics": "^3.3.0",
+        "@types/react": "*",
+        "hoist-non-react-statics": "^3.3.0",
+        "redux": "^4.0.0"
+      }
     },
     "@types/resolve": {
       "version": "0.0.8",
@@ -25240,6 +25363,11 @@
       "requires": {
         "@types/node": "*"
       }
+    },
+    "@types/scheduler": {
+      "version": "0.16.2",
+      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
+      "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew=="
     },
     "@types/source-list-map": {
       "version": "0.1.2",
@@ -27720,6 +27848,11 @@
         }
       }
     },
+    "csstype": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.9.tgz",
+      "integrity": "sha512-rpw6JPxK6Rfg1zLOYCSwle2GFOOsnjmDYDaBwEcwoOg4qlsIVCN789VkBZDJAGi4T07gI4YSutR43t9Zz4Lzuw=="
+    },
     "cyclist": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/cyclist/-/cyclist-1.0.1.tgz",
@@ -30192,6 +30325,21 @@
         "hash.js": "^1.0.3",
         "minimalistic-assert": "^1.0.0",
         "minimalistic-crypto-utils": "^1.0.1"
+      }
+    },
+    "hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "requires": {
+        "react-is": "^16.7.0"
+      },
+      "dependencies": {
+        "react-is": {
+          "version": "16.13.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+        }
       }
     },
     "hoopy": {
@@ -35469,6 +35617,26 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
+    },
+    "react-redux": {
+      "version": "7.2.5",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.2.5.tgz",
+      "integrity": "sha512-Dt29bNyBsbQaysp6s/dN0gUodcq+dVKKER8Qv82UrpeygwYeX1raTtil7O/fftw/rFqzaf6gJhDZRkkZnn6bjg==",
+      "requires": {
+        "@babel/runtime": "^7.12.1",
+        "@types/react-redux": "^7.1.16",
+        "hoist-non-react-statics": "^3.3.2",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.7.2",
+        "react-is": "^16.13.1"
+      },
+      "dependencies": {
+        "react-is": {
+          "version": "16.13.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+        }
+      }
     },
     "react-refresh": {
       "version": "0.8.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@testing-library/jest-dom": "^5.14.1",
         "@testing-library/react": "^11.2.7",
         "@testing-library/user-event": "^12.8.3",
+        "immer": "^9.0.6",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
         "react-redux": "^7.2.5",
@@ -2770,15 +2771,6 @@
         "react-redux": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@reduxjs/toolkit/node_modules/immer": {
-      "version": "9.0.6",
-      "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.6.tgz",
-      "integrity": "sha512-G95ivKpy+EvVAnAab4fVa4YGYn24J1SpEktnJX7JJ45Bd7xqME/SCplFzYFmTbrkwZbQ4xJK1xMTUYBkN6pWsQ==",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/immer"
       }
     },
     "node_modules/@rollup/plugin-node-resolve": {
@@ -10641,9 +10633,9 @@
       }
     },
     "node_modules/immer": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/immer/-/immer-8.0.1.tgz",
-      "integrity": "sha512-aqXhGP7//Gui2+UrEtvxZxSquQVXTpZ7KDxfCcKAF3Vysvw0CViVaW9RZ1j1xlIYqaaaipBoqdqeibkc18PNvA==",
+      "version": "9.0.6",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.6.tgz",
+      "integrity": "sha512-G95ivKpy+EvVAnAab4fVa4YGYn24J1SpEktnJX7JJ45Bd7xqME/SCplFzYFmTbrkwZbQ4xJK1xMTUYBkN6pWsQ==",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/immer"
@@ -17011,6 +17003,15 @@
       "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/react-dev-utils/node_modules/immer": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-8.0.1.tgz",
+      "integrity": "sha512-aqXhGP7//Gui2+UrEtvxZxSquQVXTpZ7KDxfCcKAF3Vysvw0CViVaW9RZ1j1xlIYqaaaipBoqdqeibkc18PNvA==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
       }
     },
     "node_modules/react-dev-utils/node_modules/locate-path": {
@@ -24585,13 +24586,6 @@
         "redux": "^4.1.0",
         "redux-thunk": "^2.3.0",
         "reselect": "^4.0.0"
-      },
-      "dependencies": {
-        "immer": {
-          "version": "9.0.6",
-          "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.6.tgz",
-          "integrity": "sha512-G95ivKpy+EvVAnAab4fVa4YGYn24J1SpEktnJX7JJ45Bd7xqME/SCplFzYFmTbrkwZbQ4xJK1xMTUYBkN6pWsQ=="
-        }
       }
     },
     "@rollup/plugin-node-resolve": {
@@ -30679,9 +30673,9 @@
       "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg=="
     },
     "immer": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/immer/-/immer-8.0.1.tgz",
-      "integrity": "sha512-aqXhGP7//Gui2+UrEtvxZxSquQVXTpZ7KDxfCcKAF3Vysvw0CViVaW9RZ1j1xlIYqaaaipBoqdqeibkc18PNvA=="
+      "version": "9.0.6",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.6.tgz",
+      "integrity": "sha512-G95ivKpy+EvVAnAab4fVa4YGYn24J1SpEktnJX7JJ45Bd7xqME/SCplFzYFmTbrkwZbQ4xJK1xMTUYBkN6pWsQ=="
     },
     "import-cwd": {
       "version": "2.1.0",
@@ -35555,6 +35549,11 @@
           "version": "5.1.8",
           "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
           "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw=="
+        },
+        "immer": {
+          "version": "8.0.1",
+          "resolved": "https://registry.npmjs.org/immer/-/immer-8.0.1.tgz",
+          "integrity": "sha512-aqXhGP7//Gui2+UrEtvxZxSquQVXTpZ7KDxfCcKAF3Vysvw0CViVaW9RZ1j1xlIYqaaaipBoqdqeibkc18PNvA=="
         },
         "locate-path": {
           "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "private": true,
   "dependencies": {
     "@craco/craco": "^6.3.0",
+    "@reduxjs/toolkit": "^1.6.1",
     "@testing-library/jest-dom": "^5.14.1",
     "@testing-library/react": "^11.2.7",
     "@testing-library/user-event": "^12.8.3",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "@testing-library/jest-dom": "^5.14.1",
     "@testing-library/react": "^11.2.7",
     "@testing-library/user-event": "^12.8.3",
+    "immer": "^9.0.6",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-redux": "^7.2.5",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "@testing-library/user-event": "^12.8.3",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
+    "react-redux": "^7.2.5",
     "react-scripts": "4.0.3",
     "web-vitals": "^1.1.2"
   },

--- a/src/App.js
+++ b/src/App.js
@@ -7,15 +7,14 @@ import DetailBar from './components/DetailBar';
 
 
 function App() {
-  // look into presistng state between reloads - https://blog.bitsrc.io/5-methods-to-persisting-state-between-page-reloads-in-react-8fc9abd3fa2f
-  const [currentChapter, setChapter] = useState(data.chapters[0]);
-  const [noteId, setNoteId] = useState(null);
+  // const [currentChapter, setChapter] = useState(data.chapters[0]);
+  // const [noteId, setNoteId] = useState(null);
 
   return (
     <div className="flex w-screen h-screen p-2 gap-x-4">
-      <SideBar chapters={data.chapters} selectChapter={(e) => setChapter(e)} currentChapter={currentChapter}/>
-      <ContentWindow chapter={currentChapter} openNote={setNoteId} currentNoteId={noteId}/>
-      <DetailBar noteId={noteId} closeNote={() => setNoteId(null)}/>
+      <SideBar chapters={data.chapters} />
+      <ContentWindow />
+      <DetailBar />
     </div>
   );
 }

--- a/src/App.js
+++ b/src/App.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import data from './data';
 
 import SideBar from './components/SideBar';
@@ -7,8 +7,6 @@ import DetailBar from './components/DetailBar';
 
 
 function App() {
-  // const [currentChapter, setChapter] = useState(data.chapters[0]);
-  // const [noteId, setNoteId] = useState(null);
 
   return (
     <div className="flex w-screen h-screen p-2 gap-x-4">

--- a/src/app/chaptersSlice.js
+++ b/src/app/chaptersSlice.js
@@ -1,0 +1,20 @@
+import { createSlice } from "@reduxjs/toolkit";
+import data from '../data';
+
+
+const chaptersSlice = createSlice({
+  name: "chapters",
+  initialState: {
+    current_chapter: data.chapters[0]
+  },
+  reducers: {
+    setCurrentChapter(state, action) {
+      state.current_chapter = action.payload;
+    }
+  },
+});
+
+export const { setCurrentChapter } = chaptersSlice.actions;
+
+export default chaptersSlice.reducer;
+

--- a/src/app/notesSlice.js
+++ b/src/app/notesSlice.js
@@ -20,4 +20,3 @@ const notesSlice = createSlice({
 export const { setCurrentNoteId, addNoteToVisited } = notesSlice.actions;
 
 export default notesSlice.reducer;
-

--- a/src/app/notesSlice.js
+++ b/src/app/notesSlice.js
@@ -1,0 +1,23 @@
+import { createSlice } from "@reduxjs/toolkit";
+
+
+const notesSlice = createSlice({
+  name: "notes",
+  initialState: {
+    current_note_id: null,
+    visited_notes: new Set(),
+  },
+  reducers: {
+    setCurrentNoteId(state, action) {
+      state.current_note_id = action.payload;
+    },
+    addNoteToVisited(state, action) {
+      state.visited_notes.add(action.payload);
+    },
+  },
+});
+
+export const { setCurrentNoteId, addNoteToVisited } = notesSlice.actions;
+
+export default notesSlice.reducer;
+

--- a/src/app/store.js
+++ b/src/app/store.js
@@ -1,6 +1,10 @@
 import { configureStore } from "@reduxjs/toolkit";
+import { enableMapSet } from 'immer';
 import chaptersReducer from "./chaptersSlice";
 import notesReducer from "./notesSlice";
+
+enableMapSet();
+
 
 const store = configureStore({
   reducer: {

--- a/src/app/store.js
+++ b/src/app/store.js
@@ -1,0 +1,13 @@
+import { configureStore } from "@reduxjs/toolkit";
+import chaptersReducer from "./chaptersSlice";
+import notesReducer from "./notesSlice";
+
+const store = configureStore({
+  reducer: {
+    chapters: chaptersReducer,
+    notes: notesReducer,	
+  },
+})
+
+export default store
+

--- a/src/components/Annotation.js
+++ b/src/components/Annotation.js
@@ -1,12 +1,25 @@
+import { useSelector, useDispatch } from 'react-redux'
+import { setCurrentNoteId, addNoteToVisited } from '../app/notesSlice';
+
+
 const Annotation = ({
   annotationId,
-  annotationSelect,
-  activeAnnotationId,
   children,
-  visited
 }) => {
+  const dispatch = useDispatch();
+  const activeAnnotationId = useSelector(state => state.notes.current_note_id);
   const isActive = annotationId === activeAnnotationId;
+
+  const visitedNotes  = useSelector(state => state.notes.visited_notes);
+  const visited = visitedNotes.has(annotationId);
+
   const color = isActive ? "bg-green-300" : visited ? "bg-purple-100" : "bg-gray-200";
+
+  const annotationSelect = (annotationId) => {
+    dispatch(setCurrentNoteId(annotationId));
+    dispatch(addNoteToVisited(annotationId));
+  } 
+
   return (
     <button 
     // color precedence least to most - visited, active, hover
@@ -18,3 +31,4 @@ const Annotation = ({
 }
 
 export default Annotation;
+

--- a/src/components/ContentWindow.js
+++ b/src/components/ContentWindow.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import data from '../data';
 import { useSelector } from 'react-redux';
 

--- a/src/components/ContentWindow.js
+++ b/src/components/ContentWindow.js
@@ -1,24 +1,21 @@
 import React, { useState } from 'react';
 import data from '../data';
+import { useSelector } from 'react-redux';
 
 
-const ContentWindow = ({chapter, openNote, currentNoteId}) => {
-  const [visitedNotes, setVisited] = useState(new Set());
-
-  const addToVisited = (noteId) => {
-    const updatedNotes = visitedNotes.add(noteId);
-    setVisited(updatedNotes);
-  }
+const ContentWindow = () => {
+  const currentChapter = useSelector(state => state.chapters.current_chapter);
 
   return (
     <div className="flex flex-col w-2/4 flex-grow overflow-y-auto">
-      {loadChapter(chapter, {openNote, currentNoteId, visitedNotes, addToVisited})}
+      {loadChapter(currentChapter)}
     </div>
   );
 }
 
-const loadChapter = (chapter, props) => {
-  return data.chapters.find(c => c.idx === chapter.idx).component(props);
+const loadChapter = (chapter) => {
+  return data.chapters.find(c => c.idx === chapter.idx).component();
 }
 
 export default ContentWindow;
+

--- a/src/components/DetailBar.js
+++ b/src/components/DetailBar.js
@@ -1,9 +1,14 @@
 import React, { useState, useEffect } from 'react';
 import notes from '../content/notes/notes.json';
+import { useSelector, useDispatch } from 'react-redux';
+import { setCurrentNoteId } from '../app/notesSlice';
 
-const DetailBar = ({noteId, closeNote}) => {
+
+const DetailBar = () => {
   const [expandedNote, setExpandedNote] = useState(null);
+  const noteId = useSelector(state => state.notes.current_note_id);
   const isOpen = !!noteId;
+  const dispatch = useDispatch();
 
   // when noteId changes, reset expanded note
   useEffect(() => {
@@ -20,6 +25,10 @@ const DetailBar = ({noteId, closeNote}) => {
     } else {
       setExpandedNote(notes[noteId].expandedNote);
     }
+  }
+
+  const closeNote = () => {
+    dispatch(setCurrentNoteId(null));
   }
 
   return (
@@ -52,3 +61,4 @@ const DetailBar = ({noteId, closeNote}) => {
 }
 
 export default DetailBar;
+

--- a/src/components/SideBar.js
+++ b/src/components/SideBar.js
@@ -1,7 +1,13 @@
 import { useState } from "react";
+import { useSelector, useDispatch } from 'react-redux'
+import { setCurrentChapter } from '../app/chaptersSlice';
 
-const SideBar = ({chapters, currentChapter, selectChapter}) => {
+
+const SideBar = ({chapters}) => {
   const [aboutOpen, setAboutOpen] = useState(false);
+  const currentChapter = useSelector(state => state.chapters.current_chapter);
+  const dispatch = useDispatch();
+
 
   return (
     <div className="flex flex-col w-1/5 items-start pl-2">
@@ -10,7 +16,7 @@ const SideBar = ({chapters, currentChapter, selectChapter}) => {
         {chapters.map(chapter => {
           return (
             <button 
-              onClick={() => selectChapter(chapter)}
+              onClick={() => dispatch(setCurrentChapter(chapter))}
             >
               <p className={`text-lg ${chapter === currentChapter ? "text-green-500" : "text-gray-500"}`}>
                 {chapter.name}

--- a/src/content/chapters/Aeolus.js
+++ b/src/content/chapters/Aeolus.js
@@ -1,26 +1,26 @@
 import Annotation from "../../components/Annotation";
 
 
-const Aeolus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
+const Aeolus = () => {
   return (
     <div>
       <p className="text-center uppercase font-bold">
-        <Annotation annotationId="070000aeolus" visited={visitedNotes.has("070000aeolus")} annotationSelect={() => {openNote("070000aeolus"); addToVisited("070000aeolus")}} activeAnnotationId={currentNoteId}><font size="+2">[7]</font></Annotation>
+        <Annotation annotationId="070000aeolus"><font size="+2">[7]</font></Annotation>
         <br/>
-        <Annotation annotationId="070008intheheart" visited={visitedNotes.has("070008intheheart")} annotationSelect={() => {openNote("070008intheheart"); addToVisited("070008intheheart")}} activeAnnotationId={currentNoteId}>IN THE HEART</Annotation> OF THE <Annotation annotationId="070007hibernianmetropolis" visited={visitedNotes.has("070007hibernianmetropolis")} annotationSelect={() => {openNote("070007hibernianmetropolis"); addToVisited("070007hibernianmetropolis")}} activeAnnotationId={currentNoteId}>HIBERNIAN METROPOLIS</Annotation>
+        <Annotation annotationId="070008intheheart">IN THE HEART</Annotation> OF THE <Annotation annotationId="070007hibernianmetropolis">HIBERNIAN METROPOLIS</Annotation>
       </p>
       <p>
-        Before <Annotation annotationId="070006nelsonspillar" visited={visitedNotes.has("070006nelsonspillar")} annotationSelect={() => {openNote("070006nelsonspillar"); addToVisited("070006nelsonspillar")}} activeAnnotationId={currentNoteId}>Nelson's pillar</Annotation> trams slowed, shunted, changed trolley, started
-        for Blackrock, Kingstown and <Annotation annotationId="070004dalkeytram" visited={visitedNotes.has("070004dalkeytram")} annotationSelect={() => {openNote("070004dalkeytram"); addToVisited("070004dalkeytram")}} activeAnnotationId={currentNoteId}>Dalkey</Annotation>, Clonskea, Rathgar and <Annotation annotationId="070001terenure" visited={visitedNotes.has("070001terenure")} annotationSelect={() => {openNote("070001terenure"); addToVisited("070001terenure")}} activeAnnotationId={currentNoteId}>Terenure</Annotation>,
-        Palmerston Park and upper Rathmines, <Annotation annotationId="070002sandymounttrams" visited={visitedNotes.has("070002sandymounttrams")} annotationSelect={() => {openNote("070002sandymounttrams"); addToVisited("070002sandymounttrams")}} activeAnnotationId={currentNoteId}>Sandymount Green</Annotation>, <Annotation annotationId="070009rathminestram" visited={visitedNotes.has("070009rathminestram")} annotationSelect={() => {openNote("070009rathminestram"); addToVisited("070009rathminestram")}} activeAnnotationId={currentNoteId}>Rathmines</Annotation>,
-        <Annotation annotationId="030099ringsend" visited={visitedNotes.has("030099ringsend")} annotationSelect={() => {openNote("030099ringsend"); addToVisited("030099ringsend")}} activeAnnotationId={currentNoteId}>Ringsend</Annotation> and <Annotation annotationId="070002sandymounttrams" visited={visitedNotes.has("070002sandymounttrams")} annotationSelect={() => {openNote("070002sandymounttrams"); addToVisited("070002sandymounttrams")}} activeAnnotationId={currentNoteId}>Sandymount Tower</Annotation>, Harold's Cross. The hoarse <Annotation annotationId="070003tramwaycompany" visited={visitedNotes.has("070003tramwaycompany")} annotationSelect={() => {openNote("070003tramwaycompany"); addToVisited("070003tramwaycompany")}} activeAnnotationId={currentNoteId}>Dublin United
+        Before <Annotation annotationId="070006nelsonspillar">Nelson's pillar</Annotation> trams slowed, shunted, changed trolley, started
+        for Blackrock, Kingstown and <Annotation annotationId="070004dalkeytram">Dalkey</Annotation>, Clonskea, Rathgar and <Annotation annotationId="070001terenure">Terenure</Annotation>,
+        Palmerston Park and upper Rathmines, <Annotation annotationId="070002sandymounttrams">Sandymount Green</Annotation>, <Annotation annotationId="070009rathminestram">Rathmines</Annotation>,
+        <Annotation annotationId="030099ringsend">Ringsend</Annotation> and <Annotation annotationId="070002sandymounttrams">Sandymount Tower</Annotation>, Harold's Cross. The hoarse <Annotation annotationId="070003tramwaycompany">Dublin United
         Tramway Company</Annotation>'s timekeeper bawled them off:
       </p>
       <p>
         —{" "}Rathgar and Terenure!
       </p>
       <p>
-        —{" "}<Annotation annotationId="070011comeon" visited={visitedNotes.has("070011comeon")} annotationSelect={() => {openNote("070011comeon"); addToVisited("070011comeon")}} activeAnnotationId={currentNoteId}>Come on, Sandymount Green!</Annotation>
+        —{" "}<Annotation annotationId="070011comeon">Come on, Sandymount Green!</Annotation>
       </p>
       <p>
         Right and left parallel clanging ringing a doubledecker and a singledeck
@@ -54,11 +54,11 @@ const Aeolus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       <span data-edition="ed1922" data-page="112"></span>
       <p>
         —{" "}Just cut it out, will you? Mr Bloom said, and I'll take it round to
-        <Annotation annotationId="020064telegraph" visited={visitedNotes.has("020064telegraph")} annotationSelect={() => {openNote("020064telegraph"); addToVisited("020064telegraph")}} activeAnnotationId={currentNoteId}>the <i>Telegraph</i> office</Annotation>.
+        <Annotation annotationId="020064telegraph">the <i>Telegraph</i> office</Annotation>.
       </p>
       <span data-edition="ed1932" data-page="104"></span>
       <p>
-        The door of Ruttledge's office creaked again. <Annotation annotationId="070013davystephens" visited={visitedNotes.has("070013davystephens")} annotationSelect={() => {openNote("070013davystephens"); addToVisited("070013davystephens")}} activeAnnotationId={currentNoteId}>Davy Stephens</Annotation>, minute in a
+        The door of Ruttledge's office creaked again. <Annotation annotationId="070013davystephens">Davy Stephens</Annotation>, minute in a
         large capecoat, a small felt hat crowning his ringlets, passed out with
         a roll of papers under his cape, a king's courier.
       </p>
@@ -95,12 +95,12 @@ const Aeolus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <p>
         Mr Bloom turned and saw the liveried porter raise his lettered cap as a
-        stately figure entered between the newsboards of the <Annotation annotationId="160004newspapers" visited={visitedNotes.has("160004newspapers")} annotationSelect={() => {openNote("160004newspapers"); addToVisited("160004newspapers")}} activeAnnotationId={currentNoteId}><i>Weekly Freeman</i></Annotation><i>
-        and National Press</i> and the <Annotation annotationId="050021freeman" visited={visitedNotes.has("050021freeman")} annotationSelect={() => {openNote("050021freeman"); addToVisited("050021freeman")}} activeAnnotationId={currentNoteId}><i>Freeman's Journal and National Press</i></Annotation>.
+        stately figure entered between the newsboards of the <Annotation annotationId="160004newspapers"><i>Weekly Freeman</i></Annotation><i>
+        and National Press</i> and the <Annotation annotationId="050021freeman"><i>Freeman's Journal and National Press</i></Annotation>.
         Dullthudding Guinness's barrels. It passed statelily up the staircase,
         steered by an umbrella, a solemn beardframed face. The broadcloth back
         ascended each step: back. All his brains are in the nape of his neck,
-        Simon Dedalus says. Welts of flesh behind on him. <Annotation annotationId="070012neckfatneck" visited={visitedNotes.has("070012neckfatneck")} annotationSelect={() => {openNote("070012neckfatneck"); addToVisited("070012neckfatneck")}} activeAnnotationId={currentNoteId}>Fat folds of neck,
+        Simon Dedalus says. Welts of flesh behind on him. <Annotation annotationId="070012neckfatneck">Fat folds of neck,
         fat, neck, fat, neck.</Annotation>
       </p>
       <p>
@@ -111,7 +111,7 @@ const Aeolus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         one door opposite another for the wind to. Way in. Way out.
       </p>
       <p>
-        <Annotation annotationId="050027marthamary" visited={visitedNotes.has("050027marthamary")} annotationSelect={() => {openNote("050027marthamary"); addToVisited("050027marthamary")}} activeAnnotationId={currentNoteId}>Our Saviour: beardframed oval face: talking in the dusk. Mary, Martha.</Annotation>
+        <Annotation annotationId="050027marthamary">Our Saviour: beardframed oval face: talking in the dusk. Mary, Martha.</Annotation>
         Steered by an umbrella sword to the footlights: Mario the tenor.
       </p>
       <p>
@@ -156,13 +156,13 @@ const Aeolus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       <p>
         A meek smile accompanied him as he lifted the counterflap, as he passed
         in through the sidedoor and along the warm dark stairs and passage,<span data-edition="ed1986" data-page="97"></span>
-        along the now reverberating boards. <Annotation annotationId="070014circulation" visited={visitedNotes.has("070014circulation")} annotationSelect={() => {openNote("070014circulation"); addToVisited("070014circulation")}} activeAnnotationId={currentNoteId}>But will he save the circulation?
+        along the now reverberating boards. <Annotation annotationId="070014circulation">But will he save the circulation?
         Thumping. Thumping.</Annotation>
       </p>
       <p>
         He pushed in the glass swingdoor and entered, stepping over strewn
         packing paper. Through a lane of clanking drums he made his way towards
-        <Annotation annotationId="070019nannetti" visited={visitedNotes.has("070019nannetti")} annotationSelect={() => {openNote("070019nannetti"); addToVisited("070019nannetti")}} activeAnnotationId={currentNoteId}>Nannetti's</Annotation> reading closet.
+        <Annotation annotationId="070019nannetti">Nannetti's</Annotation> reading closet.
       </p>
       <p className="text-center uppercase font-bold">
         WITH UNFEIGNED REGRET IT IS WE ANNOUNCE <br/>
@@ -179,7 +179,7 @@ const Aeolus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         away, tearing away. And that old grey rat tearing to get in.
       </p>
       <p className="text-center uppercase font-bold">
-        HOW A GREAT DAILY <Annotation annotationId="070014circulation" visited={visitedNotes.has("070014circulation")} annotationSelect={() => {openNote("070014circulation"); addToVisited("070014circulation")}} activeAnnotationId={currentNoteId}>ORGAN</Annotation> IS TURNED OUT
+        HOW A GREAT DAILY <Annotation annotationId="070014circulation">ORGAN</Annotation> IS TURNED OUT
       </p>
       <p>
         Mr Bloom halted behind the foreman's spare body, admiring a glossy
@@ -212,10 +212,10 @@ const Aeolus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         whole thing. Want a cool head.
       </p>
       <p>
-        —{" "}Well, get it into the evening edition, <Annotation annotationId="060033corporation" visited={visitedNotes.has("060033corporation")} annotationSelect={() => {openNote("060033corporation"); addToVisited("060033corporation")}} activeAnnotationId={currentNoteId}>councillor</Annotation>, Hynes said.
+        —{" "}Well, get it into the evening edition, <Annotation annotationId="060033corporation">councillor</Annotation>, Hynes said.
       </p>
       <p>
-        Soon be calling him my <Annotation annotationId="060033corporation" visited={visitedNotes.has("060033corporation")} annotationSelect={() => {openNote("060033corporation"); addToVisited("060033corporation")}} activeAnnotationId={currentNoteId}>lord mayor</Annotation>. Long John is backing him, they say.
+        Soon be calling him my <Annotation annotationId="060033corporation">lord mayor</Annotation>. Long John is backing him, they say.
       </p>
       <p>
         The foreman, without answering, scribbled press on a corner of the sheet
@@ -264,7 +264,7 @@ const Aeolus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         —{" "}He wants it in for July, Mr Bloom said.
       </p>
       <span data-edition="ed1961" data-page="119"></span>
-      <p>He doesn't hear it. <Annotation annotationId="070019nannetti" visited={visitedNotes.has("070019nannetti")} annotationSelect={() => {openNote("070019nannetti"); addToVisited("070019nannetti")}} activeAnnotationId={currentNoteId}>Nannan</Annotation>. Iron nerves.</p>
+      <p>He doesn't hear it. <Annotation annotationId="070019nannetti">Nannan</Annotation>. Iron nerves.</p>
       <p>The foreman moved his pencil towards it.</p>
       <p>
         —{" "}But wait, Mr Bloom said. He wants it changed. Keyes, you see. He wants
@@ -316,8 +316,8 @@ const Aeolus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         there quietly.
       </p>
       <p>
-        —{" "}The idea, Mr Bloom said, is the <Annotation annotationId="010146hugekey" visited={visitedNotes.has("010146hugekey")} annotationSelect={() => {openNote("010146hugekey"); addToVisited("010146hugekey")}} activeAnnotationId={currentNoteId}>house of keys. You know, councillor,
-        the Manx parliament.</Annotation> Innuendo of <Annotation annotationId="020037oldtory" visited={visitedNotes.has("020037oldtory")} annotationSelect={() => {openNote("020037oldtory"); addToVisited("020037oldtory")}} activeAnnotationId={currentNoteId}>home rule</Annotation>. Tourists, you know, from the
+        —{" "}The idea, Mr Bloom said, is the <Annotation annotationId="010146hugekey">house of keys. You know, councillor,
+        the Manx parliament.</Annotation> Innuendo of <Annotation annotationId="020037oldtory">home rule</Annotation>. Tourists, you know, from the
         isle of Man. Catches the eye, you see. Can you do that?
       </p>
       <span data-edition="ed1986" data-page="99"></span>
@@ -331,7 +331,7 @@ const Aeolus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       <p>
         —{" "}I can get it, Mr Bloom said. It was in a Kilkenny paper. He has a
         house there too. I'll just run out and ask him. Well,<span data-edition="ed1961" data-page="120"></span> you can do that
-        and just <Annotation annotationId="040082highgradeha" visited={visitedNotes.has("040082highgradeha")} annotationSelect={() => {openNote("040082highgradeha"); addToVisited("040082highgradeha")}} activeAnnotationId={currentNoteId}>a little par</Annotation> calling attention. You know the usual. Highclass
+        and just <Annotation annotationId="040082highgradeha">a little par</Annotation> calling attention. You know the usual. Highclass
         licensed premises. Longfelt want. So on.
       </p>
       <p>
@@ -350,7 +350,7 @@ const Aeolus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         ORTHOGRAPHICAL
       </p>
       <p>
-        Want to be sure of his spelling. Proof fever. <Annotation annotationId="060034martincunningham" visited={visitedNotes.has("060034martincunningham")} annotationSelect={() => {openNote("060034martincunningham"); addToVisited("060034martincunningham")}} activeAnnotationId={currentNoteId}>Martin Cunningham</Annotation> forgot
+        Want to be sure of his spelling. Proof fever. <Annotation annotationId="060034martincunningham">Martin Cunningham</Annotation> forgot
         to give us his spellingbee conundrum this morning. It is amusing to view
         the unpar one ar alleled embarra two ars is it? double ess ment of a
         harassed pedlar while gauging au the symmetry of a peeled pear
@@ -364,8 +364,8 @@ const Aeolus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <p>
         Sllt. The nethermost deck of the first machine jogged forward its
-        flyboard with sllt the first batch of quirefolded papers. <Annotation annotationId="070014circulation" visited={visitedNotes.has("070014circulation")} annotationSelect={() => {openNote("070014circulation"); addToVisited("070014circulation")}} activeAnnotationId={currentNoteId}>Sllt. Almost</Annotation><span data-edition="ed1932" data-page="108"></span>
-        <Annotation annotationId="070014circulation" visited={visitedNotes.has("070014circulation")} annotationSelect={() => {openNote("070014circulation"); addToVisited("070014circulation")}} activeAnnotationId={currentNoteId}>human the way it sllt to call attention. Doing its level best to speak.</Annotation>
+        flyboard with sllt the first batch of quirefolded papers. <Annotation annotationId="070014circulation">Sllt. Almost</Annotation><span data-edition="ed1932" data-page="108"></span>
+        <Annotation annotationId="070014circulation">human the way it sllt to call attention. Doing its level best to speak.</Annotation>
         That door too sllt creaking, asking to be shut. Everything speaks in its
         own way. Sllt.
       </p>
@@ -420,24 +420,24 @@ const Aeolus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         He walked on through the caseroom passing an old man, bowed, spectacled,
         aproned. Old Monks, the dayfather. Queer lot of stuff he must have put
         through his hands in his time: obituary notices, pubs' ads, speeches,
-        divorce suits, <Annotation annotationId="030069founddrowned" visited={visitedNotes.has("030069founddrowned")} annotationSelect={() => {openNote("030069founddrowned"); addToVisited("030069founddrowned")}} activeAnnotationId={currentNoteId}>found drowned</Annotation>. Nearing the end of his tether now. Sober
+        divorce suits, <Annotation annotationId="030069founddrowned">found drowned</Annotation>. Nearing the end of his tether now. Sober
         serious man with a bit in the savingsbank I'd say. Wife a good cook and
         washer. Daughter working the machine in the parlour. Plain Jane, no damn
         nonsense. 
       </p>
       <p className="text-center uppercase font-bold">
-        <Annotation annotationId="060043passover" visited={visitedNotes.has("060043passover")} annotationSelect={() => {openNote("060043passover"); addToVisited("060043passover")}} activeAnnotationId={currentNoteId}>AND IT WAS THE FEAST OF THE PASSOVER</Annotation>
+        <Annotation annotationId="060043passover">AND IT WAS THE FEAST OF THE PASSOVER</Annotation>
       </p>
       <p>
         He stayed in his walk to watch a typesetter neatly distributing type.
         Reads it backwards first. Quickly he does it. Must require some practice
-        that. mangiD. kcirtaP. <Annotation annotationId="060043passover" visited={visitedNotes.has("060043passover")} annotationSelect={() => {openNote("060043passover"); addToVisited("060043passover")}} activeAnnotationId={currentNoteId}>Poor papa with his hagadah book, reading backwards
+        that. mangiD. kcirtaP. <Annotation annotationId="060043passover">Poor papa with his hagadah book, reading backwards
         with his finger to me. Pessach. Next year in Jerusalem. Dear, O dear!
         All that long business about that brought us out of the land of Egypt
         and into the house of bondage <i>Alleluia. Shema Israel Adonai Elohenu</i>.
         No, that's the other. Then the twelve brothers, Jacob's sons. And then
         the lamb and the cat and the dog and the stick and the water and the
-        butcher. And then the angel of death kills the butcher and he</Annotation><span data-edition="ed1932" data-page="109"></span> <Annotation annotationId="060043passover" visited={visitedNotes.has("060043passover")} annotationSelect={() => {openNote("060043passover"); addToVisited("060043passover")}} activeAnnotationId={currentNoteId}>kills the
+        butcher. And then the angel of death kills the butcher and he</Annotation><span data-edition="ed1932" data-page="109"></span> <Annotation annotationId="060043passover">kills the
         ox and the dog kills the cat. Sounds a bit silly till you come to look
         into it well. Justice it means but it's everybody eating everyone else.</Annotation>
         That's what life is after all. How quickly he does that job. Practice
@@ -454,7 +454,7 @@ const Aeolus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         ONLY ONCE MORE THAT SOAP
       </p>
       <p>
-        He went down the house staircase. <Annotation annotationId="150016writingonthewall" visited={visitedNotes.has("150016writingonthewall")} annotationSelect={() => {openNote("150016writingonthewall"); addToVisited("150016writingonthewall")}} activeAnnotationId={currentNoteId}>Who the deuce scrawled all over these
+        He went down the house staircase. <Annotation annotationId="150016writingonthewall">Who the deuce scrawled all over these
         walls with matches? Looks as if they did it for a bet.</Annotation> Heavy greasy
         smell there always is in those works. Lukewarm glue in Thom's next door
         when I was there.
@@ -562,7 +562,7 @@ const Aeolus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         accent on the whose.
       </p>
       <p>
-        —{" "}<Annotation annotationId="060037dandawson" visited={visitedNotes.has("060037dandawson")} annotationSelect={() => {openNote("060037dandawson"); addToVisited("060037dandawson")}} activeAnnotationId={currentNoteId}>Dan Dawson's land</Annotation> Mr Dedalus said.
+        —{" "}<Annotation annotationId="060037dandawson">Dan Dawson's land</Annotation> Mr Dedalus said.
       </p>
       <span data-edition="ed1939" data-page="93"> </span>
       <p>
@@ -632,14 +632,14 @@ const Aeolus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       <span data-edition="ed1922" data-page="120"></span>
       <p>
         J. J. O'Molloy strolled to the sloping desk and began to turn back the
-        <Annotation annotationId="020064telegraph" visited={visitedNotes.has("020064telegraph")} annotationSelect={() => {openNote("020064telegraph"); addToVisited("020064telegraph")}} activeAnnotationId={currentNoteId}>pink pages</Annotation> of the file.
+        <Annotation annotationId="020064telegraph">pink pages</Annotation> of the file.
       </p>
       <p>
         Practice dwindling. A mighthavebeen. Losing heart. Gambling. Debts of
         honour. Reaping the whirlwind. Used to get good retainers from D. and T.
         Fitzgerald. Their wigs to show their grey matter. Brains on their sleeve
-        like the statue in Glasnevin. <Annotation annotationId="070017dailyexpress" visited={visitedNotes.has("070017dailyexpress")} annotationSelect={() => {openNote("070017dailyexpress"); addToVisited("070017dailyexpress")}} activeAnnotationId={currentNoteId}>Believe he does some literary work for the
-        <i>Express</i></Annotation> with <Annotation annotationId="040027conroy" visited={visitedNotes.has("040027conroy")} annotationSelect={() => {openNote("040027conroy"); addToVisited("040027conroy")}} activeAnnotationId={currentNoteId}>Gabriel Conroy</Annotation>. Wellread fellow. <Annotation annotationId="120009irishindependent" visited={visitedNotes.has("120009irishindependent")} annotationSelect={() => {openNote("120009irishindependent"); addToVisited("120009irishindependent")}} activeAnnotationId={currentNoteId}>Myles Crawford began
+        like the statue in Glasnevin. <Annotation annotationId="070017dailyexpress">Believe he does some literary work for the
+        <i>Express</i></Annotation> with <Annotation annotationId="040027conroy">Gabriel Conroy</Annotation>. Wellread fellow. <Annotation annotationId="120009irishindependent">Myles Crawford began
         on the <i>Independent.</i> Funny the way those newspaper men veer about when
         they get wind of a new opening.</Annotation> Weathercocks. Hot and cold in the same
         breath. Wouldn't know which to believe. One story good till you hear
@@ -720,7 +720,7 @@ const Aeolus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         —{" "}What is it?
       </p>
       <p>
-        —{" "}And here comes <Annotation annotationId="070018shamsquire" visited={visitedNotes.has("070018shamsquire")} annotationSelect={() => {openNote("070018shamsquire"); addToVisited("070018shamsquire")}} activeAnnotationId={currentNoteId}>the sham squire</Annotation> himself! professor MacHugh said
+        —{" "}And here comes <Annotation annotationId="070018shamsquire">the sham squire</Annotation> himself! professor MacHugh said
         grandly.
       </p>
       <p>
@@ -821,7 +821,7 @@ const Aeolus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         SPOT THE WINNER
       </p>
       <p>
-        Lenehan came out of the inner office with <Annotation annotationId="160004newspapers" visited={visitedNotes.has("160004newspapers")} annotationSelect={() => {openNote("160004newspapers"); addToVisited("160004newspapers")}} activeAnnotationId={currentNoteId}><i>Sport's</i> tissues</Annotation>.
+        Lenehan came out of the inner office with <Annotation annotationId="160004newspapers"><i>Sport's</i> tissues</Annotation>.
       </p>
       <p>
         —{" "}Who wants a dead cert for the Gold cup? he asked. Sceptre with O.
@@ -997,7 +997,7 @@ const Aeolus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       <p>
         —{" "}Seems to be, J. J. O'Molloy said, taking out a cigarettecase in
         murmuring meditation, but it is not always as it seems. Who has the most
-        <Annotation annotationId="150013matches" visited={visitedNotes.has("150013matches")} annotationSelect={() => {openNote("150013matches"); addToVisited("150013matches")}} activeAnnotationId={currentNoteId}>matches</Annotation>?
+        <Annotation annotationId="150013matches">matches</Annotation>?
       </p>
       <p className="text-center uppercase font-bold">
         THE CALUMET OF PEACE
@@ -1062,13 +1062,13 @@ const Aeolus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         The Jews in the wilderness and on the mountaintop said: <i>It is meet
         to be here. Let us build an altar to Jehovah</i>. The Roman, like the
         Englishman who follows in his footsteps, brought to every new shore on
-        which he set his foot (on our shore he never set it) only his <Annotation annotationId="070020cloacalobsession" visited={visitedNotes.has("070020cloacalobsession")} annotationSelect={() => {openNote("070020cloacalobsession"); addToVisited("070020cloacalobsession")}} activeAnnotationId={currentNoteId}>cloacal
+        which he set his foot (on our shore he never set it) only his <Annotation annotationId="070020cloacalobsession">cloacal
         obsession</Annotation>. He gazed about him in his toga and he said: <i>It is meet to be
         here. Let us construct a watercloset.</i>
       </p>
       <p>
         —{" "}Which they accordingly did do, Lenehan said. Our old ancient
-        ancestors, as we read in <Annotation annotationId="010106sacredpint" visited={visitedNotes.has("010106sacredpint")} annotationSelect={() => {openNote("010106sacredpint"); addToVisited("010106sacredpint")}} activeAnnotationId={currentNoteId}>the first chapter of Guinness's</Annotation>, were partial
+        ancestors, as we read in <Annotation annotationId="010106sacredpint">the first chapter of Guinness's</Annotation>, were partial
         to the running stream.
       </p>
       <p>
@@ -1123,7 +1123,7 @@ const Aeolus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         —{" "}Who? the editor asked.
       </p>
       <p>
-        <Annotation annotationId="020064telegraph" visited={visitedNotes.has("020064telegraph")} annotationSelect={() => {openNote("020064telegraph"); addToVisited("020064telegraph")}} activeAnnotationId={currentNoteId}>Bit torn off.</Annotation>
+        <Annotation annotationId="020064telegraph">Bit torn off.</Annotation>
       </p>
       <p>
         —{" "}Mr Garrett Deasy, Stephen said.
@@ -1131,17 +1131,17 @@ const Aeolus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       <p>
         —{" "}That old pelters, the editor said. Who tore it? Was he short taken?
       </p>
-      <p>   <Annotation annotationId="030149vampire" visited={visitedNotes.has("030149vampire")} annotationSelect={() => {openNote("030149vampire"); addToVisited("030149vampire")}} activeAnnotationId={currentNoteId}><i>On swift sail flaming <br/>
+      <p>   <Annotation annotationId="030149vampire"><i>On swift sail flaming <br/>
         From storm and south  <br/>
         He comes, pale vampire,  <br/></i></Annotation><i>
         Mouth to my mouth.</i>  
       </p>
       <p>
         —{" "}Good day, Stephen, the professor said, coming to peer over their
-        shoulders. <Annotation annotationId="020054footandmouth" visited={visitedNotes.has("020054footandmouth")} annotationSelect={() => {openNote("020054footandmouth"); addToVisited("020054footandmouth")}} activeAnnotationId={currentNoteId}>Foot and mouth?</Annotation> Are you turned...?
+        shoulders. <Annotation annotationId="020054footandmouth">Foot and mouth?</Annotation> Are you turned...?
       </p>
       <p>
-        <Annotation annotationId="020065bullockbefriending" visited={visitedNotes.has("020065bullockbefriending")} annotationSelect={() => {openNote("020065bullockbefriending"); addToVisited("020065bullockbefriending")}} activeAnnotationId={currentNoteId}>Bullockbefriending bard.</Annotation>
+        <Annotation annotationId="020065bullockbefriending">Bullockbefriending bard.</Annotation>
       </p>
       <p className="text-center uppercase font-bold">
         SHINDY IN WELLKNOWN RESTAURANT
@@ -1151,7 +1151,7 @@ const Aeolus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         Garrett Deasy asked me to...
       </p>
       <p>
-        —{" "}O, I know him, Myles Crawford said, and <Annotation annotationId="020017deasy" visited={visitedNotes.has("020017deasy")} annotationSelect={() => {openNote("020017deasy"); addToVisited("020017deasy")}} activeAnnotationId={currentNoteId}>knew his wife too</Annotation>. The
+        —{" "}O, I know him, Myles Crawford said, and <Annotation annotationId="020017deasy">knew his wife too</Annotation>. The
         bloodiest old tartar God ever made. By Jesus, she had the foot and mouth 
         <span data-edition="ed1922" data-page="127"></span>
         
@@ -1159,7 +1159,7 @@ const Aeolus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         face in the Star and Garter. Oho!
       </p>
       <p>
-        <Annotation annotationId="020070womansin" visited={visitedNotes.has("020070womansin")} annotationSelect={() => {openNote("020070womansin"); addToVisited("020070womansin")}} activeAnnotationId={currentNoteId}>A woman brought sin into the world. For Helen, the runaway wife of
+        <Annotation annotationId="020070womansin">A woman brought sin into the world. For Helen, the runaway wife of
         Menelaus, ten years the Greeks. O'Rourke, prince of Breffni.</Annotation>
       </p>
       <p>
@@ -1167,10 +1167,10 @@ const Aeolus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <p>
         —{" "}Ay, a grass one, Myles Crawford said, his eye running down the
-        typescript. <Annotation annotationId="020055serumandvirus" visited={visitedNotes.has("020055serumandvirus")} annotationSelect={() => {openNote("020055serumandvirus"); addToVisited("020055serumandvirus")}} activeAnnotationId={currentNoteId}>Emperor's horses. Habsburg.</Annotation> An Irishman saved his life on
+        typescript. <Annotation annotationId="020055serumandvirus">Emperor's horses. Habsburg.</Annotation> An Irishman saved his life on
         the ramparts of Vienna. Don't you forget! Maximilian Karl O'Donnell,
         graf von Tirconnell in Ireland. Sent his heir over to make the king
-        an Austrian fieldmarshal now. Going to be trouble there one day. <Annotation annotationId="030027wildgoose" visited={visitedNotes.has("030027wildgoose")} annotationSelect={() => {openNote("030027wildgoose"); addToVisited("030027wildgoose")}} activeAnnotationId={currentNoteId}>Wild
+        an Austrian fieldmarshal now. Going to be trouble there one day. <Annotation annotationId="030027wildgoose">Wild
         geese.</Annotation> O yes, every time. Don't you forget that!
       </p>
       <span data-edition="ed1932" data-page="118"></span>
@@ -1336,7 +1336,7 @@ const Aeolus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         «{" "}{" "}YOU CAN DO IT!{" "}{" "}»
       </p>
       <p>
-        The editor <Annotation annotationId="010152linkedarm" visited={visitedNotes.has("010152linkedarm")} annotationSelect={() => {openNote("010152linkedarm"); addToVisited("010152linkedarm")}} activeAnnotationId={currentNoteId}>laid a nervous hand on Stephen's shoulder</Annotation>.
+        The editor <Annotation annotationId="010152linkedarm">laid a nervous hand on Stephen's shoulder</Annotation>.
       </p>
       <p>
         —{" "}I want you to write something for me, he said. Something with a bite
@@ -1344,14 +1344,14 @@ const Aeolus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         ...
       </p>
       <p>
-        <Annotation annotationId="070010seeitin" visited={visitedNotes.has("070010seeitin")} annotationSelect={() => {openNote("070010seeitin"); addToVisited("070010seeitin")}} activeAnnotationId={currentNoteId}>See it in your face.</Annotation> See it in your eye. Lazy idle little schemer.
+        <Annotation annotationId="070010seeitin">See it in your face.</Annotation> See it in your eye. Lazy idle little schemer.
       </p>
       <span data-edition="ed1932" data-page="120"></span>
       <p>
         —{" "}Foot and mouth disease! the editor cried in scornful invective. Great
         nationalist meeting in Borris-in-Ossory. All balls! Bulldosing the
-        public! Give them something with a bite in it. <Annotation annotationId="070021putusall" visited={visitedNotes.has("070021putusall")} annotationSelect={() => {openNote("070021putusall"); addToVisited("070021putusall")}} activeAnnotationId={currentNoteId}>Put us all into it, damn
-        its soul.</Annotation> Father, Son and Holy Ghost and <Annotation annotationId="070022jakesmcarthy" visited={visitedNotes.has("070022jakesmcarthy")} annotationSelect={() => {openNote("070022jakesmcarthy"); addToVisited("070022jakesmcarthy")}} activeAnnotationId={currentNoteId}>Jakes M'Carthy</Annotation>.
+        public! Give them something with a bite in it. <Annotation annotationId="070021putusall">Put us all into it, damn
+        its soul.</Annotation> Father, Son and Holy Ghost and <Annotation annotationId="070022jakesmcarthy">Jakes M'Carthy</Annotation>.
       </p>
       <p>
         —{" "}We can all supply mental pabulum, Mr O'Madden Burke said.
@@ -1393,7 +1393,7 @@ const Aeolus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <p>
         —{" "}Skin-the-goat, Mr O'Madden Burke said. Fitzharris. He has that
-        <Annotation annotationId="050012cabstands" visited={visitedNotes.has("050012cabstands")} annotationSelect={() => {openNote("050012cabstands"); addToVisited("050012cabstands")}} activeAnnotationId={currentNoteId}>cabman's shelter</Annotation>, they say, down there at <Annotation annotationId="070015buttbridge" visited={visitedNotes.has("070015buttbridge")} annotationSelect={() => {openNote("070015buttbridge"); addToVisited("070015buttbridge")}} activeAnnotationId={currentNoteId}>Butt bridge</Annotation>. <Annotation annotationId="050028hoppy" visited={visitedNotes.has("050028hoppy")} annotationSelect={() => {openNote("050028hoppy"); addToVisited("050028hoppy")}} activeAnnotationId={currentNoteId}>Holohan told me.
+        <Annotation annotationId="050012cabstands">cabman's shelter</Annotation>, they say, down there at <Annotation annotationId="070015buttbridge">Butt bridge</Annotation>. <Annotation annotationId="050028hoppy">Holohan told me.
         You know Holohan?</Annotation>
       </p>
       <p>
@@ -1401,7 +1401,7 @@ const Aeolus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <p>
         —{" "}And poor Gumley is down there too, so he told me, minding stones for
-        <Annotation annotationId="060033corporation" visited={visitedNotes.has("060033corporation")} annotationSelect={() => {openNote("060033corporation"); addToVisited("060033corporation")}} activeAnnotationId={currentNoteId}>the corporation</Annotation>. A night watchman.
+        <Annotation annotationId="060033corporation">the corporation</Annotation>. A night watchman.
       </p>
       <p>
         Stephen turned in surprise.
@@ -1480,7 +1480,7 @@ const Aeolus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         history.
       </p>
       <p>
-        <Annotation annotationId="020063niare" visited={visitedNotes.has("020063niare")} annotationSelect={() => {openNote("020063niare"); addToVisited("020063niare")}} activeAnnotationId={currentNoteId}>Niare from which you will never awake.</Annotation>
+        <Annotation annotationId="020063niare">Niare from which you will never awake.</Annotation>
       </p>
       <p>
         —{" "}I saw it, the editor said proudly. I was present. Dick Adams, the
@@ -1494,7 +1494,7 @@ const Aeolus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         —{" "}Madam, I'm Adam. And Able was I ere I saw Elba.
       </p>
       <p>
-        —{" "}History! Myles Crawford cried. <Annotation annotationId="040006homerulesun" visited={visitedNotes.has("040006homerulesun")} annotationSelect={() => {openNote("040006homerulesun"); addToVisited("040006homerulesun")}} activeAnnotationId={currentNoteId}>The Old Woman of Prince's street</Annotation> was
+        —{" "}History! Myles Crawford cried. <Annotation annotationId="040006homerulesun">The Old Woman of Prince's street</Annotation> was
         there first. There was weeping and gnashing of teeth over that. Out of
         an advertisement. Gregor Grey made the design for it. That gave him the
         leg up. Then Paddy Hooper worked Tay Pay who took him on to the <i>Star.</i>
@@ -1538,7 +1538,7 @@ const Aeolus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       <p>
         —{" "}They're only in the hook and eye department, Myles Crawford said. Psha! Press and the bar! Where have you a man now at the bar like those
         fellows, like Whiteside, like Isaac Butt, like silvertongued O'Hagan.
-        Eh? Ah, bloody nonsense. Only in the <Annotation annotationId="010019money" visited={visitedNotes.has("010019money")} annotationSelect={() => {openNote("010019money"); addToVisited("010019money")}} activeAnnotationId={currentNoteId}>halfpenny</Annotation> place.
+        Eh? Ah, bloody nonsense. Only in the <Annotation annotationId="010019money">halfpenny</Annotation> place.
       </p>
       <p></p>
       <span data-edition="ed1939" data-page="102"> </span>
@@ -1585,7 +1585,7 @@ const Aeolus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         the third profession qua profession but your Cork legs are running<span data-edition="ed1932" data-page="123"></span> away
         with you. Why not bring in Henry Grattan and Flood and Demosthenes and
         Edmund Burke? Ignatius Gallaher we all know and his Chapelizod boss,
-        Harmsworth of <Annotation annotationId="010019money" visited={visitedNotes.has("010019money")} annotationSelect={() => {openNote("010019money"); addToVisited("010019money")}} activeAnnotationId={currentNoteId}>the farthing press</Annotation>, and his American cousin of the Bowery
+        Harmsworth of <Annotation annotationId="010019money">the farthing press</Annotation>, and his American cousin of the Bowery
         guttersheet not to mention <i>Paddy Kelly's Budget, Pue's Occurrences</i>
         and our watchful friend <i>The Skibereen Eagle</i>. Why bring in a master
         of forensic eloquence like Whiteside? Sufficient for the day is the
@@ -1657,7 +1657,7 @@ const Aeolus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         Messenger took out his matchbox thoughtfully and lit his cigar.
       </p>
       <p>
-        <Annotation annotationId="070005trivial" visited={visitedNotes.has("070005trivial")} annotationSelect={() => {openNote("070005trivial"); addToVisited("070005trivial")}} activeAnnotationId={currentNoteId}>I have often thought since on looking back over that strange time that
+        <Annotation annotationId="070005trivial">I have often thought since on looking back over that strange time that
         it was that small act, trivial in itself, that striking of that match,
         that determined the whole aftercourse of both our lives.</Annotation> 
       </p>
@@ -1888,11 +1888,11 @@ const Aeolus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <p>
         Gone with the
-        wind. <Annotation annotationId="020038oconnell" visited={visitedNotes.has("020038oconnell")} annotationSelect={() => {openNote("020038oconnell"); addToVisited("020038oconnell")}} activeAnnotationId={currentNoteId}>Hosts at Mullaghmast and Tara of the kings.</Annotation> 
+        wind. <Annotation annotationId="020038oconnell">Hosts at Mullaghmast and Tara of the kings.</Annotation> 
         <span data-edition="ed1922" data-page="137"></span>
         Miles of ears of 
         porches. The tribune's words, howled and scattered to the four winds.
-        A people sheltered within his voice. Dead noise. <Annotation annotationId="010079akasicrecords" visited={visitedNotes.has("010079akasicrecords")} annotationSelect={() => {openNote("010079akasicrecords"); addToVisited("010079akasicrecords")}} activeAnnotationId={currentNoteId}>Akasic records of all
+        A people sheltered within his voice. Dead noise. <Annotation annotationId="010079akasicrecords">Akasic records of all
         that ever anywhere wherever was.</Annotation> Love and laud him: me no more.
       </p>
       <p>
@@ -1997,17 +1997,17 @@ const Aeolus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <p>
         —{" "}Two Dublin vestals, Stephen said, elderly and pious, have lived fifty
-        and fiftythree years in <Annotation annotationId="030059blackpitts" visited={visitedNotes.has("030059blackpitts")} annotationSelect={() => {openNote("030059blackpitts"); addToVisited("030059blackpitts")}} activeAnnotationId={currentNoteId}>Fumbally's lane</Annotation>.
+        and fiftythree years in <Annotation annotationId="030059blackpitts">Fumbally's lane</Annotation>.
       </p>
       <p>
-        <Annotation annotationId="030059blackpitts" visited={visitedNotes.has("030059blackpitts")} annotationSelect={() => {openNote("030059blackpitts"); addToVisited("030059blackpitts")}} activeAnnotationId={currentNoteId}>—{" "}Where is that? the professor asked.</Annotation>
+        <Annotation annotationId="030059blackpitts">—{" "}Where is that? the professor asked.</Annotation>
       </p>
       <p>
-        <Annotation annotationId="030059blackpitts" visited={visitedNotes.has("030059blackpitts")} annotationSelect={() => {openNote("030059blackpitts"); addToVisited("030059blackpitts")}} activeAnnotationId={currentNoteId}>—{" "}Off Blackpitts</Annotation>.
+        <Annotation annotationId="030059blackpitts">—{" "}Off Blackpitts</Annotation>.
       </p>
       <p>
         Damp night reeking of hungry dough. Against the wall. Face glistening
-        tallow under her fustian shawl. Frantic hearts. <Annotation annotationId="010079akasicrecords" visited={visitedNotes.has("010079akasicrecords")} annotationSelect={() => {openNote("010079akasicrecords"); addToVisited("010079akasicrecords")}} activeAnnotationId={currentNoteId}>Akasic records.</Annotation> Quicker,
+        tallow under her fustian shawl. Frantic hearts. <Annotation annotationId="010079akasicrecords">Akasic records.</Annotation> Quicker,
         darlint!
       </p>
       <p>
@@ -2017,7 +2017,7 @@ const Aeolus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         —{" "}They want to see the views of Dublin from the top of Nelson's pillar.
         They save up three and tenpence in a red tin letterbox moneybox. They
         shake out the threepenny bits and a sixpence and coax out the pennies
-        with <Annotation annotationId="010007kinch" visited={visitedNotes.has("010007kinch")} annotationSelect={() => {openNote("010007kinch"); addToVisited("010007kinch")}} activeAnnotationId={currentNoteId}> the blade of a knife</Annotation>. <Annotation annotationId="010019money" visited={visitedNotes.has("010019money")} annotationSelect={() => {openNote("010019money"); addToVisited("010019money")}} activeAnnotationId={currentNoteId}>Two and three in silver and one and seven
+        with <Annotation annotationId="010007kinch"> the blade of a knife</Annotation>. <Annotation annotationId="010019money">Two and three in silver and one and seven
         in coppers.</Annotation> They put on their bonnets and best clothes and take their
         umbrellas for fear it may come on to rain.
       </p>
@@ -2042,7 +2042,7 @@ const Aeolus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         high.
       </p>
       <p>
-        Their names are <Annotation annotationId="030054swunglourdily" visited={visitedNotes.has("030054swunglourdily")} annotationSelect={() => {openNote("030054swunglourdily"); addToVisited("030054swunglourdily")}} activeAnnotationId={currentNoteId}>Anne Kearns and Florence MacCabe</Annotation>. Anne Kearns has the
+        Their names are <Annotation annotationId="030054swunglourdily">Anne Kearns and Florence MacCabe</Annotation>. Anne Kearns has the
         lumbago for which she rubs on Lourdes water, given her by a lady who got a 
         <span data-edition="ed1922" data-page="139"></span>
         
@@ -2108,11 +2108,11 @@ const Aeolus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         councillor Nannetti from the <i>Kilkenny People</i>. I can have access to
         it in the national library. House of keys, don't you see? His name is
         Keyes. It's a play on the name. But he practically promised he'd give
-        the renewal. But he wants <Annotation annotationId="070016littlepuff" visited={visitedNotes.has("070016littlepuff")} annotationSelect={() => {openNote("070016littlepuff"); addToVisited("070016littlepuff")}} activeAnnotationId={currentNoteId}>just a little puff</Annotation>. What will I tell him, Mr
+        the renewal. But he wants <Annotation annotationId="070016littlepuff">just a little puff</Annotation>. What will I tell him, Mr
         Crawford? 
       </p>
       <p className="text-center uppercase font-bold">
-        <Annotation annotationId="040082highgradeha" visited={visitedNotes.has("040082highgradeha")} annotationSelect={() => {openNote("040082highgradeha"); addToVisited("040082highgradeha")}} activeAnnotationId={currentNoteId}>K.{" "}M.{" "}A.</Annotation>
+        <Annotation annotationId="040082highgradeha">K.{" "}M.{" "}A.</Annotation>
       </p>
       <p>
         —{" "}Will you tell him he can kiss my arse? Myles Crawford said throwing
@@ -2125,7 +2125,7 @@ const Aeolus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         Lenehan's yachting cap on the cadge beyond. Usual blarney. Wonder is
         that young Dedalus the moving spirit. Has a good pair of boots on him
         today. Last time I saw him he had his heels on view. Been walking in
-        muck somewhere. Careless chap. What was he doing in <Annotation annotationId="030015irishtown" visited={visitedNotes.has("030015irishtown")} annotationSelect={() => {openNote("030015irishtown"); addToVisited("030015irishtown")}} activeAnnotationId={currentNoteId}>Irishtown</Annotation>?
+        muck somewhere. Careless chap. What was he doing in <Annotation annotationId="030015irishtown">Irishtown</Annotation>?
       </p>
       <span data-edition="ed1932" data-page="130"></span>
       <p>
@@ -2162,7 +2162,7 @@ const Aeolus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <p>
         —{" "}When they have eaten the brawn and the bread and wiped their twenty
-        fingers in the paper the bread was wrapped in they go nearer to <Annotation annotationId="070023giddytolook" visited={visitedNotes.has("070023giddytolook")} annotationSelect={() => {openNote("070023giddytolook"); addToVisited("070023giddytolook")}} activeAnnotationId={currentNoteId}>the
+        fingers in the paper the bread was wrapped in they go nearer to <Annotation annotationId="070023giddytolook">the
         railings</Annotation>.
       </p>
       <p>
@@ -2179,8 +2179,8 @@ const Aeolus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <p>
         —{" "}But they are afraid the pillar will fall, Stephen went on. They see
-        the roofs and argue about <Annotation annotationId="070024differentchurches" visited={visitedNotes.has("070024differentchurches")} annotationSelect={() => {openNote("070024differentchurches"); addToVisited("070024differentchurches")}} activeAnnotationId={currentNoteId}>where the different</Annotation><span data-edition="ed1961" data-page="147"></span> <Annotation annotationId="070024differentchurches" visited={visitedNotes.has("070024differentchurches")} annotationSelect={() => {openNote("070024differentchurches"); addToVisited("070024differentchurches")}} activeAnnotationId={currentNoteId}>churches are: Rathmines'
-        blue dome, Adam and Eve's, saint Laurence O'Toole's</Annotation>. But <Annotation annotationId="070023giddytolook" visited={visitedNotes.has("070023giddytolook")} annotationSelect={() => {openNote("070023giddytolook"); addToVisited("070023giddytolook")}} activeAnnotationId={currentNoteId}>it makes them
+        the roofs and argue about <Annotation annotationId="070024differentchurches">where the different</Annotation><span data-edition="ed1961" data-page="147"></span> <Annotation annotationId="070024differentchurches">churches are: Rathmines'
+        blue dome, Adam and Eve's, saint Laurence O'Toole's</Annotation>. But <Annotation annotationId="070023giddytolook">it makes them
         giddy to look</Annotation> so they pull up their skirts...
       </p>
       <span data-edition="ed1922" data-page="141"></span>
@@ -2236,7 +2236,7 @@ const Aeolus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
           Poor Penelope. Penelope Rich.
         </p>
         <p>
-          They made ready to cross <Annotation annotationId="060012liberatorsform" visited={visitedNotes.has("060012liberatorsform")} annotationSelect={() => {openNote("060012liberatorsform"); addToVisited("060012liberatorsform")}} activeAnnotationId={currentNoteId}>O'Connell street</Annotation>.
+          They made ready to cross <Annotation annotationId="060012liberatorsform">O'Connell street</Annotation>.
         </p>
         <p className="text-center uppercase font-bold">
           HELLO THERE, CENTRAL!
@@ -2248,7 +2248,7 @@ const Aeolus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
           <span data-edition="ed1922" data-page="142"></span>
           
           Blackrock and Dalkey, Sandymount Green, Ringsend
-          and Sandymount Tower, <Annotation annotationId="050022donnybrook" visited={visitedNotes.has("050022donnybrook")} annotationSelect={() => {openNote("050022donnybrook"); addToVisited("050022donnybrook")}} activeAnnotationId={currentNoteId}>Donnybrook</Annotation>, Palmerston Park and Upper Rathmines,
+          and Sandymount Tower, <Annotation annotationId="050022donnybrook">Donnybrook</Annotation>, Palmerston Park and Upper Rathmines,
           all still, becalmed in short circuit. Hackney cars, cabs, delivery
           waggons, mailvans, private broughams, aerated mineral water floats with
           rattling crates of bottles, rattled, rolled, horsedrawn, rapidly.
@@ -2296,7 +2296,7 @@ const Aeolus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
           —{" "}I see, the professor said.
         </p>
         <p>
-          He halted on <Annotation annotationId="060008sirjohngray" visited={visitedNotes.has("060008sirjohngray")} annotationSelect={() => {openNote("060008sirjohngray"); addToVisited("060008sirjohngray")}} activeAnnotationId={currentNoteId}>sir John Gray's pavement island</Annotation> and peered aloft at Nelson
+          He halted on <Annotation annotationId="060008sirjohngray">sir John Gray's pavement island</Annotation> and peered aloft at Nelson
           through the meshes of his wry smile.
         </p>
         <p className="text-center uppercase font-bold">

--- a/src/content/chapters/Calypso.js
+++ b/src/content/chapters/Calypso.js
@@ -1,21 +1,21 @@
 import Annotation from "../../components/Annotation";
 
 
-const Calypso = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
+const Calypso = () => {
   return (
     <div>
       <p></p>
-      <center><Annotation annotationId="040000calypso" visited={visitedNotes.has("040000calypso")} annotationSelect={() => {openNote("040000calypso"); addToVisited("040000calypso")}} activeAnnotationId={currentNoteId}><font size="+2">[4]</font></Annotation></center>
+      <center><Annotation annotationId="040000calypso"><font size="+2">[4]</font></Annotation></center>
       <br/>
-      <Annotation annotationId="040030leopoldbloom" visited={visitedNotes.has("040030leopoldbloom")} annotationSelect={() => {openNote("040030leopoldbloom"); addToVisited("040030leopoldbloom")}} activeAnnotationId={currentNoteId}>Mr Leopold Bloom</Annotation> ate with relish the inner organs of beasts and fowls.
+      <Annotation annotationId="040030leopoldbloom">Mr Leopold Bloom</Annotation> ate with relish the inner organs of beasts and fowls.
       He liked thick giblet soup, nutty gizzards, a stuffed roast heart,
       liverslices fried with crustcrumbs, fried hencods' roes. Most of all
       he liked grilled mutton kidneys which gave to his palate a fine tang of
       faintly scented urine.
       <p></p>
       <p>
-        <Annotation annotationId="040009kidneys" visited={visitedNotes.has("040009kidneys")} annotationSelect={() => {openNote("040009kidneys"); addToVisited("040009kidneys")}} activeAnnotationId={currentNoteId}>Kidneys were in his mind</Annotation> as he moved about the kitchen softly, righting
-        her breakfast things on the humpy tray. <Annotation annotationId="040063happywarmth" visited={visitedNotes.has("040063happywarmth")} annotationSelect={() => {openNote("040063happywarmth"); addToVisited("040063happywarmth")}} activeAnnotationId={currentNoteId}>Gelid light and air were in the
+        <Annotation annotationId="040009kidneys">Kidneys were in his mind</Annotation> as he moved about the kitchen softly, righting
+        her breakfast things on the humpy tray. <Annotation annotationId="040063happywarmth">Gelid light and air were in the
         kitchen but out of doors gentle summer morning everywhere. Made him feel
         a bit peckish.</Annotation>
       </p>
@@ -23,14 +23,14 @@ const Calypso = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         The coals were reddening.
       </p>
       <p>
-        Another slice of bread and butter : <Annotation annotationId="040011rightright" visited={visitedNotes.has("040011rightright")} annotationSelect={() => {openNote("040011rightright"); addToVisited("040011rightright")}} activeAnnotationId={currentNoteId}>three, four : right. She didn't like
+        Another slice of bread and butter : <Annotation annotationId="040011rightright">three, four : right. She didn't like
         her plate full. Right.</Annotation> He turned from the tray, lifted the kettle off
-        the hob and set it sideways on the fire. It sat there, <Annotation annotationId="040022lickingclean" visited={visitedNotes.has("040022lickingclean")} annotationSelect={() => {openNote("040022lickingclean"); addToVisited("040022lickingclean")}} activeAnnotationId={currentNoteId}>dull and squat,
+        the hob and set it sideways on the fire. It sat there, <Annotation annotationId="040022lickingclean">dull and squat,
         its spout stuck out</Annotation>. Cup of tea soon. Good. Mouth dry. The cat walked
         stiffly round a leg of the table with tail on high.
       </p>
       <p>
-        <Annotation annotationId="040070mrkgnao" visited={visitedNotes.has("040070mrkgnao")} annotationSelect={() => {openNote("040070mrkgnao"); addToVisited("040070mrkgnao")}} activeAnnotationId={currentNoteId}>—{" "}Mkgnao!</Annotation>
+        <Annotation annotationId="040070mrkgnao">—{" "}Mkgnao!</Annotation>
       </p>
       <p>
         —{" "}O, there you are, Mr Bloom said, turning from the fire.
@@ -42,7 +42,7 @@ const Calypso = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <p>
         Mr Bloom watched curiously, kindly, the lithe black form. Clean to see:
-        the gloss of her sleek hide, the white <Annotation annotationId="040015whitebutton" visited={visitedNotes.has("040015whitebutton")} annotationSelect={() => {openNote("040015whitebutton"); addToVisited("040015whitebutton")}} activeAnnotationId={currentNoteId}>button under the butt</Annotation> of her
+        the gloss of her sleek hide, the white <Annotation annotationId="040015whitebutton">button under the butt</Annotation> of her
         tail, the green flashing eyes. He bent down to her, his hands on his
         knees.
       </p>
@@ -53,7 +53,7 @@ const Calypso = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         —{" "}Mrkgnao! the cat cried.
       </p>
       <p>
-        <Annotation annotationId="040071theyunderstand" visited={visitedNotes.has("040071theyunderstand")} annotationSelect={() => {openNote("040071theyunderstand"); addToVisited("040071theyunderstand")}} activeAnnotationId={currentNoteId}>They call them stupid. They understand what we say better than we
+        <Annotation annotationId="040071theyunderstand">They call them stupid. They understand what we say better than we
         understand them.</Annotation> She understands all she wants to. Vindictive too. Wonder
         what I look like to her. Height of a tower? No, she can jump me.
       </p>
@@ -64,7 +64,7 @@ const Calypso = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <span data-edition="ed1932" data-page="48"></span>
       <p>
-        Cruel. Her nature. Curious mice never squeal. <Annotation annotationId="040017seemtolikeit" visited={visitedNotes.has("040017seemtolikeit")} annotationSelect={() => {openNote("040017seemtolikeit"); addToVisited("040017seemtolikeit")}} activeAnnotationId={currentNoteId}>Seem to like it.</Annotation>
+        Cruel. Her nature. Curious mice never squeal. <Annotation annotationId="040017seemtolikeit">Seem to like it.</Annotation>
       </p>
       <p>
         —{" "}Mrkrgnao! the cat said loudly.
@@ -72,8 +72,8 @@ const Calypso = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       <p>
         She blinked up out of her avid shameclosing eyes, mewing plaintively
         and long, showing him her milkwhite teeth. He watched the dark eyeslits
-        narrowing with greed till her eyes were <Annotation annotationId="010142greenstone" visited={visitedNotes.has("010142greenstone")} annotationSelect={() => {openNote("010142greenstone"); addToVisited("010142greenstone")}} activeAnnotationId={currentNoteId}>green stones</Annotation>. Then he went to
-        the<span data-edition="ed1986" data-page="45"></span> dresser, took the jug<span data-edition="ed1961" data-page="55"></span> <Annotation annotationId="040062bolandsbread" visited={visitedNotes.has("040062bolandsbread")} annotationSelect={() => {openNote("040062bolandsbread"); addToVisited("040062bolandsbread")}} activeAnnotationId={currentNoteId}>Hanlon's milkman</Annotation> had just filled for him,
+        narrowing with greed till her eyes were <Annotation annotationId="010142greenstone">green stones</Annotation>. Then he went to
+        the<span data-edition="ed1986" data-page="45"></span> dresser, took the jug<span data-edition="ed1961" data-page="55"></span> <Annotation annotationId="040062bolandsbread">Hanlon's milkman</Annotation> had just filled for him,
         poured warmbubbled milk on a saucer and set it slowly on the floor.
       </p>
       <p>
@@ -81,24 +81,24 @@ const Calypso = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <p>
         He watched the bristles shining wirily in the weak light as she tipped
-        three times and licked lightly. <Annotation annotationId="040013wonderisittrue" visited={visitedNotes.has("040013wonderisittrue")} annotationSelect={() => {openNote("040013wonderisittrue"); addToVisited("040013wonderisittrue")}} activeAnnotationId={currentNoteId}>Wonder is it true if you clip them they
+        three times and licked lightly. <Annotation annotationId="040013wonderisittrue">Wonder is it true if you clip them they
         can't mouse after. </Annotation>
         <span data-edition="ed1939" data-page="43"> </span>
-        <Annotation annotationId="040013wonderisittrue" visited={visitedNotes.has("040013wonderisittrue")} annotationSelect={() => {openNote("040013wonderisittrue"); addToVisited("040013wonderisittrue")}} activeAnnotationId={currentNoteId}>Why? They shine in the dark, perhaps, the tips. Or
+        <Annotation annotationId="040013wonderisittrue">Why? They shine in the dark, perhaps, the tips. Or
         kind of feelers in the dark, perhaps.</Annotation>
       </p>
       <p>
         He listened to her licking lap. Ham and eggs, no. No good eggs with this
         drouth. Want pure fresh water. Thursday: not a good day either for a
-        mutton kidney at <Annotation annotationId="040062bolandsbread" visited={visitedNotes.has("040062bolandsbread")} annotationSelect={() => {openNote("040062bolandsbread"); addToVisited("040062bolandsbread")}} activeAnnotationId={currentNoteId}>Buckley's</Annotation>. Fried with butter, a shake of pepper. <Annotation annotationId="040083hewasajew" visited={visitedNotes.has("040083hewasajew")} annotationSelect={() => {openNote("040083hewasajew"); addToVisited("040083hewasajew")}} activeAnnotationId={currentNoteId}>Better
-        a pork kidney</Annotation> at <Annotation annotationId="040007dorsetstreet" visited={visitedNotes.has("040007dorsetstreet")} annotationSelect={() => {openNote("040007dorsetstreet"); addToVisited("040007dorsetstreet")}} activeAnnotationId={currentNoteId}>Dlugacz's</Annotation>. While the kettle is boiling. She lapped
-        slower, then <Annotation annotationId="040022lickingclean" visited={visitedNotes.has("040022lickingclean")} annotationSelect={() => {openNote("040022lickingclean"); addToVisited("040022lickingclean")}} activeAnnotationId={currentNoteId}>licking the saucer clean</Annotation>. Why are their tongues so rough?
+        mutton kidney at <Annotation annotationId="040062bolandsbread">Buckley's</Annotation>. Fried with butter, a shake of pepper. <Annotation annotationId="040083hewasajew">Better
+        a pork kidney</Annotation> at <Annotation annotationId="040007dorsetstreet">Dlugacz's</Annotation>. While the kettle is boiling. She lapped
+        slower, then <Annotation annotationId="040022lickingclean">licking the saucer clean</Annotation>. Why are their tongues so rough?
         To lap better, all porous holes. Nothing she can eat? He glanced round
         him. No.
       </p>
       <p>
         On quietly creaky boots he went up the staircase to the hall, paused by
-        the bedroom door. She might like something tasty. <Annotation annotationId="040022lickingclean" visited={visitedNotes.has("040022lickingclean")} annotationSelect={() => {openNote("040022lickingclean"); addToVisited("040022lickingclean")}} activeAnnotationId={currentNoteId}>Thin bread and butter</Annotation>
+        the bedroom door. She might like something tasty. <Annotation annotationId="040022lickingclean">Thin bread and butter</Annotation>
         she likes in the morning. Still perhaps: once in a way.
       </p>
       <p>
@@ -117,95 +117,95 @@ const Calypso = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         A sleepy soft grunt answered:
       </p>
       <p>
-        <Annotation annotationId="040070mrkgnao" visited={visitedNotes.has("040070mrkgnao")} annotationSelect={() => {openNote("040070mrkgnao"); addToVisited("040070mrkgnao")}} activeAnnotationId={currentNoteId}>—{" "}Mn.</Annotation>
+        <Annotation annotationId="040070mrkgnao">—{" "}Mn.</Annotation>
       </p>
       <p>
         No. She did not want anything. He heard then a warm heavy sigh, softer,
-        as she turned over and <Annotation annotationId="040085brassquoits" visited={visitedNotes.has("040085brassquoits")} annotationSelect={() => {openNote("040085brassquoits"); addToVisited("040085brassquoits")}} activeAnnotationId={currentNoteId}>the loose brass quoits</Annotation> of the bedstead <Annotation annotationId="040091jingle" visited={visitedNotes.has("040091jingle")} annotationSelect={() => {openNote("040091jingle"); addToVisited("040091jingle")}} activeAnnotationId={currentNoteId}>jingled</Annotation>.
+        as she turned over and <Annotation annotationId="040085brassquoits">the loose brass quoits</Annotation> of the bedstead <Annotation annotationId="040091jingle">jingled</Annotation>.
         Must get those settled really. Pity. All the way from Gibraltar.
         Forgotten any little Spanish she knew. Wonder what her father gave for
         it. Old style. Ah yes! of course. Bought it at the governor's auction.
-        <Annotation annotationId="040059shortknock" visited={visitedNotes.has("040059shortknock")} annotationSelect={() => {openNote("040059shortknock"); addToVisited("040059shortknock")}} activeAnnotationId={currentNoteId}>Got a short knock.</Annotation> Hard as nails at a bargain, <Annotation annotationId="040018oldtweedy" visited={visitedNotes.has("040018oldtweedy")} annotationSelect={() => {openNote("040018oldtweedy"); addToVisited("040018oldtweedy")}} activeAnnotationId={currentNoteId}>old Tweedy. Yes, sir. At
+        <Annotation annotationId="040059shortknock">Got a short knock.</Annotation> Hard as nails at a bargain, <Annotation annotationId="040018oldtweedy">old Tweedy. Yes, sir. At
         Plevna that was. I rose from the ranks, sir, and I'm proud of it.</Annotation>
-        Still he had brains enough to <Annotation annotationId="040059shortknock" visited={visitedNotes.has("040059shortknock")} annotationSelect={() => {openNote("040059shortknock"); addToVisited("040059shortknock")}} activeAnnotationId={currentNoteId}>make that corner in stamps</Annotation>. Now that was
+        Still he had brains enough to <Annotation annotationId="040059shortknock">make that corner in stamps</Annotation>. Now that was
         farseeing.
       </p>
       <span data-edition="ed1922" data-page="54"></span>
       <p>
         His hand took his hat from the peg over his initialled heavy overcoat
-        and his <Annotation annotationId="040059shortknock" visited={visitedNotes.has("040059shortknock")} annotationSelect={() => {openNote("040059shortknock"); addToVisited("040059shortknock")}} activeAnnotationId={currentNoteId}>lost property office</Annotation> secondhand waterproof. Stamps: stickyback<span data-edition="ed1932" data-page="49"></span>
-        pictures. Daresay lots of officers are <Annotation annotationId="040059shortknock" visited={visitedNotes.has("040059shortknock")} annotationSelect={() => {openNote("040059shortknock"); addToVisited("040059shortknock")}} activeAnnotationId={currentNoteId}>in the swim</Annotation> too. Course they do.
-        The sweated legend in the crown of his hat told him mutely: <Annotation annotationId="040062bolandsbread" visited={visitedNotes.has("040062bolandsbread")} annotationSelect={() => {openNote("040062bolandsbread"); addToVisited("040062bolandsbread")}} activeAnnotationId={currentNoteId}>Plasto's</Annotation>
-        <Annotation annotationId="040082highgradeha" visited={visitedNotes.has("040082highgradeha")} annotationSelect={() => {openNote("040082highgradeha"); addToVisited("040082highgradeha")}} activeAnnotationId={currentNoteId}>high grade ha</Annotation>. He peeped quickly inside the leather headband. <Annotation annotationId="050015thecard" visited={visitedNotes.has("050015thecard")} annotationSelect={() => {openNote("050015thecard"); addToVisited("050015thecard")}} activeAnnotationId={currentNoteId}>White slip
+        and his <Annotation annotationId="040059shortknock">lost property office</Annotation> secondhand waterproof. Stamps: stickyback<span data-edition="ed1932" data-page="49"></span>
+        pictures. Daresay lots of officers are <Annotation annotationId="040059shortknock">in the swim</Annotation> too. Course they do.
+        The sweated legend in the crown of his hat told him mutely: <Annotation annotationId="040062bolandsbread">Plasto's</Annotation>
+        <Annotation annotationId="040082highgradeha">high grade ha</Annotation>. He peeped quickly inside the leather headband. <Annotation annotationId="050015thecard">White slip
         of paper. Quite safe.</Annotation>
       </p>
       <span data-edition="ed1961" data-page="56"></span>
       <p>
-        <Annotation annotationId="040005seveneccles" visited={visitedNotes.has("040005seveneccles")} annotationSelect={() => {openNote("040005seveneccles"); addToVisited("040005seveneccles")}} activeAnnotationId={currentNoteId}>On the doorstep</Annotation> he felt in his hip pocket for the latchkey. Not there.
-        In the trousers I left off. Must get it. <Annotation annotationId="040047potato" visited={visitedNotes.has("040047potato")} annotationSelect={() => {openNote("040047potato"); addToVisited("040047potato")}} activeAnnotationId={currentNoteId}>Potato I have.</Annotation> Creaky wardrobe.
+        <Annotation annotationId="040005seveneccles">On the doorstep</Annotation> he felt in his hip pocket for the latchkey. Not there.
+        In the trousers I left off. Must get it. <Annotation annotationId="040047potato">Potato I have.</Annotation> Creaky wardrobe.
         No use disturbing her. She turned over sleepily that time. He pulled
-        the halldoor to after him very quietly, more, <Annotation annotationId="040051footleaf" visited={visitedNotes.has("040051footleaf")} annotationSelect={() => {openNote("040051footleaf"); addToVisited("040051footleaf")}} activeAnnotationId={currentNoteId}>till the footleaf dropped
+        the halldoor to after him very quietly, more, <Annotation annotationId="040051footleaf">till the footleaf dropped
         gently over the threshold, a limp lid</Annotation>. Looked shut. All right till I
         come back anyhow.
       </p>
       <p>
-        He crossed to the bright side, avoiding the loose cellarflap of <Annotation annotationId="040075seventyfive" visited={visitedNotes.has("040075seventyfive")} annotationSelect={() => {openNote("040075seventyfive"); addToVisited("040075seventyfive")}} activeAnnotationId={currentNoteId}>number
-        seventyfive</Annotation>. The sun was nearing <Annotation annotationId="040008georgeschurch" visited={visitedNotes.has("040008georgeschurch")} annotationSelect={() => {openNote("040008georgeschurch"); addToVisited("040008georgeschurch")}} activeAnnotationId={currentNoteId}>the steeple of George's church</Annotation>. Be a
-        warm day I fancy. Specially in <Annotation annotationId="010048greypants" visited={visitedNotes.has("010048greypants")} annotationSelect={() => {openNote("010048greypants"); addToVisited("010048greypants")}} activeAnnotationId={currentNoteId}>these black clothes</Annotation> feel it more. <Annotation annotationId="040013wonderisittrue" visited={visitedNotes.has("040013wonderisittrue")} annotationSelect={() => {openNote("040013wonderisittrue"); addToVisited("040013wonderisittrue")}} activeAnnotationId={currentNoteId}>Black
+        He crossed to the bright side, avoiding the loose cellarflap of <Annotation annotationId="040075seventyfive">number
+        seventyfive</Annotation>. The sun was nearing <Annotation annotationId="040008georgeschurch">the steeple of George's church</Annotation>. Be a
+        warm day I fancy. Specially in <Annotation annotationId="010048greypants">these black clothes</Annotation> feel it more. <Annotation annotationId="040013wonderisittrue">Black
         conducts, reflects, (refracts is it?), the heat.</Annotation> But I couldn't go in
         that light suit. Make a<span data-edition="ed1986" data-page="46"></span> picnic of it. His eyelids sank quietly often as
-        he walked in happy warmth. <Annotation annotationId="040062bolandsbread" visited={visitedNotes.has("040062bolandsbread")} annotationSelect={() => {openNote("040062bolandsbread"); addToVisited("040062bolandsbread")}} activeAnnotationId={currentNoteId}>Boland's breadvan</Annotation> delivering with trays <Annotation annotationId="040077ourfather" visited={visitedNotes.has("040077ourfather")} annotationSelect={() => {openNote("040077ourfather"); addToVisited("040077ourfather")}} activeAnnotationId={currentNoteId}>our
+        he walked in happy warmth. <Annotation annotationId="040062bolandsbread">Boland's breadvan</Annotation> delivering with trays <Annotation annotationId="040077ourfather">our
         daily</Annotation> but she prefers yesterday's loaves turnovers crisp crowns hot.
         Makes you feel young. Somewhere in the east: early morning: set off at
         dawn. Travel round in front of the sun, steal a day's march on him. Keep
         it up for ever never grow a day older technically. Walk along a strand,
-        strange land, come to a city gate, sentry there, <Annotation annotationId="040018oldtweedy" visited={visitedNotes.has("040018oldtweedy")} annotationSelect={() => {openNote("040018oldtweedy"); addToVisited("040018oldtweedy")}} activeAnnotationId={currentNoteId}>old ranker too, old
+        strange land, come to a city gate, sentry there, <Annotation annotationId="040018oldtweedy">old ranker too, old
         Tweedy's big moustaches</Annotation>, leaning on a long kind of a spear. Wander
         through awned streets. Turbaned faces going by. Dark caves of carpet
-        shops, big man, <Annotation annotationId="010077pantomime" visited={visitedNotes.has("010077pantomime")} annotationSelect={() => {openNote("010077pantomime"); addToVisited("010077pantomime")}} activeAnnotationId={currentNoteId}>Turko the terrible</Annotation>, seated crosslegged, smoking a coiled
+        shops, big man, <Annotation annotationId="010077pantomime">Turko the terrible</Annotation>, seated crosslegged, smoking a coiled
         pipe. Cries of sellers in the 
         <span data-edition="ed1939" data-page="44"> </span>
-        streets. Drink water scented with fennel, <Annotation annotationId="040012sherbet" visited={visitedNotes.has("040012sherbet")} annotationSelect={() => {openNote("040012sherbet"); addToVisited("040012sherbet")}} activeAnnotationId={currentNoteId}>sherbet</Annotation>. Dander along all day. Might meet a robber or two. Well,
+        streets. Drink water scented with fennel, <Annotation annotationId="040012sherbet">sherbet</Annotation>. Dander along all day. Might meet a robber or two. Well,
         meet him. Getting on to sundown. The shadows of the mosques among the
         pillars: priest with a scroll rolled up. A shiver of the trees, signal,
         the evening wind. I pass on. Fading gold sky. A mother watches me from
         her doorway. She calls her children home in their dark language. High
-        wall: beyond strings twanged. <Annotation annotationId="020080mauve" visited={visitedNotes.has("020080mauve")} annotationSelect={() => {openNote("020080mauve"); addToVisited("020080mauve")}} activeAnnotationId={currentNoteId}>Night sky, moon, violet, colour of Molly's
+        wall: beyond strings twanged. <Annotation annotationId="020080mauve">Night sky, moon, violet, colour of Molly's
         new garters.</Annotation> Strings. Listen. A girl playing one of those instruments
         what do you call them: dulcimers. I pass.
       </p>
       <p>
-        Probably not a bit like it really. <Annotation annotationId="040026trackofthesun" visited={visitedNotes.has("040026trackofthesun")} annotationSelect={() => {openNote("040026trackofthesun"); addToVisited("040026trackofthesun")}} activeAnnotationId={currentNoteId}>Kind of stuff you read: in the track
+        Probably not a bit like it really. <Annotation annotationId="040026trackofthesun">Kind of stuff you read: in the track
         of the sun</Annotation>. Sunburst on the titlepage. He smiled, pleasing himself. What
-        <Annotation annotationId="030037griffith" visited={visitedNotes.has("030037griffith")} annotationSelect={() => {openNote("030037griffith"); addToVisited("030037griffith")}} activeAnnotationId={currentNoteId}>Arthur Griffith</Annotation> said about <Annotation annotationId="040006homerulesun" visited={visitedNotes.has("040006homerulesun")} annotationSelect={() => {openNote("040006homerulesun"); addToVisited("040006homerulesun")}} activeAnnotationId={currentNoteId}>the headpiece over the <i>Freeman</i> leader: a
+        <Annotation annotationId="030037griffith">Arthur Griffith</Annotation> said about <Annotation annotationId="040006homerulesun">the headpiece over the <i>Freeman</i> leader: a
         homerule sun rising up in the northwest from the laneway behind the bank
-        of Ireland</Annotation>. He prolonged his pleased smile. <Annotation annotationId="040050ikeymo" visited={visitedNotes.has("040050ikeymo")} annotationSelect={() => {openNote("040050ikeymo"); addToVisited("040050ikeymo")}} activeAnnotationId={currentNoteId}>Ikey touch that</Annotation>: homerule
+        of Ireland</Annotation>. He prolonged his pleased smile. <Annotation annotationId="040050ikeymo">Ikey touch that</Annotation>: homerule
         sun rising up in the northwest.
       </p>
       <span data-edition="ed1922" data-page="55"></span>
       <p>
-        He approached <Annotation annotationId="040007dorsetstreet" visited={visitedNotes.has("040007dorsetstreet")} annotationSelect={() => {openNote("040007dorsetstreet"); addToVisited("040007dorsetstreet")}} activeAnnotationId={currentNoteId}>Larry O'Rourke's</Annotation>. From the cellar grating floated up<span data-edition="ed1932" data-page="50"></span> the
+        He approached <Annotation annotationId="040007dorsetstreet">Larry O'Rourke's</Annotation>. From the cellar grating floated up<span data-edition="ed1932" data-page="50"></span> the
         flabby gush of porter. Through the open doorway the bar squirted out
         whiffs of ginger, teadust, biscuitmush.<span data-edition="ed1961" data-page="57"></span> Good house, however: just the
-        end of the city traffic. For instance <Annotation annotationId="040062bolandsbread" visited={visitedNotes.has("040062bolandsbread")} annotationSelect={() => {openNote("040062bolandsbread"); addToVisited("040062bolandsbread")}} activeAnnotationId={currentNoteId}>M'Auley's down there</Annotation>: <Annotation annotationId="040082highgradeha" visited={visitedNotes.has("040082highgradeha")} annotationSelect={() => {openNote("040082highgradeha"); addToVisited("040082highgradeha")}} activeAnnotationId={currentNoteId}>n. g.</Annotation> as
-        position. Of course if they ran <Annotation annotationId="040037cattlemarket" visited={visitedNotes.has("040037cattlemarket")} annotationSelect={() => {openNote("040037cattlemarket"); addToVisited("040037cattlemarket")}} activeAnnotationId={currentNoteId}>a tramline along the North Circular from
+        end of the city traffic. For instance <Annotation annotationId="040062bolandsbread">M'Auley's down there</Annotation>: <Annotation annotationId="040082highgradeha">n. g.</Annotation> as
+        position. Of course if they ran <Annotation annotationId="040037cattlemarket">a tramline along the North Circular from
         the cattlemarket to the quays</Annotation> value would go up like a shot.
       </p>
       <p>
         Baldhead over the blind. Cute old codger. No use canvassing him for an
-        ad. Still he knows his own business best. There he is, sure enough, <Annotation annotationId="040081boldlarry" visited={visitedNotes.has("040081boldlarry")} annotationSelect={() => {openNote("040081boldlarry"); addToVisited("040081boldlarry")}} activeAnnotationId={currentNoteId}>my
+        ad. Still he knows his own business best. There he is, sure enough, <Annotation annotationId="040081boldlarry">my
         bold Larry</Annotation>, leaning against the sugarbin in his shirtsleeves watching
-        the aproned <Annotation annotationId="040044curate" visited={visitedNotes.has("040044curate")} annotationSelect={() => {openNote("040044curate"); addToVisited("040044curate")}} activeAnnotationId={currentNoteId}>curate</Annotation> swab up with mop and bucket. Simon Dedalus takes him
+        the aproned <Annotation annotationId="040044curate">curate</Annotation> swab up with mop and bucket. Simon Dedalus takes him
         off to a tee with his eyes screwed up. Do you know what I'm going to
         tell you? What's that, Mr O'Rourke? Do you know what? The Russians,
         they'd only be an eight o'clock breakfast for the Japanese.
       </p>
       <p>
-        Stop and say a word: about the funeral perhaps. <Annotation annotationId="040067poordignam" visited={visitedNotes.has("040067poordignam")} annotationSelect={() => {openNote("040067poordignam"); addToVisited("040067poordignam")}} activeAnnotationId={currentNoteId}>Sad thing about poor
+        Stop and say a word: about the funeral perhaps. <Annotation annotationId="040067poordignam">Sad thing about poor
         Dignam</Annotation>, Mr O'Rourke.
       </p>
       <p>
-        Turning into <Annotation annotationId="040007dorsetstreet" visited={visitedNotes.has("040007dorsetstreet")} annotationSelect={() => {openNote("040007dorsetstreet"); addToVisited("040007dorsetstreet")}} activeAnnotationId={currentNoteId}>Dorset street</Annotation> he said freshly in greeting through the
+        Turning into <Annotation annotationId="040007dorsetstreet">Dorset street</Annotation> he said freshly in greeting through the
         doorway:
       </p>
       <p>
@@ -222,27 +222,27 @@ const Calypso = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <span data-edition="ed1986" data-page="47"></span>
       <p>
-        Where do they get the money? Coming up <Annotation annotationId="040046countyleitrim" visited={visitedNotes.has("040046countyleitrim")} annotationSelect={() => {openNote("040046countyleitrim"); addToVisited("040046countyleitrim")}} activeAnnotationId={currentNoteId}>redheaded curates from the county
-        Leitrim</Annotation>, rinsing empties and <Annotation annotationId="040095oldman" visited={visitedNotes.has("040095oldman")} annotationSelect={() => {openNote("040095oldman"); addToVisited("040095oldman")}} activeAnnotationId={currentNoteId}> old man in the cellar</Annotation>. Then, lo and behold,
-        they blossom out as <Annotation annotationId="040045dantallons" visited={visitedNotes.has("040045dantallons")} annotationSelect={() => {openNote("040045dantallons"); addToVisited("040045dantallons")}} activeAnnotationId={currentNoteId}>Adam Findlaters or Dan Tallons</Annotation>. Then think of the
-        competition. General thirst. <Annotation annotationId="040032passingapub" visited={visitedNotes.has("040032passingapub")} annotationSelect={() => {openNote("040032passingapub"); addToVisited("040032passingapub")}} activeAnnotationId={currentNoteId}>Good puzzle would be cross Dublin without
+        Where do they get the money? Coming up <Annotation annotationId="040046countyleitrim">redheaded curates from the county
+        Leitrim</Annotation>, rinsing empties and <Annotation annotationId="040095oldman"> old man in the cellar</Annotation>. Then, lo and behold,
+        they blossom out as <Annotation annotationId="040045dantallons">Adam Findlaters or Dan Tallons</Annotation>. Then think of the
+        competition. General thirst. <Annotation annotationId="040032passingapub">Good puzzle would be cross Dublin without
         passing a pub</Annotation>. Save it they can't. Off the drunks perhaps. Put down
         three and carry five. What is that, a bob here and there, dribs and
-        drabs. On the wholesale orders perhaps. <Annotation annotationId="040059shortknock" visited={visitedNotes.has("040059shortknock")} annotationSelect={() => {openNote("040059shortknock"); addToVisited("040059shortknock")}} activeAnnotationId={currentNoteId}>Doing a double shuffle with the
+        drabs. On the wholesale orders perhaps. <Annotation annotationId="040059shortknock">Doing a double shuffle with the
         town travellers.</Annotation> Square it with the boss and we'll split the job,
         see?
       </p>
       <p>
         How much would that tot to off the porter in the month? Say ten barrels
-        of stuff. Say he got ten per cent off. O more. Ten. Fifteen. He passed <Annotation annotationId="040002nationalschool" visited={visitedNotes.has("040002nationalschool")} annotationSelect={() => {openNote("040002nationalschool"); addToVisited("040002nationalschool")}} activeAnnotationId={currentNoteId}>Saint
+        of stuff. Say he got ten per cent off. O more. Ten. Fifteen. He passed <Annotation annotationId="040002nationalschool">Saint
         Joseph's National school</Annotation>. Brats' clamour. Windows open. Fresh air
         helps memory. Or a lilt. Ahbeesee defeegee kelomen opeecue rustyouvee
-        doubleyou. Boys are they? Yes. <Annotation annotationId="040020inish" visited={visitedNotes.has("040020inish")} annotationSelect={() => {openNote("040020inish"); addToVisited("040020inish")}} activeAnnotationId={currentNoteId}>Inishturk. Inishark. Inishboffin.</Annotation> At
-        their joggerfry. Mine. <Annotation annotationId="040073slieve" visited={visitedNotes.has("040073slieve")} annotationSelect={() => {openNote("040073slieve"); addToVisited("040073slieve")}} activeAnnotationId={currentNoteId}>Slieve Bloom.</Annotation>
+        doubleyou. Boys are they? Yes. <Annotation annotationId="040020inish">Inishturk. Inishark. Inishboffin.</Annotation> At
+        their joggerfry. Mine. <Annotation annotationId="040073slieve">Slieve Bloom.</Annotation>
       </p>
       <span data-edition="ed1939" data-page="45"> </span>
       <p>
-        He halted before <Annotation annotationId="040060dlugacz" visited={visitedNotes.has("040060dlugacz")} annotationSelect={() => {openNote("040060dlugacz"); addToVisited("040060dlugacz")}} activeAnnotationId={currentNoteId}>Dlugacz's window</Annotation>, staring at the hanks of sausages,
+        He halted before <Annotation annotationId="040060dlugacz">Dlugacz's window</Annotation>, staring at the hanks of sausages,
         polonies, black and white. Fifteen multiplied by. The figures whitened
         in his mind, unsolved: displeased, he let them fade. The shiny links
         packed with 
@@ -255,7 +255,7 @@ const Calypso = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         A kidney oozed bloodgouts on the willowpatterned dish: the last. He
         stood by the nextdoor girl at the counter. Would she buy it too, calling
         the items from a slip in her hand? Chapped: washingsoda. And a pound and
-        a half of Denny's sausages. His eyes rested on her vigorous hips. <Annotation annotationId="040072woods" visited={visitedNotes.has("040072woods")} annotationSelect={() => {openNote("040072woods"); addToVisited("040072woods")}} activeAnnotationId={currentNoteId}>Woods his name is. Wonder what he does. Wife is oldish. New blood.
+        a half of Denny's sausages. His eyes rested on her vigorous hips. <Annotation annotationId="040072woods">Woods his name is. Wonder what he does. Wife is oldish. New blood.
         No followers allowed.</Annotation> Strong pair of arms. Whacking a carpet on the
         clothesline. She does whack it, by George. The way her crooked skirt
         swings at each whack.
@@ -265,16 +265,16 @@ const Calypso = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         blotchy fingers, sausagepink. Sound meat there: like a stallfed heifer.
       </p>
       <p>
-        He took a page up from the pile of cut sheets: <Annotation annotationId="040061agendath" visited={visitedNotes.has("040061agendath")} annotationSelect={() => {openNote("040061agendath"); addToVisited("040061agendath")}} activeAnnotationId={currentNoteId}>the model farm at
+        He took a page up from the pile of cut sheets: <Annotation annotationId="040061agendath">the model farm at
         Kinnereth on the lakeshore of Tiberias. Can become ideal winter
         sanatorium. Moses Montefiore.</Annotation> I thought he was. Farmhouse, wall round
         it, blurred cattle cropping. He held the page from him: interesting:
         read it nearer, the title, the blurred cropping cattle, the page
-        rustling. A young white heifer. <Annotation annotationId="040037cattlemarket" visited={visitedNotes.has("040037cattlemarket")} annotationSelect={() => {openNote("040037cattlemarket"); addToVisited("040037cattlemarket")}} activeAnnotationId={currentNoteId}>Those mornings in the cattlemarket</Annotation>, the
+        rustling. A young white heifer. <Annotation annotationId="040037cattlemarket">Those mornings in the cattlemarket</Annotation>, the
         beasts lowing in their pens, branded sheep, flop and fall of dung, the
         breeders in hobnailed boots trudging through the litter, slapping a palm
         on a ripemeated hindquarter, there's a prime one, unpeeled switches in
-        their hands. He held the page aslant patiently, <Annotation annotationId="040017seemtolikeit" visited={visitedNotes.has("040017seemtolikeit")} annotationSelect={() => {openNote("040017seemtolikeit"); addToVisited("040017seemtolikeit")}} activeAnnotationId={currentNoteId}>bending his senses and
+        their hands. He held the page aslant patiently, <Annotation annotationId="040017seemtolikeit">bending his senses and
         his will, his soft subject gaze at rest. The crooked skirt swinging,
         whack by whack by whack.</Annotation>
       </p>
@@ -299,10 +299,10 @@ const Calypso = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         morning. Hurry up, damn it. Make hay while the sun shines. She stood
         outside the shop in sunlight and sauntered lazily to the right. He
         sighed down his nose: they never understand. Sodachapped hands. Crusted
-        toenails too. <Annotation annotationId="040036scapulars" visited={visitedNotes.has("040036scapulars")} annotationSelect={() => {openNote("040036scapulars"); addToVisited("040036scapulars")}} activeAnnotationId={currentNoteId}>Brown scapulars</Annotation> in tatters, defending her both ways.
+        toenails too. <Annotation annotationId="040036scapulars">Brown scapulars</Annotation> in tatters, defending her both ways.
         The sting<span data-edition="ed1961" data-page="59"></span> of disregard glowed to weak pleasure within his breast. For
-        another: a constable off duty cuddled her in <Annotation annotationId="040072woods" visited={visitedNotes.has("040072woods")} annotationSelect={() => {openNote("040072woods"); addToVisited("040072woods")}} activeAnnotationId={currentNoteId}>Eccles lane</Annotation>. They like
-        them <Annotation annotationId="040084sizeable" visited={visitedNotes.has("040084sizeable")} annotationSelect={() => {openNote("040084sizeable"); addToVisited("040084sizeable")}} activeAnnotationId={currentNoteId}>sizeable</Annotation>. Prime sausage. <Annotation annotationId="040088lostinthewood" visited={visitedNotes.has("040088lostinthewood")} annotationSelect={() => {openNote("040088lostinthewood"); addToVisited("040088lostinthewood")}} activeAnnotationId={currentNoteId}>O please, Mr Policeman, I'm lost in the
+        another: a constable off duty cuddled her in <Annotation annotationId="040072woods">Eccles lane</Annotation>. They like
+        them <Annotation annotationId="040084sizeable">sizeable</Annotation>. Prime sausage. <Annotation annotationId="040088lostinthewood">O please, Mr Policeman, I'm lost in the
         wood.</Annotation>
       </p>
       <p>
@@ -333,15 +333,15 @@ const Calypso = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <span data-edition="ed1939" data-page="46"> </span>
       <p>
-        He walked back along Dorset street, reading gravely. <Annotation annotationId="040061agendath" visited={visitedNotes.has("040061agendath")} annotationSelect={() => {openNote("040061agendath"); addToVisited("040061agendath")}} activeAnnotationId={currentNoteId}>Agendath Netaim:
+        He walked back along Dorset street, reading gravely. <Annotation annotationId="040061agendath">Agendath Netaim:
         planters' company. To purchase waste sandy tracts from Turkish
         government and plant with eucalyptus trees.</Annotation> Excellent for shade, fuel
         and construction. Orangegroves and immense melonfields north of Jaffa.
         You pay eighty marks and they plant a dunam of land for you with olives,
-        oranges, almonds or <Annotation annotationId="040074citrons" visited={visitedNotes.has("040074citrons")} annotationSelect={() => {openNote("040074citrons"); addToVisited("040074citrons")}} activeAnnotationId={currentNoteId}>citrons</Annotation>. Olives cheaper: oranges need artificial
+        oranges, almonds or <Annotation annotationId="040074citrons">citrons</Annotation>. Olives cheaper: oranges need artificial
         irrigation. Every year you get a sending of the crop. Your name entered
         for life as owner in the book of the union. Can pay ten down and the
-        balance in yearly instalments. <Annotation annotationId="040064bleibtreustrasse" visited={visitedNotes.has("040064bleibtreustrasse")} annotationSelect={() => {openNote("040064bleibtreustrasse"); addToVisited("040064bleibtreustrasse")}} activeAnnotationId={currentNoteId}>Bleibtreustrasse 34, Berlin, W. 15.</Annotation>
+        balance in yearly instalments. <Annotation annotationId="040064bleibtreustrasse">Bleibtreustrasse 34, Berlin, W. 15.</Annotation>
       </p>
       <p>
         Nothing doing. Still an idea behind it.
@@ -349,34 +349,34 @@ const Calypso = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       <p>
         He looked at the cattle, blurred in silver heat. Silverpowdered
         olivetrees. Quiet long days: pruning, ripening. Olives are packed in
-        jars, eh? I have a few left from <Annotation annotationId="040062bolandsbread" visited={visitedNotes.has("040062bolandsbread")} annotationSelect={() => {openNote("040062bolandsbread"); addToVisited("040062bolandsbread")}} activeAnnotationId={currentNoteId}>Andrews</Annotation>. Molly spitting them out. Knows
+        jars, eh? I have a few left from <Annotation annotationId="040062bolandsbread">Andrews</Annotation>. Molly spitting them out. Knows
         the taste of them now. Oranges in tissue paper packed in crates. Citrons
-        too. <Annotation annotationId="040049pleasantoldtimes" visited={visitedNotes.has("040049pleasantoldtimes")} annotationSelect={() => {openNote("040049pleasantoldtimes"); addToVisited("040049pleasantoldtimes")}} activeAnnotationId={currentNoteId}>Wonder is poor Citron still alive in Saint Kevin's parade. And Mastiansky
+        too. <Annotation annotationId="040049pleasantoldtimes">Wonder is poor Citron still alive in Saint Kevin's parade. And Mastiansky
         with the old cither. Pleasant evenings we had then. Molly in Citron's
         basketchair.</Annotation> Nice to hold, cool waxen fruit, hold in the hand, lift it
         to the nostrils and smell the perfume. Like that, heavy, sweet, wild
         perfume. Always the same, year after year. They fetched high prices too,
-        <Annotation annotationId="040049pleasantoldtimes" visited={visitedNotes.has("040049pleasantoldtimes")} annotationSelect={() => {openNote("040049pleasantoldtimes"); addToVisited("040049pleasantoldtimes")}} activeAnnotationId={currentNoteId}>Moisel told me. Arbutus place: Pleasants street: pleasant old times.</Annotation>
-        <Annotation annotationId="040074citrons" visited={visitedNotes.has("040074citrons")} annotationSelect={() => {openNote("040074citrons"); addToVisited("040074citrons")}} activeAnnotationId={currentNoteId}>Must be without a flaw</Annotation>, he said. Coming all that way: Spain, Gibraltar,
+        <Annotation annotationId="040049pleasantoldtimes">Moisel told me. Arbutus place: Pleasants street: pleasant old times.</Annotation>
+        <Annotation annotationId="040074citrons">Must be without a flaw</Annotation>, he said. Coming all that way: Spain, Gibraltar,
         Mediterranean, the Levant. Crates lined up on the quayside at Jaffa,
         chap<span data-edition="ed1961" data-page="60"></span> ticking them off in a book, navvies handling them in
-        soiled dungarees. There's whatdoyoucallhim out of. <Annotation annotationId="060026allofus" visited={visitedNotes.has("060026allofus")} annotationSelect={() => {openNote("060026allofus"); addToVisited("060026allofus")}} activeAnnotationId={currentNoteId}>How do you? Doesn't
-        see.</Annotation> Chap you know just to salute bit of a bore. His back is like <Annotation annotationId="040078norwegiancaptain" visited={visitedNotes.has("040078norwegiancaptain")} annotationSelect={() => {openNote("040078norwegiancaptain"); addToVisited("040078norwegiancaptain")}} activeAnnotationId={currentNoteId}>that
+        soiled dungarees. There's whatdoyoucallhim out of. <Annotation annotationId="060026allofus">How do you? Doesn't
+        see.</Annotation> Chap you know just to salute bit of a bore. His back is like <Annotation annotationId="040078norwegiancaptain">that
         Norwegian captain's</Annotation>. Wonder if<span data-edition="ed1986" data-page="49"></span> I'll meet him today. Watering cart. To
-        provoke the rain. <Annotation annotationId="040077ourfather" visited={visitedNotes.has("040077ourfather")} annotationSelect={() => {openNote("040077ourfather"); addToVisited("040077ourfather")}} activeAnnotationId={currentNoteId}>On earth as it is in heaven.</Annotation>
+        provoke the rain. <Annotation annotationId="040077ourfather">On earth as it is in heaven.</Annotation>
       </p>
       <p>
-        <Annotation annotationId="010074cloudcover" visited={visitedNotes.has("010074cloudcover")} annotationSelect={() => {openNote("010074cloudcover"); addToVisited("010074cloudcover")}} activeAnnotationId={currentNoteId}>A cloud began to cover the sun</Annotation> slowly, wholly. Grey. Far.
+        <Annotation annotationId="010074cloudcover">A cloud began to cover the sun</Annotation> slowly, wholly. Grey. Far.
       </p>
       <span data-edition="ed1922" data-page="58"></span>
       <p>
         No, not like that. A barren land, bare waste. Vulcanic lake, the dead
         sea: no fish, weedless, sunk deep in the earth. No wind would lift those<span data-edition="ed1932" data-page="53"></span>
-        waves, grey metal, poisonous foggy waters. <Annotation annotationId="040053deadsea" visited={visitedNotes.has("040053deadsea")} annotationSelect={() => {openNote("040053deadsea"); addToVisited("040053deadsea")}} activeAnnotationId={currentNoteId}>Brimstone they called it
+        waves, grey metal, poisonous foggy waters. <Annotation annotationId="040053deadsea">Brimstone they called it
         raining down: the cities of the plain: Sodom, Gomorrah, Edom.</Annotation> All dead
         names. A dead sea in a dead land, grey and old. Old now. It bore the
-        oldest, the first race. A bent hag <Annotation annotationId="040007dorsetstreet" visited={visitedNotes.has("040007dorsetstreet")} annotationSelect={() => {openNote("040007dorsetstreet"); addToVisited("040007dorsetstreet")}} activeAnnotationId={currentNoteId}>crossed from Cassidy's</Annotation>, clutching <Annotation annotationId="040090naggin" visited={visitedNotes.has("040090naggin")} annotationSelect={() => {openNote("040090naggin"); addToVisited("040090naggin")}} activeAnnotationId={currentNoteId}>a naggin bottle</Annotation> by the neck. The oldest people. <Annotation annotationId="020061wanderers" visited={visitedNotes.has("020061wanderers")} annotationSelect={() => {openNote("020061wanderers"); addToVisited("020061wanderers")}} activeAnnotationId={currentNoteId}>Wandered far away over
-        all the earth, captivity to captivity</Annotation>, <Annotation annotationId="080028multiply" visited={visitedNotes.has("080028multiply")} annotationSelect={() => {openNote("080028multiply"); addToVisited("080028multiply")}} activeAnnotationId={currentNoteId}>multiplying, dying, being born</Annotation>
+        oldest, the first race. A bent hag <Annotation annotationId="040007dorsetstreet">crossed from Cassidy's</Annotation>, clutching <Annotation annotationId="040090naggin">a naggin bottle</Annotation> by the neck. The oldest people. <Annotation annotationId="020061wanderers">Wandered far away over
+        all the earth, captivity to captivity</Annotation>, <Annotation annotationId="080028multiply">multiplying, dying, being born</Annotation>
         everywhere. It lay there now. Now it could bear no more. Dead: an old
         woman's: the grey sunken cunt of the world.
       </p>
@@ -384,26 +384,26 @@ const Calypso = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         Desolation.
       </p>
       <p>
-        Grey horror seared his flesh. Folding the page into his pocket <Annotation annotationId="040005seveneccles" visited={visitedNotes.has("040005seveneccles")} annotationSelect={() => {openNote("040005seveneccles"); addToVisited("040005seveneccles")}} activeAnnotationId={currentNoteId}>he turned
-        into Eccles street, hurrying homeward</Annotation>. <Annotation annotationId="040063happywarmth" visited={visitedNotes.has("040063happywarmth")} annotationSelect={() => {openNote("040063happywarmth"); addToVisited("040063happywarmth")}} activeAnnotationId={currentNoteId}>Cold oils slid along his veins,
-        chilling his blood</Annotation>: <Annotation annotationId="040054saltcloak" visited={visitedNotes.has("040054saltcloak")} annotationSelect={() => {openNote("040054saltcloak"); addToVisited("040054saltcloak")}} activeAnnotationId={currentNoteId}>age crusting him with a salt cloak</Annotation>. Well, I am here
+        Grey horror seared his flesh. Folding the page into his pocket <Annotation annotationId="040005seveneccles">he turned
+        into Eccles street, hurrying homeward</Annotation>. <Annotation annotationId="040063happywarmth">Cold oils slid along his veins,
+        chilling his blood</Annotation>: <Annotation annotationId="040054saltcloak">age crusting him with a salt cloak</Annotation>. Well, I am here
         now. Morning mouth bad images. Got up wrong side of
-        the bed. Must begin again those <Annotation annotationId="040024sandow" visited={visitedNotes.has("040024sandow")} annotationSelect={() => {openNote("040024sandow"); addToVisited("040024sandow")}} activeAnnotationId={currentNoteId}>Sandow's exercises</Annotation>. On the hands down.
-        Blotchy brown brick houses. <Annotation annotationId="040080eighty" visited={visitedNotes.has("040080eighty")} annotationSelect={() => {openNote("040080eighty"); addToVisited("040080eighty")}} activeAnnotationId={currentNoteId}>Number eighty still unlet. Why is that?
+        the bed. Must begin again those <Annotation annotationId="040024sandow">Sandow's exercises</Annotation>. On the hands down.
+        Blotchy brown brick houses. <Annotation annotationId="040080eighty">Number eighty still unlet. Why is that?
         Valuation is only twenty-eight. Towers, Battersby, North, MacArthur:
-        parlour windows plastered with bills.</Annotation> Plasters on a sore eye. <Annotation annotationId="040028smokeoftea" visited={visitedNotes.has("040028smokeoftea")} annotationSelect={() => {openNote("040028smokeoftea"); addToVisited("040028smokeoftea")}} activeAnnotationId={currentNoteId}>To smell
+        parlour windows plastered with bills.</Annotation> Plasters on a sore eye. <Annotation annotationId="040028smokeoftea">To smell
         the gentle smoke of tea, fume of the pan, sizzling butter. Be near her
-        ample bedwarmed flesh.</Annotation> <Annotation annotationId="180005yesyes" visited={visitedNotes.has("180005yesyes")} annotationSelect={() => {openNote("180005yesyes"); addToVisited("180005yesyes")}} activeAnnotationId={currentNoteId}>Yes, yes.</Annotation>
+        ample bedwarmed flesh.</Annotation> <Annotation annotationId="180005yesyes">Yes, yes.</Annotation>
       </p>
       <p>
-        <Annotation annotationId="010074cloudcover" visited={visitedNotes.has("010074cloudcover")} annotationSelect={() => {openNote("010074cloudcover"); addToVisited("010074cloudcover")}} activeAnnotationId={currentNoteId}>Quick warm sunlight came running</Annotation> <Annotation annotationId="060002berkeleystreet" visited={visitedNotes.has("060002berkeleystreet")} annotationSelect={() => {openNote("060002berkeleystreet"); addToVisited("060002berkeleystreet")}} activeAnnotationId={currentNoteId}>from Berkeley road</Annotation>, swiftly, in slim
+        <Annotation annotationId="010074cloudcover">Quick warm sunlight came running</Annotation> <Annotation annotationId="060002berkeleystreet">from Berkeley road</Annotation>, swiftly, in slim
         sandals, along the brightening footpath. Runs, she runs to meet me, a
         girl with gold hair on the wind.
       </p>
       <span data-edition="ed1939" data-page="47"> </span>
       <p>
         Two letters and a card lay on the hallfloor. He stooped and gathered
-        them. <Annotation annotationId="040056mrsmarion" visited={visitedNotes.has("040056mrsmarion")} annotationSelect={() => {openNote("040056mrsmarion"); addToVisited("040056mrsmarion")}} activeAnnotationId={currentNoteId}>Mrs Marion Bloom.</Annotation> His quickened heart slowed at once. Bold hand.
+        them. <Annotation annotationId="040056mrsmarion">Mrs Marion Bloom.</Annotation> His quickened heart slowed at once. Bold hand.
         Mrs Marion.
       </p>
       <p>
@@ -418,7 +418,7 @@ const Calypso = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <span data-edition="ed1961" data-page="61"></span>
       <p>
-        He looked at them. <Annotation annotationId="010126mullingar" visited={visitedNotes.has("010126mullingar")} annotationSelect={() => {openNote("010126mullingar"); addToVisited("010126mullingar")}} activeAnnotationId={currentNoteId}>Mullingar.</Annotation> Milly.
+        He looked at them. <Annotation annotationId="010126mullingar">Mullingar.</Annotation> Milly.
       </p>
       <p>
         —{" "}A letter for me from Milly, he said carefully, and a card to you. And
@@ -432,7 +432,7 @@ const Calypso = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         —{" "}Do you want the blind up?
       </p>
       <p>
-        Letting the blind up by gentle tugs halfway<Annotation annotationId="040042backwardeye" visited={visitedNotes.has("040042backwardeye")} annotationSelect={() => {openNote("040042backwardeye"); addToVisited("040042backwardeye")}} activeAnnotationId={currentNoteId}> his backward eye</Annotation> saw her
+        Letting the blind up by gentle tugs halfway<Annotation annotationId="040042backwardeye"> his backward eye</Annotation> saw her
         glance at the letter and tuck it under her pillow.
       </p>
       <p>
@@ -480,7 +480,7 @@ const Calypso = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         the kettle, crushed the pan flat on the live coals and watched the lump
         of butter slide and melt. While he unwrapped the kidney the cat mewed
         hungrily against him. Give her too much meat she won't mouse. Say they
-        won't eat pork. <Annotation annotationId="040083hewasajew" visited={visitedNotes.has("040083hewasajew")} annotationSelect={() => {openNote("040083hewasajew"); addToVisited("040083hewasajew")}} activeAnnotationId={currentNoteId}>Kosher.</Annotation> Here. He let the bloodsmeared paper fall to
+        won't eat pork. <Annotation annotationId="040083hewasajew">Kosher.</Annotation> Here. He let the bloodsmeared paper fall to
         her and dropped the kidney amid the sizzling butter sauce. Pepper. He
         sprinkled it through his fingers ringwise from the chipped eggcup.
       </p>
@@ -490,18 +490,18 @@ const Calypso = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         seaside girls.
       </p>
       <p>
-        The tea was drawn. He filled his own <Annotation annotationId="040055moustachecup" visited={visitedNotes.has("040055moustachecup")} annotationSelect={() => {openNote("040055moustachecup"); addToVisited("040055moustachecup")}} activeAnnotationId={currentNoteId}>moustachecup, sham crown Derby</Annotation>, smiling. Silly Milly's birthday gift. Only five she was then. No, wait: four. I gave her the amberoid necklace she broke. Putting pieces
+        The tea was drawn. He filled his own <Annotation annotationId="040055moustachecup">moustachecup, sham crown Derby</Annotation>, smiling. Silly Milly's birthday gift. Only five she was then. No, wait: four. I gave her the amberoid necklace she broke. Putting pieces
         of folded brown paper in the letterbox for her. He smiled, pouring.
       </p>
       <span data-edition="ed1961" data-page="62"></span>
-      <p><Annotation annotationId="040052mydarling" visited={visitedNotes.has("040052mydarling")} annotationSelect={() => {openNote("040052mydarling"); addToVisited("040052mydarling")}} activeAnnotationId={currentNoteId}><i>O, Milly Bloom, you are my darling. <br/>
+      <p><Annotation annotationId="040052mydarling"><i>O, Milly Bloom, you are my darling. <br/>
         You are my lookingglass from night to morning. <br/>
         I'd rather have you without a farthing <br/>
         Than Katey Keogh with her ass and garden.</i></Annotation>
       </p>
       <span data-edition="ed1939" data-page="48"> </span>
       <p>
-        <Annotation annotationId="040092professorgoodwin" visited={visitedNotes.has("040092professorgoodwin")} annotationSelect={() => {openNote("040092professorgoodwin"); addToVisited("040092professorgoodwin")}} activeAnnotationId={currentNoteId}>Poor old professor Goodwin. Dreadful old case.</Annotation> Still he was a courteous
+        <Annotation annotationId="040092professorgoodwin">Poor old professor Goodwin. Dreadful old case.</Annotation> Still he was a courteous
         old chap. Oldfashioned way he used to bow Molly off the platform. And
         the little mirror in his silk hat. The night Milly brought it into
         the parlour. O, 
@@ -525,8 +525,8 @@ const Calypso = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <p>
         She set the brasses jingling as she raised herself briskly, an elbow on
-        the pillow. He looked calmly down on her bulk and between <Annotation annotationId="040058shegoatsudder" visited={visitedNotes.has("040058shegoatsudder")} annotationSelect={() => {openNote("040058shegoatsudder"); addToVisited("040058shegoatsudder")}} activeAnnotationId={currentNoteId}>her large soft<span data-edition="ed1986" data-page="51"></span>
-        bubs, sloping within her nightdress like a shegoat's udder</Annotation>. <Annotation annotationId="040028smokeoftea" visited={visitedNotes.has("040028smokeoftea")} annotationSelect={() => {openNote("040028smokeoftea"); addToVisited("040028smokeoftea")}} activeAnnotationId={currentNoteId}>The warmth
+        the pillow. He looked calmly down on her bulk and between <Annotation annotationId="040058shegoatsudder">her large soft<span data-edition="ed1986" data-page="51"></span>
+        bubs, sloping within her nightdress like a shegoat's udder</Annotation>. <Annotation annotationId="040028smokeoftea">The warmth
         of her couched body rose on the air, mingling with the fragrance of the
         tea she poured.</Annotation>
       </p>
@@ -547,7 +547,7 @@ const Calypso = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         —{" "}What are you singing?
       </p>
       <p>
-        —{" "}<Annotation annotationId="040025lacidarem" visited={visitedNotes.has("040025lacidarem")} annotationSelect={() => {openNote("040025lacidarem"); addToVisited("040025lacidarem")}} activeAnnotationId={currentNoteId}><i>Là ci darem</i></Annotation> with <Annotation annotationId="040094jcdoyle" visited={visitedNotes.has("040094jcdoyle")} annotationSelect={() => {openNote("040094jcdoyle"); addToVisited("040094jcdoyle")}} activeAnnotationId={currentNoteId}>J. C. Doyle</Annotation>, she said, and <Annotation annotationId="040035oldsweetsong" visited={visitedNotes.has("040035oldsweetsong")} annotationSelect={() => {openNote("040035oldsweetsong"); addToVisited("040035oldsweetsong")}} activeAnnotationId={currentNoteId}><i>Love's Old Sweet Song</i></Annotation>.
+        —{" "}<Annotation annotationId="040025lacidarem"><i>Là ci darem</i></Annotation> with <Annotation annotationId="040094jcdoyle">J. C. Doyle</Annotation>, she said, and <Annotation annotationId="040035oldsweetsong"><i>Love's Old Sweet Song</i></Annotation>.
       </p>
       <p>
         Her full lips, drinking, smiled. Rather stale smell that incense leaves
@@ -581,10 +581,10 @@ const Calypso = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         —{" "}It must have fell down, she said.
       </p>
       <p>
-        He felt here and there. <Annotation annotationId="040025lacidarem" visited={visitedNotes.has("040025lacidarem")} annotationSelect={() => {openNote("040025lacidarem"); addToVisited("040025lacidarem")}} activeAnnotationId={currentNoteId}><i>Voglio e non vorrei</i>.</Annotation> Wonder if she pronounces
+        He felt here and there. <Annotation annotationId="040025lacidarem"><i>Voglio e non vorrei</i>.</Annotation> Wonder if she pronounces
         that right: <i>voglio</i>. Not in the bed. Must have slid down. He stooped
         and lifted the valance. The book, fallen, sprawled against the bulge of
-        <Annotation annotationId="040057orangekeyed" visited={visitedNotes.has("040057orangekeyed")} annotationSelect={() => {openNote("040057orangekeyed"); addToVisited("040057orangekeyed")}} activeAnnotationId={currentNoteId}>the orangekeyed chamberpot</Annotation>.
+        <Annotation annotationId="040057orangekeyed">the orangekeyed chamberpot</Annotation>.
       </p>
       <span data-edition="ed1922" data-page="61"></span>
       <p>
@@ -614,7 +614,7 @@ const Calypso = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <span data-edition="ed1939" data-page="49"> </span>
       <p>
-        —{" "}<Annotation annotationId="030087pastlife" visited={visitedNotes.has("030087pastlife")} annotationSelect={() => {openNote("030087pastlife"); addToVisited("030087pastlife")}} activeAnnotationId={currentNoteId}>Metempsychosis, he said, frowning. It's Greek: from the Greek. That
+        —{" "}<Annotation annotationId="030087pastlife">Metempsychosis, he said, frowning. It's Greek: from the Greek. That
         means the transmigration of souls.</Annotation>
       </p>
       <p>
@@ -622,12 +622,12 @@ const Calypso = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <p>
         He smiled, glancing askance at her mocking eyes. The same young eyes.
-        <Annotation annotationId="040041dolphinsbarn" visited={visitedNotes.has("040041dolphinsbarn")} annotationSelect={() => {openNote("040041dolphinsbarn"); addToVisited("040041dolphinsbarn")}} activeAnnotationId={currentNoteId}>The first night after the charades. Dolphin's Barn.</Annotation> He turned over
-        the smudged pages. <Annotation annotationId="040021ruby" visited={visitedNotes.has("040021ruby")} annotationSelect={() => {openNote("040021ruby"); addToVisited("040021ruby")}} activeAnnotationId={currentNoteId}><i>Ruby: the Pride of the Ring</i>.</Annotation> Hello. Illustration.
+        <Annotation annotationId="040041dolphinsbarn">The first night after the charades. Dolphin's Barn.</Annotation> He turned over
+        the smudged pages. <Annotation annotationId="040021ruby"><i>Ruby: the Pride of the Ring</i>.</Annotation> Hello. Illustration.
         Fierce Italian with carriagewhip. Must be Ruby pride of the on the floor
-        naked. <Annotation annotationId="040068kindlylight" visited={visitedNotes.has("040068kindlylight")} annotationSelect={() => {openNote("040068kindlylight"); addToVisited("040068kindlylight")}} activeAnnotationId={currentNoteId}>Sheet kindly lent.</Annotation> <i>The monster Maffei desisted and flung his
+        naked. <Annotation annotationId="040068kindlylight">Sheet kindly lent.</Annotation> <i>The monster Maffei desisted and flung his
         victim from him with an oath</i>. Cruelty behind it all. Doped animals.
-        <Annotation annotationId="040066bonethemyoung" visited={visitedNotes.has("040066bonethemyoung")} annotationSelect={() => {openNote("040066bonethemyoung"); addToVisited("040066bonethemyoung")}} activeAnnotationId={currentNoteId}>Trapeze at Hengler's.</Annotation><span data-edition="ed1986" data-page="52"></span> <Annotation annotationId="040066bonethemyoung" visited={visitedNotes.has("040066bonethemyoung")} annotationSelect={() => {openNote("040066bonethemyoung"); addToVisited("040066bonethemyoung")}} activeAnnotationId={currentNoteId}>Had to look the other way. Mob gaping. Break your
+        <Annotation annotationId="040066bonethemyoung">Trapeze at Hengler's.</Annotation><span data-edition="ed1986" data-page="52"></span> <Annotation annotationId="040066bonethemyoung">Had to look the other way. Mob gaping. Break your
         neck and we'll break our sides. Families of them. Bone them young so
         they metempsychosis.</Annotation> That we live after death. Our souls. That a man's
         soul after he dies. Dignam's soul...
@@ -643,13 +643,13 @@ const Calypso = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         —{" "}Never read it. Do you want another?
       </p>
       <p>
-        —{" "}Yes. Get another of <Annotation annotationId="040003nicename" visited={visitedNotes.has("040003nicename")} annotationSelect={() => {openNote("040003nicename"); addToVisited("040003nicename")}} activeAnnotationId={currentNoteId}>Paul de Kock's. Nice name</Annotation> he has.
+        —{" "}Yes. Get another of <Annotation annotationId="040003nicename">Paul de Kock's. Nice name</Annotation> he has.
       </p>
       <p>
         She poured more tea into her cup, watching it flow sideways.
       </p>
       <p>
-        <Annotation annotationId="040043capelstreet" visited={visitedNotes.has("040043capelstreet")} annotationSelect={() => {openNote("040043capelstreet"); addToVisited("040043capelstreet")}} activeAnnotationId={currentNoteId}>Must get that Capel street library book renewed or they'll</Annotation><span data-edition="ed1961" data-page="64"></span><Annotation annotationId="040043capelstreet" visited={visitedNotes.has("040043capelstreet")} annotationSelect={() => {openNote("040043capelstreet"); addToVisited("040043capelstreet")}} activeAnnotationId={currentNoteId}> write to
+        <Annotation annotationId="040043capelstreet">Must get that Capel street library book renewed or they'll</Annotation><span data-edition="ed1961" data-page="64"></span><Annotation annotationId="040043capelstreet"> write to
         Kearney, my guarantor.</Annotation> Reincarnation: that's the word.
       </p>
       <p>
@@ -666,8 +666,8 @@ const Calypso = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       <p>
         The <i>Bath of the Nymph</i> over the bed. Given away with the Easter number 
         <span data-edition="ed1922" data-page="62"></span>
-        of <Annotation annotationId="040034photobits" visited={visitedNotes.has("040034photobits")} annotationSelect={() => {openNote("040034photobits"); addToVisited("040034photobits")}} activeAnnotationId={currentNoteId}><i>Photo Bits</i></Annotation>: Splendid masterpiece in art colours. Tea before you
-        put milk in. <Annotation annotationId="040048slimmer" visited={visitedNotes.has("040048slimmer")} annotationSelect={() => {openNote("040048slimmer"); addToVisited("040048slimmer")}} activeAnnotationId={currentNoteId}>Not unlike her with her hair down: slimmer.</Annotation> Three and six
+        of <Annotation annotationId="040034photobits"><i>Photo Bits</i></Annotation>: Splendid masterpiece in art colours. Tea before you
+        put milk in. <Annotation annotationId="040048slimmer">Not unlike her with her hair down: slimmer.</Annotation> Three and six
         I gave for the frame. She said it would look nice over the bed. Naked
         nymphs: Greece: and for instance all the people that lived then.
       </p>
@@ -721,15 +721,15 @@ const Calypso = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         splendid. Everyone says I'm quite the belle in my new tam. I got
         mummy's lovely box of creams and am writing. They are lovely. I am
         getting on swimming in the photo business now. Mr Coghlan took one of me
-        and Mrs will send when developed. We did great biz yesterday. <Annotation annotationId="040001fairday" visited={visitedNotes.has("040001fairday")} annotationSelect={() => {openNote("040001fairday"); addToVisited("040001fairday")}} activeAnnotationId={currentNoteId}>Fair day</Annotation> and all the <Annotation annotationId="040004beefheels" visited={visitedNotes.has("040004beefheels")} annotationSelect={() => {openNote("040004beefheels"); addToVisited("040004beefheels")}} activeAnnotationId={currentNoteId}>beef to the heels</Annotation> were in. We are going to <Annotation annotationId="040033loughowel" visited={visitedNotes.has("040033loughowel")} annotationSelect={() => {openNote("040033loughowel"); addToVisited("040033loughowel")}} activeAnnotationId={currentNoteId}>lough Owel</Annotation> on
+        and Mrs will send when developed. We did great biz yesterday. <Annotation annotationId="040001fairday">Fair day</Annotation> and all the <Annotation annotationId="040004beefheels">beef to the heels</Annotation> were in. We are going to <Annotation annotationId="040033loughowel">lough Owel</Annotation> on
         Monday with a few friends to make a scrap picnic. Give my love to
         mummy and to yourself a big kiss and thanks. I hear them at the piano
         downstairs. There is to be a concert in the 
         <span data-edition="ed1922" data-page="63"></span>
-        <Annotation annotationId="040033loughowel" visited={visitedNotes.has("040033loughowel")} annotationSelect={() => {openNote("040033loughowel"); addToVisited("040033loughowel")}} activeAnnotationId={currentNoteId}>Greville Arms</Annotation> on Saturday.
+        <Annotation annotationId="040033loughowel">Greville Arms</Annotation> on Saturday.
         There is a young student comes here some evenings named Bannon his
         cousins or something are big swells he sings Boylan's (I was on the
-        pop of writing Blazes Boylan's) <Annotation annotationId="040069seasidegirls" visited={visitedNotes.has("040069seasidegirls")} annotationSelect={() => {openNote("040069seasidegirls"); addToVisited("040069seasidegirls")}} activeAnnotationId={currentNoteId}>song about those seaside girls</Annotation>. Tell him
+        pop of writing Blazes Boylan's) <Annotation annotationId="040069seasidegirls">song about those seaside girls</Annotation>. Tell him
         silly Milly sends my best respects. I must now close with fondest love.
       </p>
       <p>
@@ -747,18 +747,18 @@ const Calypso = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       <p>
         Fifteen yesterday. Curious, fifteenth of the month too. Her first
         birthday away from home. Separation. Remember the summer morning she
-        was born, running to knock up <Annotation annotationId="040086mrsthornton" visited={visitedNotes.has("040086mrsthornton")} annotationSelect={() => {openNote("040086mrsthornton"); addToVisited("040086mrsthornton")}} activeAnnotationId={currentNoteId}>Mrs Thornton</Annotation> in <Annotation annotationId="040089denzille" visited={visitedNotes.has("040089denzille")} annotationSelect={() => {openNote("040089denzille"); addToVisited("040089denzille")}} activeAnnotationId={currentNoteId}>Denzille street</Annotation>.<span data-edition="ed1932" data-page="58"></span> Jolly old
+        was born, running to knock up <Annotation annotationId="040086mrsthornton">Mrs Thornton</Annotation> in <Annotation annotationId="040089denzille">Denzille street</Annotation>.<span data-edition="ed1932" data-page="58"></span> Jolly old
         woman. Lots of babies she must have helped into the world. She knew from
-        the first <Annotation annotationId="040087poorlittlerudy" visited={visitedNotes.has("040087poorlittlerudy")} annotationSelect={() => {openNote("040087poorlittlerudy"); addToVisited("040087poorlittlerudy")}} activeAnnotationId={currentNoteId}>poor little Rudy</Annotation> wouldn't live. Well, <Annotation annotationId="040023godisgood" visited={visitedNotes.has("040023godisgood")} annotationSelect={() => {openNote("040023godisgood"); addToVisited("040023godisgood")}} activeAnnotationId={currentNoteId}>God is good</Annotation>, sir. <Annotation annotationId="040096sheknew" visited={visitedNotes.has("040096sheknew")} annotationSelect={() => {openNote("040096sheknew"); addToVisited("040096sheknew")}} activeAnnotationId={currentNoteId}>She
+        the first <Annotation annotationId="040087poorlittlerudy">poor little Rudy</Annotation> wouldn't live. Well, <Annotation annotationId="040023godisgood">God is good</Annotation>, sir. <Annotation annotationId="040096sheknew">She
         knew at once.</Annotation> He would be eleven now if he had lived.
       </p>
       <p>
         His vacant face stared pitying at the postscript. Excuse bad writing.
         Hurry. Piano downstairs. Coming out of her shell. Row with her in the
-        <Annotation annotationId="040062bolandsbread" visited={visitedNotes.has("040062bolandsbread")} annotationSelect={() => {openNote("040062bolandsbread"); addToVisited("040062bolandsbread")}} activeAnnotationId={currentNoteId}>XL Cafe</Annotation> about the bracelet. Wouldn't eat her cakes or speak or look.
+        <Annotation annotationId="040062bolandsbread">XL Cafe</Annotation> about the bracelet. Wouldn't eat her cakes or speak or look.
         Saucebox. He sopped other dies of bread in the gravy and ate piece after
         piece of kidney. Twelve and six a week. Not much. Still, she might do
-        worse. <Annotation annotationId="040076musichall" visited={visitedNotes.has("040076musichall")} annotationSelect={() => {openNote("040076musichall"); addToVisited("040076musichall")}} activeAnnotationId={currentNoteId}>Music hall stage.</Annotation> Young student. He drank a draught of cooler tea
+        worse. <Annotation annotationId="040076musichall">Music hall stage.</Annotation> Young student. He drank a draught of cooler tea
         to wash down his meal. Then he read the letter again: twice.
       </p>
       <p>
@@ -773,8 +773,8 @@ const Calypso = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       <p>
         He smiled with troubled affection at the kitchen window.<span data-edition="ed1961" data-page="66"></span> Day I caught
         her in the street pinching her cheeks to make them red. Anemic a little.
-        Was given milk too long. <Annotation annotationId="030013kishlightship" visited={visitedNotes.has("030013kishlightship")} annotationSelect={() => {openNote("030013kishlightship"); addToVisited("030013kishlightship")}} activeAnnotationId={currentNoteId}>On the <i>Erin's King</i> that day round the Kish.</Annotation>
-        Damned old tub pitching about. <Annotation annotationId="040069seasidegirls" visited={visitedNotes.has("040069seasidegirls")} annotationSelect={() => {openNote("040069seasidegirls"); addToVisited("040069seasidegirls")}} activeAnnotationId={currentNoteId}>Not a bit funky. Her pale blue scarf
+        Was given milk too long. <Annotation annotationId="030013kishlightship">On the <i>Erin's King</i> that day round the Kish.</Annotation>
+        Damned old tub pitching about. <Annotation annotationId="040069seasidegirls">Not a bit funky. Her pale blue scarf
         loose in the wind with her hair.</Annotation>
       </p>
       <span data-edition="ed1986" data-page="54"></span>
@@ -786,7 +786,7 @@ const Calypso = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       <p>
         Seaside girls. Torn envelope. Hands stuck in his trousers' pockets,
         jarvey off for the day, singing. Friend of the family. Swurls, he says.
-        <Annotation annotationId="040069seasidegirls" visited={visitedNotes.has("040069seasidegirls")} annotationSelect={() => {openNote("040069seasidegirls"); addToVisited("040069seasidegirls")}} activeAnnotationId={currentNoteId}>Pier with lamps, summer evening, band</Annotation>,
+        <Annotation annotationId="040069seasidegirls">Pier with lamps, summer evening, band</Annotation>,
       </p>
       <span data-edition="ed1922" data-page="64"></span>
       <p>  <i>Those girls, those girls, <br/>
@@ -798,16 +798,16 @@ const Calypso = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         braiding.
       </p>
       <p>
-        <Annotation annotationId="040017seemtolikeit" visited={visitedNotes.has("040017seemtolikeit")} annotationSelect={() => {openNote("040017seemtolikeit"); addToVisited("040017seemtolikeit")}} activeAnnotationId={currentNoteId}>A soft qualm, regret, flowed down his backbone, increasing. Will happen,
+        <Annotation annotationId="040017seemtolikeit">A soft qualm, regret, flowed down his backbone, increasing. Will happen,
         yes. Prevent. Useless: can't move.</Annotation> Girl's sweet light lips. Will happen
         too. He felt the flowing qualm spread over him. Useless to move now.
         Lips kissed, kissing, kissed. Full gluey woman's lips.
       </p>
       <p>
         Better where she is down there: away. Occupy her. Wanted a dog to pass
-        the time. <Annotation annotationId="010126mullingar" visited={visitedNotes.has("010126mullingar")} annotationSelect={() => {openNote("010126mullingar"); addToVisited("010126mullingar")}} activeAnnotationId={currentNoteId}>Might take a trip down there.</Annotation> August <Annotation annotationId="040029bankholiday" visited={visitedNotes.has("040029bankholiday")} annotationSelect={() => {openNote("040029bankholiday"); addToVisited("040029bankholiday")}} activeAnnotationId={currentNoteId}>bank holiday</Annotation>, only two
+        the time. <Annotation annotationId="010126mullingar">Might take a trip down there.</Annotation> August <Annotation annotationId="040029bankholiday">bank holiday</Annotation>, only two
         and six return. Six weeks off, however. Might work a press pass. Or
-        through <Annotation annotationId="040079mcoy" visited={visitedNotes.has("040079mcoy")} annotationSelect={() => {openNote("040079mcoy"); addToVisited("040079mcoy")}} activeAnnotationId={currentNoteId}>M'Coy.</Annotation>
+        through <Annotation annotationId="040079mcoy">M'Coy.</Annotation>
       </p>
       <p>
         The cat, having cleaned all her fur, returned to the meatstained paper,<span data-edition="ed1932" data-page="59"></span>
@@ -832,7 +832,7 @@ const Calypso = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         I'm.
       </p>
       <p>
-        In the tabledrawer he found <Annotation annotationId="040019titbits" visited={visitedNotes.has("040019titbits")} annotationSelect={() => {openNote("040019titbits"); addToVisited("040019titbits")}} activeAnnotationId={currentNoteId}>an old number of <i>Titbits</i></Annotation>. He folded it
+        In the tabledrawer he found <Annotation annotationId="040019titbits">an old number of <i>Titbits</i></Annotation>. He folded it
         under his armpit, went to the door and opened<span data-edition="ed1961" data-page="67"></span> it. The cat went up in
         soft bounds. Ah, wanted to go upstairs, curl up in a ball on the bed.
       </p>
@@ -845,7 +845,7 @@ const Calypso = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       <p>
         He went out through the backdoor into the garden: stood to listen
         towards the next garden. No sound. Perhaps hanging clothes out to dry.
-        <Annotation annotationId="040014singasong" visited={visitedNotes.has("040014singasong")} annotationSelect={() => {openNote("040014singasong"); addToVisited("040014singasong")}} activeAnnotationId={currentNoteId}>The maid was in the garden.</Annotation> Fine morning.
+        <Annotation annotationId="040014singasong">The maid was in the garden.</Annotation> Fine morning.
       </p>
       <p>
         He bent down to regard a lean file of spearmint growing by the wall.
@@ -859,35 +859,35 @@ const Calypso = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         fed on those oilcakes. Mulch of dung. Best thing to clean ladies' kid
         gloves. Dirty cleans. Ashes too. Reclaim the whole place. Grow peas in
         that corner there. Lettuce. Always have fresh greens then. Still gardens
-        have their drawbacks. <Annotation annotationId="040040bluebottle" visited={visitedNotes.has("040040bluebottle")} annotationSelect={() => {openNote("040040bluebottle"); addToVisited("040040bluebottle")}} activeAnnotationId={currentNoteId}>That bee or bluebottle here Whitmonday.</Annotation>
+        have their drawbacks. <Annotation annotationId="040040bluebottle">That bee or bluebottle here Whitmonday.</Annotation>
       </p>
       <p>
         He walked on. Where is my hat, by the way? Must have put it back on the
-        peg. Or hanging up on the floor. <Annotation annotationId="040010myhat" visited={visitedNotes.has("040010myhat")} annotationSelect={() => {openNote("040010myhat"); addToVisited("040010myhat")}} activeAnnotationId={currentNoteId}>Funny, I don't remember that.</Annotation> Hallstand
+        peg. Or hanging up on the floor. <Annotation annotationId="040010myhat">Funny, I don't remember that.</Annotation> Hallstand
         too full. Four umbrellas, her raincloak. Picking up the letters.
-        <Annotation annotationId="040062bolandsbread" visited={visitedNotes.has("040062bolandsbread")} annotationSelect={() => {openNote("040062bolandsbread"); addToVisited("040062bolandsbread")}} activeAnnotationId={currentNoteId}>Drago's</Annotation> shopbell ringing. Queer I was just thinking that moment. Brown
+        <Annotation annotationId="040062bolandsbread">Drago's</Annotation> shopbell ringing. Queer I was just thinking that moment. Brown
         brillantined hair over his collar. Just had a wash and brushup. Wonder
         have I time for a bath this 
         <span data-edition="ed1939" data-page="52"> </span>
-        morning. <Annotation annotationId="050010mosquebaths" visited={visitedNotes.has("050010mosquebaths")} annotationSelect={() => {openNote("050010mosquebaths"); addToVisited("050010mosquebaths")}} activeAnnotationId={currentNoteId}>Tara street.</Annotation> Chap in the paybox
-        there <Annotation annotationId="020073fenians" visited={visitedNotes.has("020073fenians")} annotationSelect={() => {openNote("020073fenians"); addToVisited("020073fenians")}} activeAnnotationId={currentNoteId}>got away James Stephens</Annotation>, they say. <Annotation annotationId="040031smithobrien" visited={visitedNotes.has("040031smithobrien")} annotationSelect={() => {openNote("040031smithobrien"); addToVisited("040031smithobrien")}} activeAnnotationId={currentNoteId}>O'Brien.</Annotation>
+        morning. <Annotation annotationId="050010mosquebaths">Tara street.</Annotation> Chap in the paybox
+        there <Annotation annotationId="020073fenians">got away James Stephens</Annotation>, they say. <Annotation annotationId="040031smithobrien">O'Brien.</Annotation>
       </p>
       <p>
         Deep voice that fellow Dlugacz has. Agenda what is it? Now, my miss.
-        <Annotation annotationId="040060dlugacz" visited={visitedNotes.has("040060dlugacz")} annotationSelect={() => {openNote("040060dlugacz"); addToVisited("040060dlugacz")}} activeAnnotationId={currentNoteId}>Enthusiast.</Annotation>
+        <Annotation annotationId="040060dlugacz">Enthusiast.</Annotation>
       </p>
       <p>
         He kicked open the crazy door of the jakes. Better be careful not to get
-        these trousers dirty for the funeral. He went in, <Annotation annotationId="040038lowlintel" visited={visitedNotes.has("040038lowlintel")} annotationSelect={() => {openNote("040038lowlintel"); addToVisited("040038lowlintel")}} activeAnnotationId={currentNoteId}>bowing his head</Annotation><span data-edition="ed1932" data-page="60"></span>
-        <Annotation annotationId="040038lowlintel" visited={visitedNotes.has("040038lowlintel")} annotationSelect={() => {openNote("040038lowlintel"); addToVisited("040038lowlintel")}} activeAnnotationId={currentNoteId}>under the low lintel</Annotation>. Leaving the door ajar, amid the stench of mouldy
+        these trousers dirty for the funeral. He went in, <Annotation annotationId="040038lowlintel">bowing his head</Annotation><span data-edition="ed1932" data-page="60"></span>
+        <Annotation annotationId="040038lowlintel">under the low lintel</Annotation>. Leaving the door ajar, amid the stench of mouldy
         limewash and stale cobwebs he undid his braces. Before sitting down he
-        peered through a chink up at the nextdoor window. <Annotation annotationId="040014singasong" visited={visitedNotes.has("040014singasong")} annotationSelect={() => {openNote("040014singasong"); addToVisited("040014singasong")}} activeAnnotationId={currentNoteId}>The king was in his
+        peered through a chink up at the nextdoor window. <Annotation annotationId="040014singasong">The king was in his
         countinghouse.</Annotation> Nobody.
       </p>
       <p>
-        Asquat on the <Annotation annotationId="040093cuckstool" visited={visitedNotes.has("040093cuckstool")} annotationSelect={() => {openNote("040093cuckstool"); addToVisited("040093cuckstool")}} activeAnnotationId={currentNoteId}>cuckstool</Annotation> he folded out his paper, turning its pages over
+        Asquat on the <Annotation annotationId="040093cuckstool">cuckstool</Annotation> he folded out his paper, turning its pages over
         on his bared knees. Something new and easy. No great hurry. Keep it a
-        bit. <Annotation annotationId="040019titbits" visited={visitedNotes.has("040019titbits")} annotationSelect={() => {openNote("040019titbits"); addToVisited("040019titbits")}} activeAnnotationId={currentNoteId}>Our prize titbit</Annotation>: <i>Matcham's Masterstroke</i>. Written by Mr Philip
+        bit. <Annotation annotationId="040019titbits">Our prize titbit</Annotation>: <i>Matcham's Masterstroke</i>. Written by Mr Philip
         Beaufoy, Playgoers' Club, London. Payment at the rate of one guinea
         a column has been<span data-edition="ed1961" data-page="68"></span> made to the writer. Three and a half. Three pounds
         three. Three pounds, thirteen and six.
@@ -897,11 +897,11 @@ const Calypso = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         resisting, began the second. Midway, his last resistance yielding, he
         allowed his bowels to ease themselves quietly as he read, reading still
         patiently, that slight constipation of yesterday quite gone. Hope it's
-        not too big bring on piles again. No, just right. So. Ah! <Annotation annotationId="040039cascara" visited={visitedNotes.has("040039cascara")} annotationSelect={() => {openNote("040039cascara"); addToVisited("040039cascara")}} activeAnnotationId={currentNoteId}>Costive. One
+        not too big bring on piles again. No, just right. So. Ah! <Annotation annotationId="040039cascara">Costive. One
         tabloid of cascara sagrada.</Annotation> Life might be so. It did not move or touch
         him but it was something quick and neat. Print anything now. Silly
         season. He read on, seated calm above his own rising smell. Neat
-        certainly. <Annotation annotationId="040065matcham" visited={visitedNotes.has("040065matcham")} annotationSelect={() => {openNote("040065matcham"); addToVisited("040065matcham")}} activeAnnotationId={currentNoteId}><i>Matcham often thinks of the masterstroke by which he won the
+        certainly. <Annotation annotationId="040065matcham"><i>Matcham often thinks of the masterstroke by which he won the
         laughing witch who now</i>. Begins and ends morally. <i>Hand in hand</i>.</Annotation> Smart.
         He glanced back through what he had read and, while feeling 
         <span data-edition="ed1922" data-page="66"></span>
@@ -914,13 +914,13 @@ const Calypso = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         some proverb. Which? Time I used to try jotting down on my cuff what she
         said dressing. Dislike dressing together. Nicked myself shaving. Biting
         her nether lip, hooking the placket of her skirt. Timing her. 9.l5.
-        Did Roberts pay you yet? 9.20. What had <Annotation annotationId="040027conroy" visited={visitedNotes.has("040027conroy")} annotationSelect={() => {openNote("040027conroy"); addToVisited("040027conroy")}} activeAnnotationId={currentNoteId}>Gretta Conroy</Annotation> on? 9.23. What
+        Did Roberts pay you yet? 9.20. What had <Annotation annotationId="040027conroy">Gretta Conroy</Annotation> on? 9.23. What
         possessed me to buy this comb? 9.24. I'm swelled after that cabbage. A
         speck of dust on the patent leather of her boot.
       </p>
       <p>
         Rubbing smartly in turn<span data-edition="ed1986" data-page="56"></span> each welt against her stockinged calf. Morning
-        after the bazaar dance when <Annotation annotationId="040062bolandsbread" visited={visitedNotes.has("040062bolandsbread")} annotationSelect={() => {openNote("040062bolandsbread"); addToVisited("040062bolandsbread")}} activeAnnotationId={currentNoteId}>May's band</Annotation> played <Annotation annotationId="040016danceofthehours" visited={visitedNotes.has("040016danceofthehours")} annotationSelect={() => {openNote("040016danceofthehours"); addToVisited("040016danceofthehours")}} activeAnnotationId={currentNoteId}>Ponchielli's dance of the
+        after the bazaar dance when <Annotation annotationId="040062bolandsbread">May's band</Annotation> played <Annotation annotationId="040016danceofthehours">Ponchielli's dance of the
         hours</Annotation>. Explain that: morning hours, noon, then evening coming on, then
         night hours. Washing her teeth. That was the first night. Her head
         dancing. Her fansticks clicking. Is that Boylan well off? He has money.
@@ -950,14 +950,14 @@ const Calypso = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         is the funeral? Better find out in the paper.
       </p>
       <p>
-        A creak and a dark whirr in the air high up. <Annotation annotationId="040008georgeschurch" visited={visitedNotes.has("040008georgeschurch")} annotationSelect={() => {openNote("040008georgeschurch"); addToVisited("040008georgeschurch")}} activeAnnotationId={currentNoteId}>The bells of George's
+        A creak and a dark whirr in the air high up. <Annotation annotationId="040008georgeschurch">The bells of George's
         church.</Annotation> They tolled the hour: loud dark iron.
       </p>
-      <p><Annotation annotationId="010012quarterto" visited={visitedNotes.has("010012quarterto")} annotationSelect={() => {openNote("010012quarterto"); addToVisited("010012quarterto")}} activeAnnotationId={currentNoteId}><i>Heigho! Heigho! <br/>
+      <p><Annotation annotationId="010012quarterto"><i>Heigho! Heigho! <br/>
         Heigho! Heigho! <br/>
         Heigho! Heigho!</i></Annotation>
       </p>
-      <p><Annotation annotationId="010012quarterto" visited={visitedNotes.has("010012quarterto")} annotationSelect={() => {openNote("010012quarterto"); addToVisited("010012quarterto")}} activeAnnotationId={currentNoteId}>
+      <p><Annotation annotationId="010012quarterto">
         Quarter to.</Annotation> There again: the overtone following through the air, third.
       </p>
       <p>

--- a/src/content/chapters/Circe.js
+++ b/src/content/chapters/Circe.js
@@ -1,16 +1,16 @@
 import Annotation from "../../components/Annotation";
 
 
-const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
+const Circe = () => {
   return (
     <div>
       <p style={{textIndent:"-.3in", marginLeft:".75in", paddingTop:".2in"}}></p>
       <center><font size="+2">[15]</font></center>
       <br/>
-      <i>(<Annotation annotationId="150005nighttown" visited={visitedNotes.has("150005nighttown")} annotationSelect={() => {openNote("150005nighttown"); addToVisited("150005nighttown")}} activeAnnotationId={currentNoteId}>The Mabbot street entrance of nighttown</Annotation>, before which stretches
+      <i>(<Annotation annotationId="150005nighttown">The Mabbot street entrance of nighttown</Annotation>, before which stretches
       an uncobbled tramsiding set with skeleton tracks, red and green
-      <Annotation annotationId="150004willowisp" visited={visitedNotes.has("150004willowisp")} annotationSelect={() => {openNote("150004willowisp"); addToVisited("150004willowisp")}} activeAnnotationId={currentNoteId}>will-o'-the-wisps</Annotation> and danger signals. Rows of grimy houses with gaping
-      doors. Rare lamps with faint rainbow fins. <Annotation annotationId="050047hokypoky" visited={visitedNotes.has("050047hokypoky")} annotationSelect={() => {openNote("050047hokypoky"); addToVisited("050047hokypoky")}} activeAnnotationId={currentNoteId}>Round Rabaiotti's halted ice
+      <Annotation annotationId="150004willowisp">will-o'-the-wisps</Annotation> and danger signals. Rows of grimy houses with gaping
+      doors. Rare lamps with faint rainbow fins. <Annotation annotationId="050047hokypoky">Round Rabaiotti's halted ice
       gondola stunted men and women squabble. They grab wafers between which
       are wedged lumps of coral and copper snow.</Annotation> Sucking, they scatter slowly.
       Children. The swancomb of the gondola, highreared, forges on through the
@@ -30,7 +30,7 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <p>
         <i>(A deafmute idiot with goggle eyes, his shapeless mouth dribbling,
-        jerks past, shaken in <Annotation annotationId="150003saintvitus" visited={visitedNotes.has("150003saintvitus")} annotationSelect={() => {openNote("150003saintvitus"); addToVisited("150003saintvitus")}} activeAnnotationId={currentNoteId}>Saint Vitus' dance</Annotation>. A chain of children's hands
+        jerks past, shaken in <Annotation annotationId="150003saintvitus">Saint Vitus' dance</Annotation>. A chain of children's hands
         imprisons him.)</i>
       </p>
       <p>
@@ -124,7 +124,7 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         PRIVATE COMPTON 
       </p>
       <p>
-        <i>(Jerks his finger.)</i> Way for the <Annotation annotationId="010097latinquarterhat" visited={visitedNotes.has("010097latinquarterhat")} annotationSelect={() => {openNote("010097latinquarterhat"); addToVisited("010097latinquarterhat")}} activeAnnotationId={currentNoteId}>parson</Annotation>.
+        <i>(Jerks his finger.)</i> Way for the <Annotation annotationId="010097latinquarterhat">parson</Annotation>.
       </p>
       <p>
         PRIVATE CARR
@@ -192,7 +192,7 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         <i>(Bickering.)</i> And says the one: I seen you up Faithful
         place with your squarepusher, the greaser off the railway, in his
         cometobed hat. Did you, says I. That's not for you to say, says I. You
-        never seen me in <Annotation annotationId="150014mantrap" visited={visitedNotes.has("150014mantrap")} annotationSelect={() => {openNote("150014mantrap"); addToVisited("150014mantrap")}} activeAnnotationId={currentNoteId}>the mantrap</Annotation> with a married highlander, says I. The
+        never seen me in <Annotation annotationId="150014mantrap">the mantrap</Annotation> with a married highlander, says I. The
         likes of her! Stag that one is! Stubborn as a mule! And her walking with
         two fellows the one time, Kilbride, the enginedriver, and lancecorporal
         Oliphant.
@@ -227,14 +227,14 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         LYNCH
       </p>
       <p>
-        Pornosophical philotheology. Metaphysics in <Annotation annotationId="150005nighttown" visited={visitedNotes.has("150005nighttown")} annotationSelect={() => {openNote("150005nighttown"); addToVisited("150005nighttown")}} activeAnnotationId={currentNoteId}>Mecklenburgh street</Annotation>!
+        Pornosophical philotheology. Metaphysics in <Annotation annotationId="150005nighttown">Mecklenburgh street</Annotation>!
       </p>
       <p>
         STEPHEN
       </p>
       <p>
-        <Annotation annotationId="090005shrewridden" visited={visitedNotes.has("090005shrewridden")} annotationSelect={() => {openNote("090005shrewridden"); addToVisited("090005shrewridden")}} activeAnnotationId={currentNoteId}>We have shrewridden Shakespeare and henpecked Socrates. Even
-        the allwisest Stagyrite was bitted, bridled and mounted</Annotation> by a <Annotation annotationId="090006lightoflove" visited={visitedNotes.has("090006lightoflove")} annotationSelect={() => {openNote("090006lightoflove"); addToVisited("090006lightoflove")}} activeAnnotationId={currentNoteId}>light of
+        <Annotation annotationId="090005shrewridden">We have shrewridden Shakespeare and henpecked Socrates. Even
+        the allwisest Stagyrite was bitted, bridled and mounted</Annotation> by a <Annotation annotationId="090006lightoflove">light of
         love</Annotation>.
         <span data-edition="ed1922" data-page="411"> </span>
       </p>
@@ -264,7 +264,7 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <p>
         Lecherous lynx, to <i>la belle dame sans merci,</i> Georgina
-        Johnson, <Annotation annotationId="010006introibo" visited={visitedNotes.has("010006introibo")} annotationSelect={() => {openNote("010006introibo"); addToVisited("010006introibo")}} activeAnnotationId={currentNoteId}><i>ad deam qui laetificat iuventutem meam.</i></Annotation>
+        Johnson, <Annotation annotationId="010006introibo"><i>ad deam qui laetificat iuventutem meam.</i></Annotation>
       </p>
       <p>
         <i>(Stephen thrusts the ashplant on him and slowly holds out his hands,
@@ -296,9 +296,9 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         cleaves the crowd and lurches towards the tramsiding. On the farther side
         under the railway bridge Bloom appears, flushed, panting, cramming bread
         and chocolate into a sidepocket. From Gillen's hairdresser's window a
-        composite portrait shows him <Annotation annotationId="010093doduty" visited={visitedNotes.has("010093doduty")} annotationSelect={() => {openNote("010093doduty"); addToVisited("010093doduty")}} activeAnnotationId={currentNoteId}>gallant Nelson</Annotation>'s image. A concave mirror</i>
+        composite portrait shows him <Annotation annotationId="010093doduty">gallant Nelson</Annotation>'s image. A concave mirror</i>
         <span data-edition="ed1922" data-page="412"> </span>
-        <i>at the side presents to him lovelorn</i> <span data-edition="ed1961" data-page="433"> </span><i>longlost lugubru Booloohoom. <Annotation annotationId="010141blamehistory" visited={visitedNotes.has("010141blamehistory")} annotationSelect={() => {openNote("010141blamehistory"); addToVisited("010141blamehistory")}} activeAnnotationId={currentNoteId}>Grave
+        <i>at the side presents to him lovelorn</i> <span data-edition="ed1961" data-page="433"> </span><i>longlost lugubru Booloohoom. <Annotation annotationId="010141blamehistory">Grave
         Gladstone</Annotation> sees him level, Bloom for Bloom. He passes, struck by the
         stare of truculent Wellington, but in the convex mirror grin unstruck
         the bonham eyes and fatchuck cheekchops of Jollypoldy the rixdix doldy.</i>
@@ -416,9 +416,9 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       <br/>
       <p>
         No thoroughfare. Close
-        shave that but cured the stitch. Must take up <Annotation annotationId="040024sandow" visited={visitedNotes.has("040024sandow")} annotationSelect={() => {openNote("040024sandow"); addToVisited("040024sandow")}} activeAnnotationId={currentNoteId}>Sandow's exercises</Annotation> again.
+        shave that but cured the stitch. Must take up <Annotation annotationId="040024sandow">Sandow's exercises</Annotation> again.
         On the hands down. Insure against street accident too. The Providential.
-        <i>(He feels his trouser pocket.)</i> <Annotation annotationId="040047potato" visited={visitedNotes.has("040047potato")} annotationSelect={() => {openNote("040047potato"); addToVisited("040047potato")}} activeAnnotationId={currentNoteId}>Poor mamma's panacea.</Annotation> Heel easily 
+        <i>(He feels his trouser pocket.)</i> <Annotation annotationId="040047potato">Poor mamma's panacea.</Annotation> Heel easily 
         <span data-edition="ed1939" data-page="312"> </span>
         catch in track or bootlace in a cog. Day the wheel of the black Maria peeled
         off my shoe at Leonard's corner. Third time is the charm. Shoe <span data-edition="ed1961" data-page="435"> </span>trick.
@@ -603,7 +603,7 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         <span data-edition="ed1939" data-page="314"> </span>
         <i>and cries out in shrill alarm.)</i> O blessed Redeemer, what have they done
         to him! My smelling salts! <i>(She hauls up a reef of skirt and ransacks
-        the pouch of her striped blay petticoat. A phial, an Agnus Dei, <Annotation annotationId="040047potato" visited={visitedNotes.has("040047potato")} annotationSelect={() => {openNote("040047potato"); addToVisited("040047potato")}} activeAnnotationId={currentNoteId}>a
+        the pouch of her striped blay petticoat. A phial, an Agnus Dei, <Annotation annotationId="040047potato">a
         shrivelled potato</Annotation> and a celluloid doll fall out.)</i> Sacred Heart of Mary,
         where were you at all, at all?
       </p>
@@ -884,7 +884,7 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       <p>
         <i>(Looks behind.)</i> She often said she'd like to visit. Slumming.
         The exotic, you see. Negro servants too in livery if she had money.
-        Othello black brute. <Annotation annotationId="060003eugenestratton" visited={visitedNotes.has("060003eugenestratton")} annotationSelect={() => {openNote("060003eugenestratton"); addToVisited("060003eugenestratton")}} activeAnnotationId={currentNoteId}>Eugene Stratton</Annotation>. Even the bones and cornerman at
+        Othello black brute. <Annotation annotationId="060003eugenestratton">Eugene Stratton</Annotation>. Even the bones and cornerman at
         the Livermore christies. Bohee brothers. Sweep for that matter.
       </p>
       <p>
@@ -948,7 +948,7 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       <p>
         <i>(Seizes her wrist with his free hand.)</i> Josie Powell that was,
         prettiest deb in Dublin. How time flies by! Do you remember, harking
-        back in <Annotation annotationId="060030retrospective" visited={visitedNotes.has("060030retrospective")} annotationSelect={() => {openNote("060030retrospective"); addToVisited("060030retrospective")}} activeAnnotationId={currentNoteId}>a retrospective arrangement</Annotation>, <Annotation annotationId="150001oldchristmas" visited={visitedNotes.has("150001oldchristmas")} annotationSelect={() => {openNote("150001oldchristmas"); addToVisited("150001oldchristmas")}} activeAnnotationId={currentNoteId}>Old Christmas</Annotation> night, Georgina
+        back in <Annotation annotationId="060030retrospective">a retrospective arrangement</Annotation>, <Annotation annotationId="150001oldchristmas">Old Christmas</Annotation> night, Georgina
         Simpson's housewarming while they were playing the Irving Bishop game,
         finding the pin blindfold and thoughtreading? Subject, what is in this
         snuffbox?
@@ -977,7 +977,7 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         MRS BREEN
       </p>
       <p>
-        <Annotation annotationId="040035oldsweetsong" visited={visitedNotes.has("040035oldsweetsong")} annotationSelect={() => {openNote("040035oldsweetsong"); addToVisited("040035oldsweetsong")}} activeAnnotationId={currentNoteId}>The dear dead days beyond recall. Love's old sweet song.</Annotation>
+        <Annotation annotationId="040035oldsweetsong">The dear dead days beyond recall. Love's old sweet song.</Annotation>
       </p>
       <p>
         BLOOM
@@ -1001,11 +1001,11 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         BLOOM
       </p>
       <p>
-        <i>(Wearing a <Annotation annotationId="020080mauve" visited={visitedNotes.has("020080mauve")} annotationSelect={() => {openNote("020080mauve"); addToVisited("020080mauve")}} activeAnnotationId={currentNoteId}>purple Napoleon hat</Annotation> with an amber halfmoon, his
+        <i>(Wearing a <Annotation annotationId="020080mauve">purple Napoleon hat</Annotation> with an amber halfmoon, his
         fingers and thumb passing slowly down to her soft moist meaty palm which
         she surrenders gently.)</i> The witching hour of night. I took the splinter
         out of this hand, carefully, slowly. <i>(Tenderly, as he slips on her
-        finger <Annotation annotationId="040021ruby" visited={visitedNotes.has("040021ruby")} annotationSelect={() => {openNote("040021ruby"); addToVisited("040021ruby")}} activeAnnotationId={currentNoteId}>a ruby ring</Annotation>.)</i> <i><Annotation annotationId="040025lacidarem" visited={visitedNotes.has("040025lacidarem")} annotationSelect={() => {openNote("040025lacidarem"); addToVisited("040025lacidarem")}} activeAnnotationId={currentNoteId}>Là ci darem la mano.</Annotation></i>
+        finger <Annotation annotationId="040021ruby">a ruby ring</Annotation>.)</i> <i><Annotation annotationId="040025lacidarem">Là ci darem la mano.</Annotation></i>
       </p>
       <p>
         MRS BREEN
@@ -1039,7 +1039,7 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         ALF BERGAN
       </p>
       <p>
-        <i>(Points jeering at the sandwich boards.)</i> <Annotation annotationId="080010upup" visited={visitedNotes.has("080010upup")} annotationSelect={() => {openNote("080010upup"); addToVisited("080010upup")}} activeAnnotationId={currentNoteId}>U. p.: Up.</Annotation>
+        <i>(Points jeering at the sandwich boards.)</i> <Annotation annotationId="080010upup">U. p.: Up.</Annotation>
       </p>
       <p>
         MRS BREEN
@@ -1068,14 +1068,14 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <p>
         <i>(Offhandedly.)</i> Kosher. A snack for supper. The home without
-        potted meat is incomplete. <Annotation annotationId="050032leah" visited={visitedNotes.has("050032leah")} annotationSelect={() => {openNote("050032leah"); addToVisited("050032leah")}} activeAnnotationId={currentNoteId}>I was at <i>Leah.</i> Mrs Bandmann Palmer.</Annotation>
+        potted meat is incomplete. <Annotation annotationId="050032leah">I was at <i>Leah.</i> Mrs Bandmann Palmer.</Annotation>
         Trenchant exponent of Shakespeare. Unfortunately threw away the
         programme. Rattling good place round there for pigs' feet. Feel.
       </p>
       <span data-edition="ed1986" data-page="364"> </span>
       <p>
         <i>(Richie Goulding, three ladies' hats pinned on his head, appears
-        weighted to one side by the <Annotation annotationId="030113richiegoulding" visited={visitedNotes.has("030113richiegoulding")} annotationSelect={() => {openNote("030113richiegoulding"); addToVisited("030113richiegoulding")}} activeAnnotationId={currentNoteId}>black legal bag of Collis and Ward</Annotation> on which
+        weighted to one side by the <Annotation annotationId="030113richiegoulding">black legal bag of Collis and Ward</Annotation> on which
         a skull and crossbones are painted in</i> <span data-edition="ed1961" data-page="446"> </span><i>white limewash. He opens it
         and shows it full of polonies, kippered herrings, Findon haddies and
         tightpacked pills.)</i>
@@ -1084,7 +1084,7 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         RICHIE
       </p>
       <p>
-        <Annotation annotationId="110001bestvalue" visited={visitedNotes.has("110001bestvalue")} annotationSelect={() => {openNote("110001bestvalue"); addToVisited("110001bestvalue")}} activeAnnotationId={currentNoteId}>Best value in Dub.</Annotation>
+        <Annotation annotationId="110001bestvalue">Best value in Dub.</Annotation>
       </p>
       <p>
         <i>(Bald Pat, bothered beetle, stands on the curbstone, folding his
@@ -1112,7 +1112,7 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         RICHIE
       </p>
       <p>
-        <i>(With a cry of pain, his hand to his back.)</i> Ah! <Annotation annotationId="030076backachepills" visited={visitedNotes.has("030076backachepills")} annotationSelect={() => {openNote("030076backachepills"); addToVisited("030076backachepills")}} activeAnnotationId={currentNoteId}>Bright's!</Annotation>
+        <i>(With a cry of pain, his hand to his back.)</i> Ah! <Annotation annotationId="030076backachepills">Bright's!</Annotation>
         Lights!
       </p>
       <p>
@@ -1176,7 +1176,7 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         tony buff shirt, shepherd's plaid Saint Andrew's cross scarftie, white
         spats, fawn dustcoat on his</i> 
         <span data-edition="ed1922" data-page="425"> </span>
-        <i>arm, tawny red <Annotation annotationId="020076brogues" visited={visitedNotes.has("020076brogues")} annotationSelect={() => {openNote("020076brogues"); addToVisited("020076brogues")}} activeAnnotationId={currentNoteId}>brogues</Annotation>, fieldglasses in
+        <i>arm, tawny red <Annotation annotationId="020076brogues">brogues</Annotation>, fieldglasses in
         bandolier and a grey billycock hat.)</i> Do you remember a long long time,
         years and years ago, just after Milly, Marionette we called her, was
         weaned when we all went together to Fairyhouse races, was it?
@@ -1211,7 +1211,7 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <p>
         Because it didn't suit you one quarter as well as the other ducky
-        little tammy toque <Annotation annotationId="010075featherfans" visited={visitedNotes.has("010075featherfans")} annotationSelect={() => {openNote("010075featherfans"); addToVisited("010075featherfans")}} activeAnnotationId={currentNoteId}>with the bird of paradise wing in it</Annotation> that I admired
+        little tammy toque <Annotation annotationId="010075featherfans">with the bird of paradise wing in it</Annotation> that I admired
         on you and you honestly looked just too fetching in it though it was a
         pity to kill it, you cruel naughty creature, little mite of a thing with
         a heart the size of a fullstop.
@@ -1243,9 +1243,9 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         BLOOM
       </p>
       <p>
-        Yes. And Molly was laughing <Annotation annotationId="170008precedingseries" visited={visitedNotes.has("170008precedingseries")} annotationSelect={() => {openNote("170008precedingseries"); addToVisited("170008precedingseries")}} activeAnnotationId={currentNoteId}>because Rogers and Maggot O'Reilly were</Annotation> 
+        Yes. And Molly was laughing <Annotation annotationId="170008precedingseries">because Rogers and Maggot O'Reilly were</Annotation> 
         <span data-edition="ed1922" data-page="426"> </span>
-        <Annotation annotationId="170008precedingseries" visited={visitedNotes.has("170008precedingseries")} annotationSelect={() => {openNote("170008precedingseries"); addToVisited("170008precedingseries")}} activeAnnotationId={currentNoteId}>mimicking a cock</Annotation> as we passed a farmhouse and Marcus Tertius Moses,
+        <Annotation annotationId="170008precedingseries">mimicking a cock</Annotation> as we passed a farmhouse and Marcus Tertius Moses,
         the tea merchant, drove past us in a gig with his daughter, Dancer Moses
         was her name, and the poodle in her lap bridled up and you asked me if I
         ever heard or read or knew or came across...
@@ -1254,12 +1254,12 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         MRS BREEN
       </p>
       <p>
-        <i>(Eagerly.)</i> <Annotation annotationId="180005yesyes" visited={visitedNotes.has("180005yesyes")} annotationSelect={() => {openNote("180005yesyes"); addToVisited("180005yesyes")}} activeAnnotationId={currentNoteId}>Yes, yes, yes, yes, yes, yes, yes.</Annotation>
+        <i>(Eagerly.)</i> <Annotation annotationId="180005yesyes">Yes, yes, yes, yes, yes, yes, yes.</Annotation>
       </p>
       <p>
         <i>(She fades from his side. Followed by the whining dog he walks on
-        towards hellsgates. In <Annotation annotationId="030024archway" visited={visitedNotes.has("030024archway")} annotationSelect={() => {openNote("030024archway"); addToVisited("030024archway")}} activeAnnotationId={currentNoteId}>an archway</Annotation> a standing</i> <span data-edition="ed1961" data-page="449"> </span><i>woman, bent forward, her
-        feet apart, <Annotation annotationId="010086maryann" visited={visitedNotes.has("010086maryann")} annotationSelect={() => {openNote("010086maryann"); addToVisited("010086maryann")}} activeAnnotationId={currentNoteId}>pisses cowily</Annotation>. Outside a shuttered pub a bunch of loiterers
+        towards hellsgates. In <Annotation annotationId="030024archway">an archway</Annotation> a standing</i> <span data-edition="ed1961" data-page="449"> </span><i>woman, bent forward, her
+        feet apart, <Annotation annotationId="010086maryann">pisses cowily</Annotation>. Outside a shuttered pub a bunch of loiterers
         listen to a tale which their brokensnouted gaffer rasps out with raucous
         humour. An armless pair of them flop wrestling, growling, in maimed
         sodden playfight.)</i>
@@ -1270,7 +1270,7 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       <p>
         <i>(Crouches, his voice twisted in his snout.)</i> And when Cairns
         came down from the scaffolding in Beaver street what was he after doing
-        it into only <Annotation annotationId="170005dustbuckets" visited={visitedNotes.has("170005dustbuckets")} annotationSelect={() => {openNote("170005dustbuckets"); addToVisited("170005dustbuckets")}} activeAnnotationId={currentNoteId}>into the bucket of porter</Annotation> that was there waiting on the
+        it into only <Annotation annotationId="170005dustbuckets">into the bucket of porter</Annotation> that was there waiting on the
         shavings for Derwan's plasterers.
       </p>
       <p>
@@ -1357,7 +1357,7 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         PRIVATE CARR
       </p>
       <p>
-        <i>(To the navvy.)</i> <Annotation annotationId="010013barracks" visited={visitedNotes.has("010013barracks")} annotationSelect={() => {openNote("010013barracks"); addToVisited("010013barracks")}} activeAnnotationId={currentNoteId}>Portobello barracks</Annotation> canteen. You ask for
+        <i>(To the navvy.)</i> <Annotation annotationId="010013barracks">Portobello barracks</Annotation> canteen. You ask for
         Carr. Just Carr.
       </p>
       <p>
@@ -1405,7 +1405,7 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         Wildgoose chase this. Disorderly houses. Lord knows where they
         are gone. Drunks cover distance double quick. Nice mixup. Scene at
         Westland row. Then jump in first class with third ticket. Then too far.
-        Train with engine behind. <Annotation annotationId="030150malahide" visited={visitedNotes.has("030150malahide")} annotationSelect={() => {openNote("030150malahide"); addToVisited("030150malahide")}} activeAnnotationId={currentNoteId}>Might have taken me to Malahide or a siding
+        Train with engine behind. <Annotation annotationId="030150malahide">Might have taken me to Malahide or a siding
         for the night</Annotation> or collision. Second drink does it. Once is a dose. What
         am I following him for? Still, he's the best of that lot. If I hadn't
         heard about Mrs Beaufoy Purefoy I wouldn't have gone and wouldn't have
@@ -1417,17 +1417,17 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         <span data-edition="ed1939" data-page="323"> </span>
         later would have been shot.
         Absence of body. Still if bullet only went through my coat get damages
-        for shock, five hundred pounds. What was he? <Annotation annotationId="050042kildareclub" visited={visitedNotes.has("050042kildareclub")} annotationSelect={() => {openNote("050042kildareclub"); addToVisited("050042kildareclub")}} activeAnnotationId={currentNoteId}>Kildare street club toff.</Annotation>
+        for shock, five hundred pounds. What was he? <Annotation annotationId="050042kildareclub">Kildare street club toff.</Annotation>
         God help his gamekeeper.
       </p>
       <p style={{marginBottom:"8px"}}>
-        <Annotation annotationId="150016writingonthewall" visited={visitedNotes.has("150016writingonthewall")} annotationSelect={() => {openNote("150016writingonthewall"); addToVisited("150016writingonthewall")}} activeAnnotationId={currentNoteId}><i>(He gazes ahead, reading on the wall a scrawled chalk legend</i> Wet Dream
+        <Annotation annotationId="150016writingonthewall"><i>(He gazes ahead, reading on the wall a scrawled chalk legend</i> Wet Dream
         <i>and a phallic design.</i>)</Annotation> 
       </p>
       <p>
         Odd! Molly drawing on the frosted carriagepane
         at Kingstown. What's that like? <i>(Gaudy dollwomen loll in the lighted
-        doorways, in window embrasures, smoking <Annotation annotationId="100002tobacco" visited={visitedNotes.has("100002tobacco")} annotationSelect={() => {openNote("100002tobacco"); addToVisited("100002tobacco")}} activeAnnotationId={currentNoteId}>birdseye cigarettes</Annotation>. The
+        doorways, in window embrasures, smoking <Annotation annotationId="100002tobacco">birdseye cigarettes</Annotation>. The
         odour of the sicksweet weed floats towards him in slow round ovalling
         wreaths.)</i>
       </p>
@@ -1505,7 +1505,7 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       <span data-edition="ed1939" data-page="324"> </span>
       <span data-edition="ed1961" data-page="453"> </span>
       <p>
-        <i>(He points. <Annotation annotationId="050038bobdoran" visited={visitedNotes.has("050038bobdoran")} annotationSelect={() => {openNote("050038bobdoran"); addToVisited("050038bobdoran")}} activeAnnotationId={currentNoteId}>Bob Doran, toppling from a high barstool</Annotation>, sways over the
+        <i>(He points. <Annotation annotationId="050038bobdoran">Bob Doran, toppling from a high barstool</Annotation>, sways over the
         munching spaniel.)</i>
       </p>
       <span data-edition="ed1922" data-page="430"> </span>
@@ -1537,7 +1537,7 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         tram. All tales of circus life are highly demoralising.
       </p>
       <p>
-        <i>(<Annotation annotationId="040021ruby" visited={visitedNotes.has("040021ruby")} annotationSelect={() => {openNote("040021ruby"); addToVisited("040021ruby")}} activeAnnotationId={currentNoteId}>Signor Maffei</Annotation>, passionpale, in liontamer's costume with diamond studs
+        <i>(<Annotation annotationId="040021ruby">Signor Maffei</Annotation>, passionpale, in liontamer's costume with diamond studs
         in his shirtfront, steps forward, holding a circus paperhoop, a
         curling carriagewhip and a revolver with which he covers the gorging
         boarhound.)</i>
@@ -1631,14 +1631,14 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         THE DARK MERCURY
       </p>
       <p>
-        <Annotation annotationId="080013dublincastle" visited={visitedNotes.has("080013dublincastle")} annotationSelect={() => {openNote("080013dublincastle"); addToVisited("080013dublincastle")}} activeAnnotationId={currentNoteId}>The Castle is looking for him.</Annotation> He was drummed out of
+        <Annotation annotationId="080013dublincastle">The Castle is looking for him.</Annotation> He was drummed out of
         the army.
       </p>
       <p>
         MARTHA
       </p>
       <p>
-        <i>(Thickveiled, a crimson halter round her neck, a copy of the </i><Annotation annotationId="080012irishtimes" visited={visitedNotes.has("080012irishtimes")} annotationSelect={() => {openNote("080012irishtimes"); addToVisited("080012irishtimes")}} activeAnnotationId={currentNoteId}>Irish Times</Annotation><i> in her hand, in tone of reproach, pointing.)</i> Henry!
+        <i>(Thickveiled, a crimson halter round her neck, a copy of the </i><Annotation annotationId="080012irishtimes">Irish Times</Annotation><i> in her hand, in tone of reproach, pointing.)</i> Henry!
         Leopold! Lionel, thou lost one! Clear my name.
       </p>
       <span data-edition="ed1922" data-page="432"> </span>
@@ -1654,7 +1654,7 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       <p>
         <i>(Scared, hats himself, steps back, then, plucking at his heart
         and lifting his right forearm on the square, he gives the sign and
-        dueguard of fellowcraft.)</i> No, no, worshipful master, <Annotation annotationId="090006lightoflove" visited={visitedNotes.has("090006lightoflove")} annotationSelect={() => {openNote("090006lightoflove"); addToVisited("090006lightoflove")}} activeAnnotationId={currentNoteId}>light of love</Annotation>. <Annotation annotationId="150017mistakenidentity" visited={visitedNotes.has("150017mistakenidentity")} annotationSelect={() => {openNote("150017mistakenidentity"); addToVisited("150017mistakenidentity")}} activeAnnotationId={currentNoteId}>Mistaken identity. The Lyons mail. Lesurques and Dubosc.</Annotation> You remember
+        dueguard of fellowcraft.)</i> No, no, worshipful master, <Annotation annotationId="090006lightoflove">light of love</Annotation>. <Annotation annotationId="150017mistakenidentity">Mistaken identity. The Lyons mail. Lesurques and Dubosc.</Annotation> You remember
         the Childs fratricide case. We medical men. By striking him dead with
         a hatchet. I am wrongfully accused. Better one guilty escape than
         ninetynine wrongfully condemned.
@@ -1691,7 +1691,7 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         a man misunderstood. I am being made a scapegoat of. I am a respectable
         married man, without a stain on my character. I live in Eccles street.
         <span data-edition="ed1932" data-page="408"> </span>My wife, I am the daughter of a most distinguished commander, a gallant
-        upstanding gentleman, what do you call him, <Annotation annotationId="040018oldtweedy" visited={visitedNotes.has("040018oldtweedy")} annotationSelect={() => {openNote("040018oldtweedy"); addToVisited("040018oldtweedy")}} activeAnnotationId={currentNoteId}>Majorgeneral Brian Tweedy</Annotation>,
+        upstanding gentleman, what do you call him, <Annotation annotationId="040018oldtweedy">Majorgeneral Brian Tweedy</Annotation>,
         one of Britain's fighting men who helped to win our battles. Got his
         majority for the heroic defence of Rorke's Drift.
       </p>
@@ -1705,19 +1705,19 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         BLOOM
       </p>
       <p>
-        <i>(Turns to the gallery.)</i> <Annotation annotationId="030118royaldublins" visited={visitedNotes.has("030118royaldublins")} annotationSelect={() => {openNote("030118royaldublins"); addToVisited("030118royaldublins")}} activeAnnotationId={currentNoteId}>The royal Dublins</Annotation>, boys, the salt of the
+        <i>(Turns to the gallery.)</i> <Annotation annotationId="030118royaldublins">The royal Dublins</Annotation>, boys, the salt of the
         earth, known the world over. I think I see some old comrades in arms
         up there 
         <span data-edition="ed1922" data-page="433"> </span>
         among you. The R. D. F., with our own Metropolitan police,
         guardians of our homes, the pluckiest lads and the finest body of men,
-        <Annotation annotationId="040084sizeable" visited={visitedNotes.has("040084sizeable")} annotationSelect={() => {openNote("040084sizeable"); addToVisited("040084sizeable")}} activeAnnotationId={currentNoteId}>as physique</Annotation>, in the service of our sovereign.
+        <Annotation annotationId="040084sizeable">as physique</Annotation>, in the service of our sovereign.
       </p>
       <p>
         A VOICE
       </p>
       <p>
-        <Annotation annotationId="080021joechamberlain" visited={visitedNotes.has("080021joechamberlain")} annotationSelect={() => {openNote("080021joechamberlain"); addToVisited("080021joechamberlain")}} activeAnnotationId={currentNoteId}>Turncoat! Up the Boers! Who booed Joe Chamberlain?</Annotation>
+        <Annotation annotationId="080021joechamberlain">Turncoat! Up the Boers! Who booed Joe Chamberlain?</Annotation>
       </p>
       <p>
         BLOOM
@@ -1725,7 +1725,7 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       <p>
         <i>(His hand on the shoulder of the first watch.)</i> My old dad too
         was a J. P. I'm as staunch a Britisher as you are, sir. I fought with
-        the colours for king and country in <Annotation annotationId="090001absentminded" visited={visitedNotes.has("090001absentminded")} annotationSelect={() => {openNote("090001absentminded"); addToVisited("090001absentminded")}} activeAnnotationId={currentNoteId}>the absentminded war</Annotation> under general
+        the colours for king and country in <Annotation annotationId="090001absentminded">the absentminded war</Annotation> under general
         Gough in the park and was disabled at <span data-edition="ed1961" data-page="457"> </span>Spion Kop and Bloemfontein, was
         mentioned in dispatches. I did all a white man could. <i>(With quiet
         feeling.)</i> Jim Bludso. Hold her nozzle again the bank.
@@ -1762,12 +1762,12 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <span data-edition="ed1932" data-page="409"> </span>
       <p>
-        <i>(Mr Philip Beaufoy, <Annotation annotationId="010024stranger" visited={visitedNotes.has("010024stranger")} annotationSelect={() => {openNote("010024stranger"); addToVisited("010024stranger")}} activeAnnotationId={currentNoteId}>palefaced</Annotation>, stands in the witnessbox, in accurate
+        <i>(Mr Philip Beaufoy, <Annotation annotationId="010024stranger">palefaced</Annotation>, stands in the witnessbox, in accurate
         morning dress, outbreast pocket with peak of handkerchief showing,
         creased lavender </i>
         <span data-edition="ed1939" data-page="327"> </span>
         <i>trousers and patent boots. He carries a large portfolio
-        labelled</i> <Annotation annotationId="040065matcham" visited={visitedNotes.has("040065matcham")} annotationSelect={() => {openNote("040065matcham"); addToVisited("040065matcham")}} activeAnnotationId={currentNoteId}>Matcham's Masterstrokes</Annotation>.)
+        labelled</i> <Annotation annotationId="040065matcham">Matcham's Masterstrokes</Annotation>.)
       </p>
       <span data-edition="ed1922" data-page="434"> </span>
       <p>
@@ -1777,7 +1777,7 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         <i>(Drawls.)</i> No, you aren't. Not by a long shot if I know it.
         I don't see it that's all. No born gentleman, no-one with the most
         rudimentary promptings of a gentleman would stoop to such particularly
-        loathsome conduct. One of those, my lord.<Annotation annotationId="040019titbits" visited={visitedNotes.has("040019titbits")} annotationSelect={() => {openNote("040019titbits"); addToVisited("040019titbits")}} activeAnnotationId={currentNoteId}> A plagiarist.</Annotation> A soapy sneak
+        loathsome conduct. One of those, my lord.<Annotation annotationId="040019titbits"> A plagiarist.</Annotation> A soapy sneak
         masquerading as a litterateur. It's perfectly obvious that with the most
         inherent baseness he has cribbed some of my bestselling copy, really
         gorgeous stuff, a <span data-edition="ed1961" data-page="458"> </span>perfect gem, the love passages in which are beneath
@@ -1824,7 +1824,7 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         A VOICE FROM THE GALLERY
       </p>
       <p>
-        <Annotation annotationId="040050ikeymo" visited={visitedNotes.has("040050ikeymo")} annotationSelect={() => {openNote("040050ikeymo"); addToVisited("040050ikeymo")}} activeAnnotationId={currentNoteId}>Moses, Moses, king of the jews,</Annotation> <br/>
+        <Annotation annotationId="040050ikeymo">Moses, Moses, king of the jews,</Annotation> <br/>
         Wiped his arse in the <i>Daily News.</i>
       </p>
       <span data-edition="ed1932" data-page="410"> </span>
@@ -2012,7 +2012,7 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         A plasterer's bucket. By walking stifflegged. Suffered untold misery.
         Deadly agony. About noon. Love or burgundy. Yes, some spinach. Crucial
         moment. He did not look in the bucket. Nobody. Rather a mess. Not
-        completely.</i> <Annotation annotationId="040019titbits" visited={visitedNotes.has("040019titbits")} annotationSelect={() => {openNote("040019titbits"); addToVisited("040019titbits")}} activeAnnotationId={currentNoteId}>A Titbits <i>back number</i>.</Annotation>)
+        completely.</i> <Annotation annotationId="040019titbits">A Titbits <i>back number</i>.</Annotation>)
       </p>
       <span data-edition="ed1961" data-page="462"> </span>
       <p>
@@ -2085,7 +2085,7 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         or cast a stone at a girl who took the wrong turning when some dastard,
         responsible for her condition, had worked his own sweet will on her. He
         wants to go straight. I regard him as the whitest man I know. He is down
-        on his luck at present owing to the mortgaging of his extensive <Annotation annotationId="040061agendath" visited={visitedNotes.has("040061agendath")} annotationSelect={() => {openNote("040061agendath"); addToVisited("040061agendath")}} activeAnnotationId={currentNoteId}>property
+        on his luck at present owing to the mortgaging of his extensive <Annotation annotationId="040061agendath">property
         at Agendath Netaim in faraway Asia Minor</Annotation>, slides of which will now be
         shown. <i>(To Bloom.)</i> I suggest that you will do the handsome thing.
       </p>
@@ -2099,7 +2099,7 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <p>
         <i>(The image of the lake of Kinnereth with blurred cattle cropping in
-        silver haze is projected on the wall. <Annotation annotationId="040060dlugacz" visited={visitedNotes.has("040060dlugacz")} annotationSelect={() => {openNote("040060dlugacz"); addToVisited("040060dlugacz")}} activeAnnotationId={currentNoteId}>Moses Dlugacz, ferreteyed</Annotation> albino,
+        silver haze is projected on the wall. <Annotation annotationId="040060dlugacz">Moses Dlugacz, ferreteyed</Annotation> albino,
         in blue dungarees, stands up in the gallery, holding in each hand an
         orange citron and a pork kidney.)</i>
       </p>
@@ -2107,7 +2107,7 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         DLUGACZ
       </p>
       <p>
-        <i>(Hoarsely.)</i> <Annotation annotationId="040064bleibtreustrasse" visited={visitedNotes.has("040064bleibtreustrasse")} annotationSelect={() => {openNote("040064bleibtreustrasse"); addToVisited("040064bleibtreustrasse")}} activeAnnotationId={currentNoteId}>Bleibtreustrasse, Berlin, W.13.</Annotation>
+        <i>(Hoarsely.)</i> <Annotation annotationId="040064bleibtreustrasse">Bleibtreustrasse, Berlin, W.13.</Annotation>
       </p>
       <p>
         <i>(J. J. O'Molloy steps on to a low plinth and holds the lapel of his
@@ -2151,11 +2151,11 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         brilliants and panache of osprey in her hair.)</i> Arrest him, constable. He
         wrote me an anonymous letter in prentice backhand when my husband was
         in the North Riding of Tipperary on the Munster circuit, signed James
-        Lovebirch. He said that <Annotation annotationId="110005theatreroyal" visited={visitedNotes.has("110005theatreroyal")} annotationSelect={() => {openNote("110005theatreroyal"); addToVisited("110005theatreroyal")}} activeAnnotationId={currentNoteId}> he had seen from the gods my peerless globes as
+        Lovebirch. He said that <Annotation annotationId="110005theatreroyal"> he had seen from the gods my peerless globes as
         I sat in a box of the <i>Theatre Royal</i> at a command performance</Annotation> of <i>La
         Cigale</i>. I deeply inflamed him, he said. He made improper overtures
         to me to misconduct myself at half past <span data-edition="ed1986" data-page="379"> </span>four p.m. on the following
-        Thursday, Dunsink time. He offered to send me through the post <Annotation annotationId="040003nicename" visited={visitedNotes.has("040003nicename")} annotationSelect={() => {openNote("040003nicename"); addToVisited("040003nicename")}} activeAnnotationId={currentNoteId}>a work
+        Thursday, Dunsink time. He offered to send me through the post <Annotation annotationId="040003nicename">a work
         of fiction by Monsieur Paul de Kock, entitled <i>The Girl with the Three
         Pairs of Stays</i></Annotation>.
       </p>
@@ -2173,7 +2173,7 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         he enclosed a bloom of edelweiss 
         <span data-edition="ed1939" data-page="332"> </span>
         culled on the heights, as he said,
-        in my honour. <Annotation annotationId="050025botanicgardens" visited={visitedNotes.has("050025botanicgardens")} annotationSelect={() => {openNote("050025botanicgardens"); addToVisited("050025botanicgardens")}} activeAnnotationId={currentNoteId}>I had it examined by a botanical expert</Annotation> and
+        in my honour. <Annotation annotationId="050025botanicgardens">I had it examined by a botanical expert</Annotation> and
         <span data-edition="ed1932" data-page="415"> </span>elicited the
         information that it was a blossom of the homegrown potato plant purloined
         from a forcingcase of the model farm.
@@ -2192,7 +2192,7 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <p>
         <i>(Screaming.)</i> Stop thief! Hurrah there,
-        Bluebeard! Three cheers for <Annotation annotationId="040050ikeymo" visited={visitedNotes.has("040050ikeymo")} annotationSelect={() => {openNote("040050ikeymo"); addToVisited("040050ikeymo")}} activeAnnotationId={currentNoteId}>Ikey Mo</Annotation>!
+        Bluebeard! Three cheers for <Annotation annotationId="040050ikeymo">Ikey Mo</Annotation>!
       </p>
       <p>
         SECOND WATCH
@@ -2221,25 +2221,25 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <span data-edition="ed1986" data-page="380"> </span><span data-edition="ed1961" data-page="466"> </span>
       <p>
-        <Annotation annotationId="050043horseywomen" visited={visitedNotes.has("050043horseywomen")} annotationSelect={() => {openNote("050043horseywomen"); addToVisited("050043horseywomen")}} activeAnnotationId={currentNoteId}>THE HONOURABLE MRS MERVYN TALBOYS</Annotation>
+        <Annotation annotationId="050043horseywomen">THE HONOURABLE MRS MERVYN TALBOYS</Annotation>
       </p>
       <p>
-        <Annotation annotationId="050043horseywomen" visited={visitedNotes.has("050043horseywomen")} annotationSelect={() => {openNote("050043horseywomen"); addToVisited("050043horseywomen")}} activeAnnotationId={currentNoteId}><i>(In amazon costume, hard hat,
+        <Annotation annotationId="050043horseywomen"><i>(In amazon costume, hard hat,
         jackboots cockspurred, vermilion waistcoat, fawn musketeer gauntlets
         with braided drums, long train held up and hunting crop with which she
         strikes her welt constantly.)</i> Also me. Because he saw me on the polo
         ground of the Phoenix park at the match All Ireland versus the Rest of
         Ireland.</Annotation> My eyes, I know, shone divinely as I watched Captain Slogger
         Dennehy of the Inniskillings win the final chukkar on his darling cob
-        <i>Centaur.</i> This plebeian Don Juan observed me from behind a <Annotation annotationId="050013jauntingcar" visited={visitedNotes.has("050013jauntingcar")} annotationSelect={() => {openNote("050013jauntingcar"); addToVisited("050013jauntingcar")}} activeAnnotationId={currentNoteId}>hackney car</Annotation>
-        and sent me in double envelopes an <Annotation annotationId="010127photogirl" visited={visitedNotes.has("010127photogirl")} annotationSelect={() => {openNote("010127photogirl"); addToVisited("010127photogirl")}} activeAnnotationId={currentNoteId}>obscene photograph</Annotation>, such as are sold
+        <i>Centaur.</i> This plebeian Don Juan observed me from behind a <Annotation annotationId="050013jauntingcar">hackney car</Annotation>
+        and sent me in double envelopes an <Annotation annotationId="010127photogirl">obscene photograph</Annotation>, such as are sold
         after dark on Paris boulevards, insulting to any lady. I have it still.
         It represents a partially nude señorita, frail and lovely (his wife, as
         he solemnly assured me, taken by him from nature), practising illicit
         intercourse with a muscular torero, evidently a blackguard. He urged me
         to do likewise, to misbehave, to sin with officers of<span data-edition="ed1932" data-page="416"> </span> the garrison. He
         implored me to soil his letter in an unspeakable manner, to chastise
-        him as he richly deserves, <Annotation annotationId="050043horseywomen" visited={visitedNotes.has("050043horseywomen")} annotationSelect={() => {openNote("050043horseywomen"); addToVisited("050043horseywomen")}} activeAnnotationId={currentNoteId}>to bestride and ride him, to give him a most
+        him as he richly deserves, <Annotation annotationId="050043horseywomen">to bestride and ride him, to give him a most
         vicious horsewhipping</Annotation>.
       </p>
       <p>
@@ -2362,21 +2362,21 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         <i>(Trembling, beginning to obey.)</i> The weather has been so warm.
       </p>
       <p>
-        <i>(<Annotation annotationId="070013davystephens" visited={visitedNotes.has("070013davystephens")} annotationSelect={() => {openNote("070013davystephens"); addToVisited("070013davystephens")}} activeAnnotationId={currentNoteId}>Davy Stephens, ringletted, passes with a bevy of barefoot newsboys.</Annotation>)</i>
+        <i>(<Annotation annotationId="070013davystephens">Davy Stephens, ringletted, passes with a bevy of barefoot newsboys.</Annotation>)</i>
       </p>
       <span data-edition="ed1986" data-page="382"> </span>
       <p>
         DAVY STEPHENS
       </p>
       <p>
-        <i>Messenger of the Sacred Heart</i> and <i><Annotation annotationId="020064telegraph" visited={visitedNotes.has("020064telegraph")} annotationSelect={() => {openNote("020064telegraph"); addToVisited("020064telegraph")}} activeAnnotationId={currentNoteId}>Evening Telegraph</Annotation></i>
+        <i>Messenger of the Sacred Heart</i> and <i><Annotation annotationId="020064telegraph">Evening Telegraph</Annotation></i>
         with Saint Patrick's Day supplement. Containing the new addresses of all
         the cuckolds in Dublin.
       </p>
       <p>
         <i>(The very reverend Canon O'Hanlon in cloth of gold cope elevates and
         exposes a marble timepiece. Before him Father Conroy and the reverend
-        John Hughes <Annotation annotationId="010008jesuit" visited={visitedNotes.has("010008jesuit")} annotationSelect={() => {openNote("010008jesuit"); addToVisited("010008jesuit")}} activeAnnotationId={currentNoteId}>S.J.</Annotation> bend low.)</i>
+        John Hughes <Annotation annotationId="010008jesuit">S.J.</Annotation> bend low.)</i>
       </p>
       <p>
         THE TIMEPIECE
@@ -2384,23 +2384,23 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       <p>
         <i>(Unportalling.)</i>
       </p>
-      <p style={{paddingLeft:0, textAlign:"center"}}><Annotation annotationId="130005cuckoo" visited={visitedNotes.has("130005cuckoo")} annotationSelect={() => {openNote("130005cuckoo"); addToVisited("130005cuckoo")}} activeAnnotationId={currentNoteId}>Cuckoo.<br/>
+      <p style={{paddingLeft:0, textAlign:"center"}}><Annotation annotationId="130005cuckoo">Cuckoo.<br/>
         Cuckoo.<br/>Cuckoo.</Annotation>
       </p>
       <p>
-        <i>(The  <Annotation annotationId="040085brassquoits" visited={visitedNotes.has("040085brassquoits")} annotationSelect={() => {openNote("040085brassquoits"); addToVisited("040085brassquoits")}} activeAnnotationId={currentNoteId}>brass quoits</Annotation> of a bed are heard to jingle.)</i>
+        <i>(The  <Annotation annotationId="040085brassquoits">brass quoits</Annotation> of a bed are heard to jingle.)</i>
       </p>
       <p>
         THE QUOITS
       </p>
       <p>
-        <Annotation annotationId="040091jingle" visited={visitedNotes.has("040091jingle")} annotationSelect={() => {openNote("040091jingle"); addToVisited("040091jingle")}} activeAnnotationId={currentNoteId}>Jigjag. Jigajiga. Jigjag.</Annotation>
+        <Annotation annotationId="040091jingle">Jigjag. Jigajiga. Jigjag.</Annotation>
       </p>
       <p>
         <i>(A panel of fog rolls back rapidly, revealing rapidly in the jurybox
-        the faces of <Annotation annotationId="060034martincunningham" visited={visitedNotes.has("060034martincunningham")} annotationSelect={() => {openNote("060034martincunningham"); addToVisited("060034martincunningham")}} activeAnnotationId={currentNoteId}>Martin Cunningham, foreman,</Annotation></i> <span data-edition="ed1961" data-page="469"> </span><i><Annotation annotationId="060034martincunningham" visited={visitedNotes.has("060034martincunningham")} annotationSelect={() => {openNote("060034martincunningham"); addToVisited("060034martincunningham")}} activeAnnotationId={currentNoteId}>silkhatted</Annotation>, Jack Power, Simon
-        Dedalus, <Annotation annotationId="050037tomkernan" visited={visitedNotes.has("050037tomkernan")} annotationSelect={() => {openNote("050037tomkernan"); addToVisited("050037tomkernan")}} activeAnnotationId={currentNoteId}>Tom Kernan</Annotation>, Ned Lambert, John Henry Menton, Myles Crawford,
-        Lenehan, Paddy Leonard, Nosey Flynn, <Annotation annotationId="040079mcoy" visited={visitedNotes.has("040079mcoy")} annotationSelect={() => {openNote("040079mcoy"); addToVisited("040079mcoy")}} activeAnnotationId={currentNoteId}>M'Coy</Annotation> and the featureless face of a
+        the faces of <Annotation annotationId="060034martincunningham">Martin Cunningham, foreman,</Annotation></i> <span data-edition="ed1961" data-page="469"> </span><i><Annotation annotationId="060034martincunningham">silkhatted</Annotation>, Jack Power, Simon
+        Dedalus, <Annotation annotationId="050037tomkernan">Tom Kernan</Annotation>, Ned Lambert, John Henry Menton, Myles Crawford,
+        Lenehan, Paddy Leonard, Nosey Flynn, <Annotation annotationId="040079mcoy">M'Coy</Annotation> and the featureless face of a
         Nameless One.)</i>
       </p>
       <p></p>
@@ -2457,9 +2457,9 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         assizes the most honourable...
       </p>
       <p>
-        <i>His Honour, (<Annotation annotationId="080002sirfrederick" visited={visitedNotes.has("080002sirfrederick")} annotationSelect={() => {openNote("080002sirfrederick"); addToVisited("080002sirfrederick")}} activeAnnotationId={currentNoteId}>sir Frederick Falkiner, recorder of Dublin</Annotation>, in judicial
+        <i>His Honour, (<Annotation annotationId="080002sirfrederick">sir Frederick Falkiner, recorder of Dublin</Annotation>, in judicial
         garb of grey stone rises from the bench, stonebearded. He bears in his
-        arms <Annotation annotationId="080002sirfrederick" visited={visitedNotes.has("080002sirfrederick")} annotationSelect={() => {openNote("080002sirfrederick"); addToVisited("080002sirfrederick")}} activeAnnotationId={currentNoteId}>an umbrella sceptre</Annotation>. From his forehead arise starkly the Mosaic
+        arms <Annotation annotationId="080002sirfrederick">an umbrella sceptre</Annotation>. From his forehead arise starkly the Mosaic
         ramshorns.)</i>
       </p>
       <span data-edition="ed1961" data-page="470"> </span>
@@ -2486,7 +2486,7 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <p>
         <i>(Scowls and calls with rich rolling utterance.)</i>
-        <Annotation annotationId="080002sirfrederick" visited={visitedNotes.has("080002sirfrederick")} annotationSelect={() => {openNote("080002sirfrederick"); addToVisited("080002sirfrederick")}} activeAnnotationId={currentNoteId}>Who'll hang Judas Iscariot?</Annotation>
+        <Annotation annotationId="080002sirfrederick">Who'll hang Judas Iscariot?</Annotation>
       </p>
       <p>
         <i>(H. Rumbold, master barber, in a bloodcoloured jerkin and tanner's
@@ -2505,7 +2505,7 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         nothing.
       </p>
       <p>
-        <i>(<Annotation annotationId="040008georgeschurch" visited={visitedNotes.has("040008georgeschurch")} annotationSelect={() => {openNote("040008georgeschurch"); addToVisited("040008georgeschurch")}} activeAnnotationId={currentNoteId}>The bells of George's church toll slowly, loud dark iron.</Annotation>)</i>
+        <i>(<Annotation annotationId="040008georgeschurch">The bells of George's church toll slowly, loud dark iron.</Annotation>)</i>
       </p>
       <p>
         THE BELLS
@@ -2562,7 +2562,7 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         Dignam. He has gnawed all. He exhales a putrid carcasefed breath.
         He grows to human size and shape. His dachshund coat becomes a brown
         mortuary habit. His green eye flashes bloodshot. Half of one ear, all
-        the nose and both thumbs are <Annotation annotationId="010062ghoul" visited={visitedNotes.has("010062ghoul")} annotationSelect={() => {openNote("010062ghoul"); addToVisited("010062ghoul")}} activeAnnotationId={currentNoteId}>ghouleaten</Annotation>.)</i>
+        the nose and both thumbs are <Annotation annotationId="010062ghoul">ghouleaten</Annotation>.)</i>
       </p>
       <p>
         PADDY DIGNAM
@@ -2611,7 +2611,7 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         PADDY DIGNAM
       </p>
       <p>
-        By <Annotation annotationId="030087pastlife" visited={visitedNotes.has("030087pastlife")} annotationSelect={() => {openNote("030087pastlife"); addToVisited("030087pastlife")}} activeAnnotationId={currentNoteId}>metempsychosis</Annotation>. Spooks.
+        By <Annotation annotationId="030087pastlife">metempsychosis</Annotation>. Spooks.
       </p>
       <p>
         A VOICE
@@ -2665,7 +2665,7 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         JOHN O'CONNELL
       </p>
       <p>
-        <Annotation annotationId="080010upup" visited={visitedNotes.has("080010upup")} annotationSelect={() => {openNote("080010upup"); addToVisited("080010upup")}} activeAnnotationId={currentNoteId}>Burial docket letter number U. P.</Annotation> eightyfive thousand.
+        <Annotation annotationId="080010upup">Burial docket letter number U. P.</Annotation> eightyfive thousand.
         Field seventeen. House of Keys. Plot, one hundred and one.
       </p>
       <span data-edition="ed1986" data-page="386"> </span>
@@ -2683,7 +2683,7 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       <span data-edition="ed1932" data-page="421"> </span>
       <p>
         <i>(He worms down through a coalhole, his brown habit trailing its tether
-        <Annotation annotationId="030038pebbles" visited={visitedNotes.has("030038pebbles")} annotationSelect={() => {openNote("030038pebbles"); addToVisited("030038pebbles")}} activeAnnotationId={currentNoteId}>over rattling pebbles</Annotation>. After him toddles an obese grandfather rat on
+        <Annotation annotationId="030038pebbles">over rattling pebbles</Annotation>. After him toddles an obese grandfather rat on
         fungus turtle paws under a grey carapace. Dignam's voice, muffled, is
         heard baying under ground:</i> Dignam's dead and gone below. <i>Tom Rochford,
         robinredbreasted, in cap and breeches, jumps from his twocolumned
@@ -2748,7 +2748,7 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <p>
         No, eightyone. Mrs Cohen's. You might go farther and fare worse.
-        <Annotation annotationId="060045slipperslapper" visited={visitedNotes.has("060045slipperslapper")} annotationSelect={() => {openNote("060045slipperslapper"); addToVisited("060045slipperslapper")}} activeAnnotationId={currentNoteId}> Mother Slipperslapper.</Annotation> <i>(Familiarly.)</i> She's on the job herself tonight
+        <Annotation annotationId="060045slipperslapper"> Mother Slipperslapper.</Annotation> <i>(Familiarly.)</i> She's on the job herself tonight
         with the vet her tipster that gives her all the winners and pays for
         her son in Oxford. Working overtime but her luck's turned today.
         <i>(Suspiciously.)</i> You're not his father, are you?
@@ -2813,7 +2813,7 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         BLOOM
       </p>
       <p>
-        <Annotation annotationId="040047potato" visited={visitedNotes.has("040047potato")} annotationSelect={() => {openNote("040047potato"); addToVisited("040047potato")}} activeAnnotationId={currentNoteId}>A talisman. Heirloom.</Annotation>
+        <Annotation annotationId="040047potato">A talisman. Heirloom.</Annotation>
       </p>
       <span data-edition="ed1986" data-page="388"> </span>
       <p>
@@ -2894,7 +2894,7 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <p>
         <i>(Catches a stray hair deftly and twists it to her coil.)</i> No bloody
-        fear. I'm English. Have you a <Annotation annotationId="100002tobacco" visited={visitedNotes.has("100002tobacco")} annotationSelect={() => {openNote("100002tobacco"); addToVisited("100002tobacco")}} activeAnnotationId={currentNoteId}>swaggerroot</Annotation>?
+        fear. I'm English. Have you a <Annotation annotationId="100002tobacco">swaggerroot</Annotation>?
       </p>
       <span data-edition="ed1986" data-page="389"> </span><span data-edition="ed1961" data-page="477"> </span>
       <p>
@@ -2917,8 +2917,8 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <p>
         <i>(In workman's corduroy overalls, black gansy with red floating
-        tie and apache cap.)</i> Mankind is incorrigible. <Annotation annotationId="150011broughtthepoison" visited={visitedNotes.has("150011broughtthepoison")} annotationSelect={() => {openNote("150011broughtthepoison"); addToVisited("150011broughtthepoison")}} activeAnnotationId={currentNoteId}>Sir Walter Ralegh brought
-        from the new world</Annotation> that potato and that weed, the one <Annotation annotationId="040047potato" visited={visitedNotes.has("040047potato")} annotationSelect={() => {openNote("040047potato"); addToVisited("040047potato")}} activeAnnotationId={currentNoteId}>a killer of
+        tie and apache cap.)</i> Mankind is incorrigible. <Annotation annotationId="150011broughtthepoison">Sir Walter Ralegh brought
+        from the new world</Annotation> that potato and that weed, the one <Annotation annotationId="040047potato">a killer of
         pestilence by absorption</Annotation>, the other a poisoner of the ear, eye, heart,
         memory, will, understanding, all. That is to say he brought the poison
         a hundred years before another person whose 
@@ -2933,7 +2933,7 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         THE CHIMES
       </p>
       <p>
-        Turn again, Leopold! <Annotation annotationId="060033corporation" visited={visitedNotes.has("060033corporation")} annotationSelect={() => {openNote("060033corporation"); addToVisited("060033corporation")}} activeAnnotationId={currentNoteId}>Lord mayor of Dublin!</Annotation>
+        Turn again, Leopold! <Annotation annotationId="060033corporation">Lord mayor of Dublin!</Annotation>
       </p>
       <p></p>
       <span data-edition="ed1932" data-page="424"> </span>
@@ -2941,9 +2941,9 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         BLOOM
       </p>
       <p>
-        <i>(In <Annotation annotationId="060033corporation" visited={visitedNotes.has("060033corporation")} annotationSelect={() => {openNote("060033corporation"); addToVisited("060033corporation")}} activeAnnotationId={currentNoteId}>alderman's gown and chain</Annotation>.)</i> Electors of Arran Quay, Inns
-        Quay, Rotunda, Mountjoy and North Dock, better <Annotation annotationId="040037cattlemarket" visited={visitedNotes.has("040037cattlemarket")} annotationSelect={() => {openNote("040037cattlemarket"); addToVisited("040037cattlemarket")}} activeAnnotationId={currentNoteId}>run a tramline, I say,
-        from the cattlemarket to the river</Annotation>. <Annotation annotationId="160009flyingdutchmen" visited={visitedNotes.has("160009flyingdutchmen")} annotationSelect={() => {openNote("160009flyingdutchmen"); addToVisited("160009flyingdutchmen")}} activeAnnotationId={currentNoteId}>That's the music of the future.
+        <i>(In <Annotation annotationId="060033corporation">alderman's gown and chain</Annotation>.)</i> Electors of Arran Quay, Inns
+        Quay, Rotunda, Mountjoy and North Dock, better <Annotation annotationId="040037cattlemarket">run a tramline, I say,
+        from the cattlemarket to the river</Annotation>. <Annotation annotationId="160009flyingdutchmen">That's the music of the future.
         That's my programme. <i>Cui bono</i>? But our buccaneering Vanderdeckens in
         their phantom ship of finance</Annotation>...
       </p>
@@ -2965,7 +2965,7 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <p>
         <i>(Several wellknown burgesses, city magnates and freemen of the city
-        shake hands with Bloom and congratulate him. <Annotation annotationId="060033corporation" visited={visitedNotes.has("060033corporation")} annotationSelect={() => {openNote("060033corporation"); addToVisited("060033corporation")}} activeAnnotationId={currentNoteId}>Timothy Harrington, late
+        shake hands with Bloom and congratulate him. <Annotation annotationId="060033corporation">Timothy Harrington, late
         thrice Lord Mayor of Dublin, imposing in mayoral scarlet, gold chain and
         white silk tie, confers with councillor Lorcan Sherlock, locum tenens.</Annotation>
         They nod vigorously in agreement.)</i>
@@ -2993,7 +2993,7 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         BLOOM
       </p>
       <p>
-        <i>(Impassionedly.)</i> <Annotation annotationId="160009flyingdutchmen" visited={visitedNotes.has("160009flyingdutchmen")} annotationSelect={() => {openNote("160009flyingdutchmen"); addToVisited("160009flyingdutchmen")}} activeAnnotationId={currentNoteId}>These flying Dutchmen or lying Dutchmen as
+        <i>(Impassionedly.)</i> <Annotation annotationId="160009flyingdutchmen">These flying Dutchmen or lying Dutchmen as
         they recline in their upholstered poop, casting dice, what reck they?</Annotation>
         Machines is their cry, their chimera, their panacea. Laboursaving
         apparatuses, supplanters, bugbears, manufactured monsters for mutual
@@ -3007,11 +3007,11 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         <i>(Prolonged applause. Venetian masts, maypoles and festal arches spring
         up. A streamer bearing the legends</i> Cead Mile Failte <i>and</i> Mah Ttob
         Melek Israel <i>spans the street. All the windows are thronged with </i><span data-edition="ed1932" data-page="425"> </span><i>sightseers, chiefly ladies. Along the route the regiments of the
-        <Annotation annotationId="030118royaldublins" visited={visitedNotes.has("030118royaldublins")} annotationSelect={() => {openNote("030118royaldublins"); addToVisited("030118royaldublins")}} activeAnnotationId={currentNoteId}>royal Dublin Fusiliers</Annotation>, the King's own Scottish Borderers, the Cameron
+        <Annotation annotationId="030118royaldublins">royal Dublin Fusiliers</Annotation>, the King's own Scottish Borderers, the Cameron
         Highlanders</i> <span data-edition="ed1961" data-page="479"> </span><i>and the Welsh Fusiliers standing </i>
         <span data-edition="ed1939" data-page="341"> </span>
         <i>to attention, keep back
-        the crowd. Boys from <Annotation annotationId="050020highschool" visited={visitedNotes.has("050020highschool")} annotationSelect={() => {openNote("050020highschool"); addToVisited("050020highschool")}} activeAnnotationId={currentNoteId}>High school</Annotation> are perched on the lampposts,
+        the crowd. Boys from <Annotation annotationId="050020highschool">High school</Annotation> are perched on the lampposts,
         telegraph poles, windowsills, cornices, gutters, chimneypots, railings,
         rainspouts, whistling and cheering. The pillar of the cloud appears. A
         fife and drum band is heard in the distance playing the Kol Nidre. The
@@ -3020,7 +3020,7 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         surrounded by pennons of the civic flag. The van of the procession
         appears headed by John Howard Parnell, city marshal, in a chessboard
         tabard, the Athlone Poursuivant and Ulster King of Arms. They are
-        followed by <Annotation annotationId="060033corporation" visited={visitedNotes.has("060033corporation")} annotationSelect={() => {openNote("060033corporation"); addToVisited("060033corporation")}} activeAnnotationId={currentNoteId}>the Right Honourable Joseph Hutchinson, lord mayor of
+        followed by <Annotation annotationId="060033corporation">the Right Honourable Joseph Hutchinson, lord mayor of
         Dublin</Annotation>, his lordship the lord mayor of Cork, their worships the
         mayors of Limerick, Galway,</i> 
         <span data-edition="ed1922" data-page="453"> </span>
@@ -3041,7 +3041,7 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         undertakers, silk mercers, lapidaries, salesmasters, corkcutters,
         assessors of fire losses, dyers and cleaners, export bottlers,
         fellmongers, ticketwriters, heraldic seal engravers, horse repository
-        hands, bullion brokers, <Annotation annotationId="050041cricket" visited={visitedNotes.has("050041cricket")} annotationSelect={() => {openNote("050041cricket"); addToVisited("050041cricket")}} activeAnnotationId={currentNoteId}>cricket</Annotation> and archery outfitters, riddlemakers,
+        hands, bullion brokers, <Annotation annotationId="050041cricket">cricket</Annotation> and archery outfitters, riddlemakers,
         egg and potato factors, hosiers and glovers, plumbing contractors. After
         them march gentlemen of the bedchamber, Black Rod, Deputy Garter,
         Gold Stick, the master of horse, the lord great chamberlain, the earl
@@ -3063,7 +3063,7 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       <p>The wren, the wren, <br/>
         The king of all birds, <br/>
         Saint Stephen's his day <br/>
-        Was caught <Annotation annotationId="120008gorse" visited={visitedNotes.has("120008gorse")} annotationSelect={() => {openNote("120008gorse"); addToVisited("120008gorse")}} activeAnnotationId={currentNoteId}>in the furze</Annotation>.
+        Was caught <Annotation annotationId="120008gorse">in the furze</Annotation>.
       </p>
       <span data-edition="ed1922" data-page="454"> </span>
       <p>
@@ -3111,7 +3111,7 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         A classic face! He has the forehead of a thinker.
       </p>
       <p>
-        <i>(Bloom's weather. <Annotation annotationId="040006homerulesun" visited={visitedNotes.has("040006homerulesun")} annotationSelect={() => {openNote("040006homerulesun"); addToVisited("040006homerulesun")}} activeAnnotationId={currentNoteId}>A sunburst appears in the northwest.</Annotation>)</i>
+        <i>(Bloom's weather. <Annotation annotationId="040006homerulesun">A sunburst appears in the northwest.</Annotation>)</i>
       </p>
       <p>
         THE BISHOP OF DOWN AND CONNOR
@@ -3131,7 +3131,7 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         BLOOM
       </p>
       <p>
-        <i>(<Annotation annotationId="020080mauve" visited={visitedNotes.has("020080mauve")} annotationSelect={() => {openNote("020080mauve"); addToVisited("020080mauve")}} activeAnnotationId={currentNoteId}>In dalmatic and purple mantle</Annotation>, to the bishop of Down and
+        <i>(<Annotation annotationId="020080mauve">In dalmatic and purple mantle</Annotation>, to the bishop of Down and
         Connor, with dignity.)</i> Thanks, somewhat eminent sir.
       </p>
       <p>
@@ -3161,10 +3161,10 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         Patrick, Andrew, David, George, be thou anointed!
       </p>
       <p>
-        <i>(Bloom assumes a mantle of cloth of gold and puts on <Annotation annotationId="040021ruby" visited={visitedNotes.has("040021ruby")} annotationSelect={() => {openNote("040021ruby"); addToVisited("040021ruby")}} activeAnnotationId={currentNoteId}>a ruby ring</Annotation>. He
+        <i>(Bloom assumes a mantle of cloth of gold and puts on <Annotation annotationId="040021ruby">a ruby ring</Annotation>. He
         ascends and stands on the stone of destiny. The representative peers put
         on at the same time their twentyeight crowns. Joybells ring in Christ
-        church, Saint Patrick's, <Annotation annotationId="040008georgeschurch" visited={visitedNotes.has("040008georgeschurch")} annotationSelect={() => {openNote("040008georgeschurch"); addToVisited("040008georgeschurch")}} activeAnnotationId={currentNoteId}>George's</Annotation> and gay Malahide.</i> <span data-edition="ed1986" data-page="393"> </span><i>Mirus bazaar
+        church, Saint Patrick's, <Annotation annotationId="040008georgeschurch">George's</Annotation> and gay Malahide.</i> <span data-edition="ed1986" data-page="393"> </span><i>Mirus bazaar
         fireworks go up from all sides with symbolical phallopyrotechnic
         designs. The peers do homage, one by one, approaching and
         genuflecting.)</i>
@@ -3252,7 +3252,7 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         JOHN WYSE NOLAN
       </p>
       <p>
-        <Annotation annotationId="020073fenians" visited={visitedNotes.has("020073fenians")} annotationSelect={() => {openNote("020073fenians"); addToVisited("020073fenians")}} activeAnnotationId={currentNoteId}>There's the man that got away James Stephens.</Annotation>
+        <Annotation annotationId="020073fenians">There's the man that got away James Stephens.</Annotation>
       </p>
       <p>
         A BLUECOAT SCHOOLBOY
@@ -3384,7 +3384,7 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         Peep! Bopeep! <i>(He wheels twins in a perambulator.)</i> Ticktacktwo
         wouldyousetashoe? <i>(He performs juggler's tricks, draws red, orange,
         yellow, green, blue, indigo and violet silk handkerchiefs from his
-        mouth.)</i> <Annotation annotationId="040013wonderisittrue" visited={visitedNotes.has("040013wonderisittrue")} annotationSelect={() => {openNote("040013wonderisittrue"); addToVisited("040013wonderisittrue")}} activeAnnotationId={currentNoteId}>Roygbiv. 32 feet per second.</Annotation> <i>(He consoles a widow.)</i> Absence
+        mouth.)</i> <Annotation annotationId="040013wonderisittrue">Roygbiv. 32 feet per second.</Annotation> <i>(He consoles a widow.)</i> Absence
         makes the heart grow younger. <i>(He dances the Highland fling with
         grotesque antics.)</i> Leg it, ye devils! <i>(He kisses the bedsores of a
         palsied veteran.</i>) Honourable wounds! <i>(He trips up a fit policeman.)</i>
@@ -3499,7 +3499,7 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         CHRIS CALLINAN
       </p>
       <p>
-        What is the <Annotation annotationId="080008parallax" visited={visitedNotes.has("080008parallax")} annotationSelect={() => {openNote("080008parallax"); addToVisited("080008parallax")}} activeAnnotationId={currentNoteId}>parallax</Annotation> of the subsolar ecliptic of
+        What is the <Annotation annotationId="080008parallax">parallax</Annotation> of the subsolar ecliptic of
         Aldebaran?
       </p>
       <p>
@@ -3595,7 +3595,7 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         must now cease. General amnesty, weekly carnival with masked licence,
         <span data-edition="ed1961" data-page="489"> </span>bonuses for all, esperanto the universal language with universal
         brotherhood. No more patriotism of barspongers and dropsical impostors.
-        Free money, free rent, <Annotation annotationId="050045samaritan" visited={visitedNotes.has("050045samaritan")} annotationSelect={() => {openNote("050045samaritan"); addToVisited("050045samaritan")}} activeAnnotationId={currentNoteId}>free love and a free lay church in a free lay
+        Free money, free rent, <Annotation annotationId="050045samaritan">free love and a free lay church in a free lay
         state</Annotation>.
       </p>
       <span data-edition="ed1986" data-page="399"> </span>
@@ -3606,7 +3606,7 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         Free fox in a free henroost.
       </p>
       <p>
-        <Annotation annotationId="080024davybyrnes" visited={visitedNotes.has("080024davybyrnes")} annotationSelect={() => {openNote("080024davybyrnes"); addToVisited("080024davybyrnes")}} activeAnnotationId={currentNoteId}>DAVY BYRNE</Annotation>
+        <Annotation annotationId="080024davybyrnes">DAVY BYRNE</Annotation>
       </p>
       <p>
         <i>(Yawning.)</i> Iiiiiiiiiaaaaaaach!
@@ -3626,10 +3626,10 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       <span data-edition="ed1939" data-page="348"> </span>
       <p>
         <i>(Bloom explains to those near him his schemes for social regeneration.
-        All agree with him. <Annotation annotationId="080005venus" visited={visitedNotes.has("080005venus")} annotationSelect={() => {openNote("080005venus"); addToVisited("080005venus")}} activeAnnotationId={currentNoteId}>The keeper of the Kildare Street Museum appears,
+        All agree with him. <Annotation annotationId="080005venus">The keeper of the Kildare Street Museum appears,
         dragging a lorry on which are the shaking statues of several naked</Annotation></i>
         <span data-edition="ed1922" data-page="462"> </span>
-        <i><Annotation annotationId="080005venus" visited={visitedNotes.has("080005venus")} annotationSelect={() => {openNote("080005venus"); addToVisited("080005venus")}} activeAnnotationId={currentNoteId}>goddesses, Venus Callipyge, Venus Pandemos,</Annotation> Venus Metempsychosis, and
+        <i><Annotation annotationId="080005venus">goddesses, Venus Callipyge, Venus Pandemos,</Annotation> Venus Metempsychosis, and
         plaster figures, also naked, representing the new nine muses, Commerce,
         Operatic Music, Amor, Publicity, Manufacture, Liberty of Speech, Plural
         Voting, Gastronomy, Private Hygiene, Seaside Concert Entertainments,
@@ -3644,13 +3644,13 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <span data-edition="ed1932" data-page="433"> </span>
       <p>
-        <Annotation annotationId="060015riordan" visited={visitedNotes.has("060015riordan")} annotationSelect={() => {openNote("060015riordan"); addToVisited("060015riordan")}} activeAnnotationId={currentNoteId}>MRS RIORDAN</Annotation>
+        <Annotation annotationId="060015riordan">MRS RIORDAN</Annotation>
       </p>
       <p>
         <i>(Tears up her will.)</i> I'm disappointed in you! You bad man!
       </p>
       <p>
-        <Annotation annotationId="010134mothergrogan" visited={visitedNotes.has("010134mothergrogan")} annotationSelect={() => {openNote("010134mothergrogan"); addToVisited("010134mothergrogan")}} activeAnnotationId={currentNoteId}>MOTHER GROGAN</Annotation>
+        <Annotation annotationId="010134mothergrogan">MOTHER GROGAN</Annotation>
       </p>
       <p>
         <i>(Removes her boot to throw it at Bloom.)</i> You beast! You
@@ -3675,7 +3675,7 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <span data-edition="ed1986" data-page="400"> </span>
       <p>
-        <Annotation annotationId="050028hoppy" visited={visitedNotes.has("050028hoppy")} annotationSelect={() => {openNote("050028hoppy"); addToVisited("050028hoppy")}} activeAnnotationId={currentNoteId}>HOPPY HOLOHAN</Annotation>
+        <Annotation annotationId="050028hoppy">HOPPY HOLOHAN</Annotation>
       </p>
       <p>
         Good old Bloom! There's nobody like him after all.
@@ -3731,9 +3731,9 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <p>
         <i>(Many most attractive and enthusiastic women also commit suicide by
-        stabbing, drowning, drinking prussic acid, <Annotation annotationId="150007aconite" visited={visitedNotes.has("150007aconite")} annotationSelect={() => {openNote("150007aconite"); addToVisited("150007aconite")}} activeAnnotationId={currentNoteId}>aconite</Annotation>, arsenic, opening
+        stabbing, drowning, drinking prussic acid, <Annotation annotationId="150007aconite">aconite</Annotation>, arsenic, opening
         their veins, refusing food, casting themselves under steamrollers, from
-        the top of <Annotation annotationId="070006nelsonspillar" visited={visitedNotes.has("070006nelsonspillar")} annotationSelect={() => {openNote("070006nelsonspillar"); addToVisited("070006nelsonspillar")}} activeAnnotationId={currentNoteId}>Nelson's Pillar</Annotation>, into the great vat of Guinness's brewery,
+        the top of <Annotation annotationId="070006nelsonspillar">Nelson's Pillar</Annotation>, into the great vat of Guinness's brewery,
         asphyxiating</i> <span data-edition="ed1932" data-page="434"> </span><i>themselves by placing their heads in gasovens, hanging
         themselves in stylish garters, leaping from windows of different
         storeys.)</i>
@@ -3760,7 +3760,7 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         Lynch him! Roast him! He's as bad as Parnell was. Mr Fox!
       </p>
       <p>
-        <i>(Mother Grogan throws her boot at Bloom. Several <Annotation annotationId="040007dorsetstreet" visited={visitedNotes.has("040007dorsetstreet")} annotationSelect={() => {openNote("040007dorsetstreet"); addToVisited("040007dorsetstreet")}} activeAnnotationId={currentNoteId}>shopkeepers from upper
+        <i>(Mother Grogan throws her boot at Bloom. Several <Annotation annotationId="040007dorsetstreet">shopkeepers from upper
         and lower Dorset street</Annotation> throw objects of little or no commercial value,
         hambones, condensed milk tins, unsaleable cabbage, stale bread, sheeps'
         tails, odd pieces of fat.)</i>
@@ -3856,7 +3856,7 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         O, I so want to be a mother.
       </p>
       <p>
-        <Annotation annotationId="040086mrsthornton" visited={visitedNotes.has("040086mrsthornton")} annotationSelect={() => {openNote("040086mrsthornton"); addToVisited("040086mrsthornton")}} activeAnnotationId={currentNoteId}>MRS THORNTON</Annotation>
+        <Annotation annotationId="040086mrsthornton">MRS THORNTON</Annotation>
       </p>
       <p>
         <i>(In nursetender's gown.)</i> Embrace me tight, dear. You'll
@@ -3906,9 +3906,9 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       <p>
         <i>(Bloom walks on a net, covers his left eye with his left ear, passes
         through several walls, climbs Nelson's Pillar, hangs from the top ledge
-        by his eyelids, <Annotation annotationId="060020redbank" visited={visitedNotes.has("060020redbank")} annotationSelect={() => {openNote("060020redbank"); addToVisited("060020redbank")}} activeAnnotationId={currentNoteId}>eats twelve dozen oysters</Annotation> (shells included), heals
+        by his eyelids, <Annotation annotationId="060020redbank">eats twelve dozen oysters</Annotation> (shells included), heals
         several sufferers from king's evil, contracts his face so as to resemble
-        many historical personages, Lord Beaconsfield, <Annotation annotationId="180006lordbyron" visited={visitedNotes.has("180006lordbyron")} annotationSelect={() => {openNote("180006lordbyron"); addToVisited("180006lordbyron")}} activeAnnotationId={currentNoteId}>Lord Byron</Annotation>, Wat Tyler,
+        many historical personages, Lord Beaconsfield, <Annotation annotationId="180006lordbyron">Lord Byron</Annotation>, Wat Tyler,
         Moses of Egypt, Moses Maimonides, Moses Mendelssohn, Henry Irving, Rip
         van Winkle, Kossuth, Jean Jacques Rousseau, Baron Leopold Rothschild,
         Robinson Crusoe, Sherlock Holmes, Pasteur, turns each foot
@@ -3941,10 +3941,10 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <span data-edition="ed1922" data-page="467"> </span>
       <p>
-        <Annotation annotationId="150016writingonthewall" visited={visitedNotes.has("150016writingonthewall")} annotationSelect={() => {openNote("150016writingonthewall"); addToVisited("150016writingonthewall")}} activeAnnotationId={currentNoteId}>A DEADHAND</Annotation>
+        <Annotation annotationId="150016writingonthewall">A DEADHAND</Annotation>
       </p>
       <p>
-        <Annotation annotationId="150016writingonthewall" visited={visitedNotes.has("150016writingonthewall")} annotationSelect={() => {openNote("150016writingonthewall"); addToVisited("150016writingonthewall")}} activeAnnotationId={currentNoteId}><i>(Writes on the wall.)</i></Annotation> <Annotation annotationId="150016writingonthewall" visited={visitedNotes.has("150016writingonthewall")} annotationSelect={() => {openNote("150016writingonthewall"); addToVisited("150016writingonthewall")}} activeAnnotationId={currentNoteId}>Bloom is a cod.</Annotation>
+        <Annotation annotationId="150016writingonthewall"><i>(Writes on the wall.)</i></Annotation> <Annotation annotationId="150016writingonthewall">Bloom is a cod.</Annotation>
       </p>
       <span data-edition="ed1986" data-page="404"> </span>
       <p>
@@ -3978,12 +3978,12 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         THE IRISH EVICTED TENANTS
       </p>
       <p>
-        <i>(In bodycoats, kneebreeches, with <Annotation annotationId="050022donnybrook" visited={visitedNotes.has("050022donnybrook")} annotationSelect={() => {openNote("050022donnybrook"); addToVisited("050022donnybrook")}} activeAnnotationId={currentNoteId}>Donnybrook
-        fair shillelaghs</Annotation>.)</i> <Annotation annotationId="150018sjambok" visited={visitedNotes.has("150018sjambok")} annotationSelect={() => {openNote("150018sjambok"); addToVisited("150018sjambok")}} activeAnnotationId={currentNoteId}>Sjambok him!</Annotation>
+        <i>(In bodycoats, kneebreeches, with <Annotation annotationId="050022donnybrook">Donnybrook
+        fair shillelaghs</Annotation>.)</i> <Annotation annotationId="150018sjambok">Sjambok him!</Annotation>
       </p>
       <p>
         <i>(Bloom with asses' ears seats himself in the pillory with crossed arms,
-        his feet protruding. He whistles</i> <Annotation annotationId="080030cenarteco" visited={visitedNotes.has("080030cenarteco")} annotationSelect={() => {openNote("080030cenarteco"); addToVisited("080030cenarteco")}} activeAnnotationId={currentNoteId}>Don Giovanni, a cenar teco.</Annotation> <i>Artane
+        his feet protruding. He whistles</i> <Annotation annotationId="080030cenarteco">Don Giovanni, a cenar teco.</Annotation> <i>Artane
         orphans, joining hands, caper round him. Girls of the Prison Gate
         Mission, joining hands, caper round in the opposite direction.)</i>
       </p>
@@ -4068,9 +4068,9 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         BROTHER BUZZ
       </p>
       <p>
-        <i>(Invests Bloom in a <Annotation annotationId="010004yellowdressinggown" visited={visitedNotes.has("010004yellowdressinggown")} annotationSelect={() => {openNote("010004yellowdressinggown"); addToVisited("010004yellowdressinggown")}} activeAnnotationId={currentNoteId}>yellow habit</Annotation> with embroidery of
+        <i>(Invests Bloom in a <Annotation annotationId="010004yellowdressinggown">yellow habit</Annotation> with embroidery of
         painted flames and high pointed hat. He places a bag of gunpowder round
-        his neck and hands him over to the civil power, saying)</i> <Annotation annotationId="040077ourfather" visited={visitedNotes.has("040077ourfather")} annotationSelect={() => {openNote("040077ourfather"); addToVisited("040077ourfather")}} activeAnnotationId={currentNoteId}>Forgive him his
+        his neck and hands him over to the civil power, saying)</i> <Annotation annotationId="040077ourfather">Forgive him his
         trespasses.</Annotation>
       </p>
       <p>
@@ -4116,7 +4116,7 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <p>
         <i>(A choir of six hundred voices, conducted by Mr Vincent O'Brien, sings
-        <Annotation annotationId="080004themessiah" visited={visitedNotes.has("080004themessiah")} annotationSelect={() => {openNote("080004themessiah"); addToVisited("080004themessiah")}} activeAnnotationId={currentNoteId}>the Alleluia chorus</Annotation>, accompanied on the organ by Joseph Glynn. Bloom becomes mute,
+        <Annotation annotationId="080004themessiah">the Alleluia chorus</Annotation>, accompanied on the organ by Joseph Glynn. Bloom becomes mute,
         shrunken, carbonised.)</i>
       </p>
       <p>
@@ -4129,15 +4129,15 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         BLOOM
       </p>
       <p>
-        <i>(In caubeen with <Annotation annotationId="150010claypipe" visited={visitedNotes.has("150010claypipe")} annotationSelect={() => {openNote("150010claypipe"); addToVisited("150010claypipe")}} activeAnnotationId={currentNoteId}>clay pipe</Annotation> stuck in the band, dusty <Annotation annotationId="020076brogues" visited={visitedNotes.has("020076brogues")} annotationSelect={() => {openNote("020076brogues"); addToVisited("020076brogues")}} activeAnnotationId={currentNoteId}>brogues</Annotation>, an
-        emigrant's red handkerchief bundle in his hand, leading a black <Annotation annotationId="030062bogoak" visited={visitedNotes.has("030062bogoak")} annotationSelect={() => {openNote("030062bogoak"); addToVisited("030062bogoak")}} activeAnnotationId={currentNoteId}>bogoak</Annotation>
+        <i>(In caubeen with <Annotation annotationId="150010claypipe">clay pipe</Annotation> stuck in the band, dusty <Annotation annotationId="020076brogues">brogues</Annotation>, an
+        emigrant's red handkerchief bundle in his hand, leading a black <Annotation annotationId="030062bogoak">bogoak</Annotation>
         pig by a sugaun, with a smile in his eye.)</i> Let me be going now, woman of
         the house, for by all the goats in Connemara I'm after having the
         father and mother of a bating. <i>(With a tear in his eye.)</i> All insanity.
         <span data-edition="ed1939" data-page="354"> </span>
         Patriotism, sorrow for the dead, music, future of the race. To be or not
         to be. Life's dream is o'er. End it peacefully. They can live on. <i>(He
-        gazes far away mournfully.)</i> I am ruined. <Annotation annotationId="150007aconite" visited={visitedNotes.has("150007aconite")} annotationSelect={() => {openNote("150007aconite"); addToVisited("150007aconite")}} activeAnnotationId={currentNoteId}>A few pastilles of aconite.</Annotation> The
+        gazes far away mournfully.)</i> I am ruined. <Annotation annotationId="150007aconite">A few pastilles of aconite.</Annotation> The
         blinds drawn. A letter. Then lie back to rest. <i>(He breathes softly.)</i> No
         more. I have lived. Fare. Farewell.
       </p>
@@ -4187,14 +4187,14 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         BLOOM
       </p>
       <p>
-        <i>(Smiles, nods slowly.)</i> More, <Annotation annotationId="150012houri" visited={visitedNotes.has("150012houri")} annotationSelect={() => {openNote("150012houri"); addToVisited("150012houri")}} activeAnnotationId={currentNoteId}>houri</Annotation>, more.
+        <i>(Smiles, nods slowly.)</i> More, <Annotation annotationId="150012houri">houri</Annotation>, more.
       </p>
       <p>
         ZOE
       </p>
       <p>
         And more's mother? <i>(She pats him offhandedly with velvet paws.)</i>
-        Are you coming <Annotation annotationId="150019pianola" visited={visitedNotes.has("150019pianola")} annotationSelect={() => {openNote("150019pianola"); addToVisited("150019pianola")}} activeAnnotationId={currentNoteId}>into the musicroom to see our new pianola</Annotation>? Come and I'll
+        Are you coming <Annotation annotationId="150019pianola">into the musicroom to see our new pianola</Annotation>? Come and I'll
         peel off.
       </p>
       <p>
@@ -4305,7 +4305,7 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         full waterjugjar, his twotailed black braces dangling at heels. Averting
         his face quickly Bloom bends to examine on the halltable the spaniel
         eyes of a running fox: then, his lifted head sniffing, follows Zoe
-        into the musicroom. A <Annotation annotationId="020080mauve" visited={visitedNotes.has("020080mauve")} annotationSelect={() => {openNote("020080mauve"); addToVisited("020080mauve")}} activeAnnotationId={currentNoteId}>shade of mauve tissuepaper</Annotation> dims the light of the
+        into the musicroom. A <Annotation annotationId="020080mauve">shade of mauve tissuepaper</Annotation> dims the light of the
         chandelier. Round and round a moth flies, colliding, escaping. The
         floor is covered with an oilcloth mosaic of jade and azure and cinnabar
         rhomboids. Footmarks are stamped over it in all senses, heel to heel,
@@ -4409,7 +4409,7 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <p>
         <i>(With saturnine spleen.)</i> Bah! It is because it is. Woman's
-        reason. <Annotation annotationId="010022hellenise" visited={visitedNotes.has("010022hellenise")} annotationSelect={() => {openNote("010022hellenise"); addToVisited("010022hellenise")}} activeAnnotationId={currentNoteId}>Jewgreek is greekjew. Extremes meet.</Annotation> Death is the highest form
+        reason. <Annotation annotationId="010022hellenise">Jewgreek is greekjew. Extremes meet.</Annotation> Death is the highest form
         of life. Bah!
       </p>
       <span data-edition="ed1922" data-page="474"> </span>
@@ -4465,7 +4465,7 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         <i>(Abruptly.)</i> What went forth to the ends of the world to
         traverse not itself, God, the sun, Shakespeare, a commercial traveller,
         having itself traversed in reality itself becomes that self. Wait a
-        moment. Wait a second. Damn that fellow's <Annotation annotationId="020069streetshout" visited={visitedNotes.has("020069streetshout")} annotationSelect={() => {openNote("020069streetshout"); addToVisited("020069streetshout")}} activeAnnotationId={currentNoteId}>noise in the street</Annotation>. Self
+        moment. Wait a second. Damn that fellow's <Annotation annotationId="020069streetshout">noise in the street</Annotation>. Self
         which it itself was ineluctably preconditioned to become. <i>Ecco!</i>
       </p>
       <p>
@@ -4523,7 +4523,7 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <p>
         Stop press edition. Result of the rockinghorse races. Sea
-        serpent in <Annotation annotationId="060016canals" visited={visitedNotes.has("060016canals")} annotationSelect={() => {openNote("060016canals"); addToVisited("060016canals")}} activeAnnotationId={currentNoteId}>the royal canal</Annotation>. Safe arrival of Antichrist.
+        serpent in <Annotation annotationId="060016canals">the royal canal</Annotation>. Safe arrival of Antichrist.
       </p>
       <p>
         <i>(Stephen turns and sees Bloom.)</i>
@@ -4536,14 +4536,14 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         A time, times and half a time.
       </p>
       <p>
-        <i>(Reuben J. Antichrist, <Annotation annotationId="020061wanderers" visited={visitedNotes.has("020061wanderers")} annotationSelect={() => {openNote("020061wanderers"); addToVisited("020061wanderers")}} activeAnnotationId={currentNoteId}>wandering jew</Annotation>, a clutching hand open on his
+        <i>(Reuben J. Antichrist, <Annotation annotationId="020061wanderers">wandering jew</Annotation>, a clutching hand open on his
         spine, stumps forward. Across his loins is slung a pilgrim's wallet from
         which protrude promissory notes and dishonoured bills. Aloft over his
         shoulder he bears a long boatpole from the hook of which the sodden
         huddled mass of his only son, saved from Liffey waters, hangs from
         the slack of its breeches. A hobgoblin in the image of Punch Costello,
         hipshot, crookbacked, hydrocephalic, prognathic with receding forehead
-        and <Annotation annotationId="040050ikeymo" visited={visitedNotes.has("040050ikeymo")} annotationSelect={() => {openNote("040050ikeymo"); addToVisited("040050ikeymo")}} activeAnnotationId={currentNoteId}>Ally Sloper</Annotation> nose, tumbles in somersaults through the gathering
+        and <Annotation annotationId="040050ikeymo">Ally Sloper</Annotation> nose, tumbles in somersaults through the gathering
         darkness.)</i>
       </p>
       <p>
@@ -4599,7 +4599,7 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         <i>(A rocket rushes up the sky and bursts. A white star falls from it,
         proclaiming the consummation of all things and second coming of Elijah.
         Along an infinite invisible tightrope taut from zenith to nadir the End
-        of the World, a twoheaded octopus in gillie's kilts, busby and <Annotation annotationId="020036filibegs" visited={visitedNotes.has("020036filibegs")} annotationSelect={() => {openNote("020036filibegs"); addToVisited("020036filibegs")}} activeAnnotationId={currentNoteId}>tartan
+        of the World, a twoheaded octopus in gillie's kilts, busby and <Annotation annotationId="020036filibegs">tartan
         filibegs</Annotation>, whirls through the murk, head over heels, in the form of the
         Three Legs of Man.)</i>
       </p>
@@ -4664,7 +4664,7 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         ELIJAH
       </p>
       <p>
-        <i>(In rolledup shirtsleeves, <Annotation annotationId="060003eugenestratton" visited={visitedNotes.has("060003eugenestratton")} annotationSelect={() => {openNote("060003eugenestratton"); addToVisited("060003eugenestratton")}} activeAnnotationId={currentNoteId}>black in the face</Annotation>, shouts at the top
+        <i>(In rolledup shirtsleeves, <Annotation annotationId="060003eugenestratton">black in the face</Annotation>, shouts at the top
         of his voice, his arms uplifted.)</i> Big Brother up there, Mr President,
         you hear what I done just been saying to you. Certainly, I sort of
         believe strong in you, Mr <span data-edition="ed1986" data-page="414"> </span>President. I certainly am thinking now Miss
@@ -4682,7 +4682,7 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       <p>
         I forgot myself. In a weak moment I erred and did what I did on 
         <span data-edition="ed1922" data-page="478"> </span>
-        Constitution hill. I was confirmed by the bishop and <Annotation annotationId="040036scapulars" visited={visitedNotes.has("040036scapulars")} annotationSelect={() => {openNote("040036scapulars"); addToVisited("040036scapulars")}} activeAnnotationId={currentNoteId}>enrolled in
+        Constitution hill. I was confirmed by the bishop and <Annotation annotationId="040036scapulars">enrolled in
         the brown scapular</Annotation>. My mother's sister married a Montmorency. It was a
         working plumber was my ruination when I was pure.
       </p>
@@ -4705,7 +4705,7 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         STEPHEN
       </p>
       <p>
-        In the beginning was the word, in the end the <Annotation annotationId="020025asitwas" visited={visitedNotes.has("020025asitwas")} annotationSelect={() => {openNote("020025asitwas"); addToVisited("020025asitwas")}} activeAnnotationId={currentNoteId}>world without
+        In the beginning was the word, in the end the <Annotation annotationId="020025asitwas">world without
         end</Annotation>. Blessed be the eight beatitudes.
       </p>
       <p>
@@ -4725,7 +4725,7 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         LYSTER
       </p>
       <p>
-        <i>(<Annotation annotationId="090004quakerlibrarian" visited={visitedNotes.has("090004quakerlibrarian")} annotationSelect={() => {openNote("090004quakerlibrarian"); addToVisited("090004quakerlibrarian")}} activeAnnotationId={currentNoteId}>In quakergrey kneebreeches</Annotation> and broadbrimmed hat, says
+        <i>(<Annotation annotationId="090004quakerlibrarian">In quakergrey kneebreeches</Annotation> and broadbrimmed hat, says
         discreetly.)</i> He is our friend. I need not mention names. Seek thou the
         light.
       </p>
@@ -4756,7 +4756,7 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         Plain truth for a plain man. Tanderagee wants the facts and means to get them.
       </p>
       <p>
-        <i>(<Annotation annotationId="030042mananaan" visited={visitedNotes.has("030042mananaan")} annotationSelect={() => {openNote("030042mananaan"); addToVisited("030042mananaan")}} activeAnnotationId={currentNoteId}>In the cone of the searchlight behind the coalscuttle, ollave,
+        <i>(<Annotation annotationId="030042mananaan">In the cone of the searchlight behind the coalscuttle, ollave,
         holyeyed, the bearded figure of Mananaun Maclir broods, chin on knees.
         He rises slowly. A cold seawind blows from his druid mouth. About his
         head writhe eels and elvers. He is encrusted with weeds and shells.</Annotation> His
@@ -4774,7 +4774,7 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         of Shakti. <i>(With a cry of stormbirds.)</i> Shakti Shiva, darkhidden Father!
         <i>(He smites with his bicycle pump the crayfish in his left hand. On its
         cooperative dial glow the twelve signs of the zodiac. He wails with
-        the vehemence of the ocean.)</i> Aum! Baum! Pyjaum! I am the light of <Annotation annotationId="020077homestead" visited={visitedNotes.has("020077homestead")} annotationSelect={() => {openNote("020077homestead"); addToVisited("020077homestead")}} activeAnnotationId={currentNoteId}>the
+        the vehemence of the ocean.)</i> Aum! Baum! Pyjaum! I am the light of <Annotation annotationId="020077homestead">the
         homestead</Annotation>! I am the dreamery creamery butter.
       </p>
       <p>
@@ -4835,7 +4835,7 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         then twists round towards him, pulling her slip free of the poker. Blue
         fluid again flows over her flesh. Bloom stands, smiling desirously,
         twirling his thumbs. Kitty Ricketts licks her middle finger with her
-        spittle and, gazing in the mirror, smooths both eyebrows. <Annotation annotationId="050026henryflower" visited={visitedNotes.has("050026henryflower")} annotationSelect={() => {openNote("050026henryflower"); addToVisited("050026henryflower")}} activeAnnotationId={currentNoteId}>Lipoti Virag,
+        spittle and, gazing in the mirror, smooths both eyebrows. <Annotation annotationId="050026henryflower">Lipoti Virag,
         basilicogrammate,</Annotation> chutes rapidly down through the chimneyflue and struts
         two steps to the left on gawky pink stilts. He is sausaged into several
         overcoats and wears a brown macintosh under which he holds a roll of
@@ -4891,7 +4891,7 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         bunchiness of hip. A new purchase at some monster sale for which a gull
         has been mulcted. Meretricious finery to deceive the eye. Observe the
         attention to details of dustspecks. Never put on you tomorrow what you
-        can wear today. <Annotation annotationId="080008parallax" visited={visitedNotes.has("080008parallax")} annotationSelect={() => {openNote("080008parallax"); addToVisited("080008parallax")}} activeAnnotationId={currentNoteId}>Parallax!</Annotation> <i>(With a nervous twitch of his head.)</i> Did you
+        can wear today. <Annotation annotationId="080008parallax">Parallax!</Annotation> <i>(With a nervous twitch of his head.)</i> Did you
         hear my brain go snap? Pollysyllabax!
       </p>
       <p>
@@ -5004,7 +5004,7 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       <p>
         <i>(Excitedly.)</i> I say so. I say so. E'en so. Technic. <i>(He taps his
         parchmentroll energetically.)</i> This book tells you how to act with all
-        descriptive <span data-edition="ed1932" data-page="451"> </span>particulars. Consult index for agitated fear of <Annotation annotationId="150007aconite" visited={visitedNotes.has("150007aconite")} annotationSelect={() => {openNote("150007aconite"); addToVisited("150007aconite")}} activeAnnotationId={currentNoteId}>aconite</Annotation>,
+        descriptive <span data-edition="ed1932" data-page="451"> </span>particulars. Consult index for agitated fear of <Annotation annotationId="150007aconite">aconite</Annotation>,
         melancholy of muriatic, priapic pulsatilla. Virag is going to talk about
         amputation. Our old friend caustic. 
         <span data-edition="ed1922" data-page="483"> </span>
@@ -5058,7 +5058,7 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         BLOOM
       </p>
       <p>
-        <Annotation annotationId="040040bluebottle" visited={visitedNotes.has("040040bluebottle")} annotationSelect={() => {openNote("040040bluebottle"); addToVisited("040040bluebottle")}} activeAnnotationId={currentNoteId}>Bee or bluebottle too other day</Annotation> butting shadow on wall dazed self
+        <Annotation annotationId="040040bluebottle">Bee or bluebottle too other day</Annotation> butting shadow on wall dazed self
         then me wandered dazed down shirt good job I...
       </p>
       <span data-edition="ed1932" data-page="452"> </span><span data-edition="ed1961" data-page="515"> </span>
@@ -5072,7 +5072,7 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         gluttonously with turkey wattles.)</i> Bubbly jock! Bubbly jock! Where are
         we? Open Sesame! Cometh forth! <i>(He unrolls his parchment rapidly and
         reads, his glowworm's nose running backwards over the letters which he
-        claws.)</i> Stay, good friend. I bring thee thy answer. <Annotation annotationId="060020redbank" visited={visitedNotes.has("060020redbank")} annotationSelect={() => {openNote("060020redbank"); addToVisited("060020redbank")}} activeAnnotationId={currentNoteId}>Redbank oysters</Annotation> will
+        claws.)</i> Stay, good friend. I bring thee thy answer. <Annotation annotationId="060020redbank">Redbank oysters</Annotation> will
         shortly be upon us. I'm the best o'cook. Those succulent bivalves may
         help us and the truffles of Perigord, tubers dislodged through mister
         omnivorous porker, were unsurpassed in cases of nervous debility or
@@ -5189,7 +5189,7 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         FLORRY
       </p>
       <p>
-        Sing us something. <Annotation annotationId="040035oldsweetsong" visited={visitedNotes.has("040035oldsweetsong")} annotationSelect={() => {openNote("040035oldsweetsong"); addToVisited("040035oldsweetsong")}} activeAnnotationId={currentNoteId}>Love's old sweet song.</Annotation>
+        Sing us something. <Annotation annotationId="040035oldsweetsong">Love's old sweet song.</Annotation>
       </p>
       <span data-edition="ed1932" data-page="454"> </span>
       <p>
@@ -5206,7 +5206,7 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         <i>(Smirking.)</i> The bird that can sing and won't sing.
       </p>
       <p>
-        <i>(The Siamese twins, Philip Drunk and Philip Sober, <Annotation annotationId="010022hellenise" visited={visitedNotes.has("010022hellenise")} annotationSelect={() => {openNote("010022hellenise"); addToVisited("010022hellenise")}} activeAnnotationId={currentNoteId}>two Oxford dons with
+        <i>(The Siamese twins, Philip Drunk and Philip Sober, <Annotation annotationId="010022hellenise">two Oxford dons with
         lawnmowers, appear in the window embrasure. Both are masked with Matthew
         Arnold's face.</Annotation>)</i>
       </p>
@@ -5217,7 +5217,7 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       <p>
         Take a fool's advice. All is not well. Work it out with
         the buttend of a pencil, like a good young idiot. Three pounds twelve
-        you got, two notes, one sovereign, two crowns, <Annotation annotationId="020033mademoney" visited={visitedNotes.has("020033mademoney")} annotationSelect={() => {openNote("020033mademoney"); addToVisited("020033mademoney")}} activeAnnotationId={currentNoteId}>if youth but knew</Annotation>.
+        you got, two notes, one sovereign, two crowns, <Annotation annotationId="020033mademoney">if youth but knew</Annotation>.
         Mooney's en ville, Mooney's sur mer, the Moira, Larchet's, Holles street
         hospital, Burke's. Eh? I am watching you.
       </p>
@@ -5354,7 +5354,7 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         PHILIP DRUNK
       </p>
       <p>
-        <i>(Gravely.) <Annotation annotationId="010150fatherbird" visited={visitedNotes.has("010150fatherbird")} annotationSelect={() => {openNote("010150fatherbird"); addToVisited("010150fatherbird")}} activeAnnotationId={currentNoteId}>Qui vous a mis dans cette fichue position</Annotation>,
+        <i>(Gravely.) <Annotation annotationId="010150fatherbird">Qui vous a mis dans cette fichue position</Annotation>,
         Philippe?</i>
       </p>
       <p>
@@ -5448,7 +5448,7 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         HENRY
       </p>
       <p>
-        <i><Annotation annotationId="050026henryflower" visited={visitedNotes.has("050026henryflower")} annotationSelect={() => {openNote("050026henryflower"); addToVisited("050026henryflower")}} activeAnnotationId={currentNoteId}>(Caressing on his breast a severed female head, murmurs.)</Annotation></i>Thine
+        <i><Annotation annotationId="050026henryflower">(Caressing on his breast a severed female head, murmurs.)</Annotation></i>Thine
         heart, mine love. <i>(He plucks his lutestrings.)</i> When first I saw...
       </p>
         <p>
@@ -5500,7 +5500,7 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       <p>
         <i>(Over his shoulder to Zoe.)</i> You would have preferred
         the fighting parson who founded the protestant error. But beware
-        Antisthenes, the dog sage, and<Annotation annotationId="030040arius" visited={visitedNotes.has("030040arius")} annotationSelect={() => {openNote("030040arius"); addToVisited("030040arius")}} activeAnnotationId={currentNoteId}>the last end of Arius Heresiarchus. The
+        Antisthenes, the dog sage, and<Annotation annotationId="030040arius">the last end of Arius Heresiarchus. The
         agony in the closet.</Annotation>
       </p>
       <span data-edition="ed1986" data-page="426"> </span>
@@ -5986,7 +5986,7 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       <p>
         <i>(With bobbed hair, purple gills, fit moustache rings round his
         shaven mouth, in mountaineer's puttees, green silverbuttoned coat, sport
-        skirt and <Annotation annotationId="010075featherfans" visited={visitedNotes.has("010075featherfans")} annotationSelect={() => {openNote("010075featherfans"); addToVisited("010075featherfans")}} activeAnnotationId={currentNoteId}>alpine hat with moorcock's feather</Annotation>, his hands stuck deep in
+        skirt and <Annotation annotationId="010075featherfans">alpine hat with moorcock's feather</Annotation>, his hands stuck deep in
         his breeches pockets, places his heel on her neck and grinds it in.)</i>
         Footstool! Feel my entire weight. Bow, bondslave, before the throne of
         your despot's glorious heels so glistening in their proud erectness.
@@ -6139,7 +6139,7 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <p>
         <i>(The brothel cook, Mrs Keogh, wrinkled, greybearded, in a greasy bib,
-        men's grey and green socks and <Annotation annotationId="020076brogues" visited={visitedNotes.has("020076brogues")} annotationSelect={() => {openNote("020076brogues"); addToVisited("020076brogues")}} activeAnnotationId={currentNoteId}>brogues</Annotation>,</i> <span data-edition="ed1961" data-page="533"> </span><i>floursmeared, a rollingpin stuck
+        men's grey and green socks and <Annotation annotationId="020076brogues">brogues</Annotation>,</i> <span data-edition="ed1961" data-page="533"> </span><i>floursmeared, a rollingpin stuck
         with raw pastry in her bare red arm and hand, appears at the door.)</i>
       </p>
       <p>
@@ -6154,7 +6154,7 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       <p>
         <i>(Squats with a grunt on Bloom's upturned face, puffing
         cigarsmoke, nursing a fat leg.)</i> I see Keating Clay is elected
-        vicechairman of <Annotation annotationId="010050dottyville" visited={visitedNotes.has("010050dottyville")} annotationSelect={() => {openNote("010050dottyville"); addToVisited("010050dottyville")}} activeAnnotationId={currentNoteId}>the Richmond asylum</Annotation> and by the by Guinness's preference
+        vicechairman of <Annotation annotationId="010050dottyville">the Richmond asylum</Annotation> and by the by Guinness's preference
         shares are at sixteen three quarters. Curse me for a fool that didn't
         buy that lot Craig and Gardner told me about. Just my infernal luck,
         curse it. And that Goddamned outsider <i>Throwaway</i> at twenty 
@@ -6227,7 +6227,7 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         <i>(Stands up.)</i> No more blow hot and cold. What you longed for has
         come to pass. Henceforth you are unmanned and mine in earnest, a thing
         under the yoke. Now for your punishment frock. You will shed your male
-        garments, you understand, <Annotation annotationId="040021ruby" visited={visitedNotes.has("040021ruby")} annotationSelect={() => {openNote("040021ruby"); addToVisited("040021ruby")}} activeAnnotationId={currentNoteId}>Ruby Cohen</Annotation>? and don the shot silk luxuriously
+        garments, you understand, <Annotation annotationId="040021ruby">Ruby Cohen</Annotation>? and don the shot silk luxuriously
         rustling over head and shoulders and quickly too.
       </p>
       <span data-edition="ed1922" data-page="501"> </span>
@@ -6252,7 +6252,7 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         pretty two ounce petticoats and fringes and things stamped, of course,
         with my houseflag, creations of lovely lingerie for Alice and 
         <span data-edition="ed1939" data-page="378"> </span>
-        nice scent for Alice. Alice will feel the pullpull. <Annotation annotationId="050027marthamary" visited={visitedNotes.has("050027marthamary")} annotationSelect={() => {openNote("050027marthamary"); addToVisited("050027marthamary")}} activeAnnotationId={currentNoteId}>Martha and</Annotation> <span data-edition="ed1961" data-page="535"> </span><Annotation annotationId="050027marthamary" visited={visitedNotes.has("050027marthamary")} annotationSelect={() => {openNote("050027marthamary"); addToVisited("050027marthamary")}} activeAnnotationId={currentNoteId}>Mary</Annotation> will be
+        nice scent for Alice. Alice will feel the pullpull. <Annotation annotationId="050027marthamary">Martha and</Annotation> <span data-edition="ed1961" data-page="535"> </span><Annotation annotationId="050027marthamary">Mary</Annotation> will be
         a little chilly at first in such delicate thighcasing but the frilly
         flimsiness of lace round your bare knees will remind you...
       </p>
@@ -6273,7 +6273,7 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         <i>(Jeers.)</i> Little jobs that make mother pleased, eh? And showed
         off coquettishly in your domino at the mirror behind closedrawn blinds
         your unskirted thighs and hegoat's udders in various poses of surrender,
-        eh? Ho! ho! I have to laugh! <Annotation annotationId="080016shelbourne" visited={visitedNotes.has("080016shelbourne")} annotationSelect={() => {openNote("080016shelbourne"); addToVisited("080016shelbourne")}} activeAnnotationId={currentNoteId}>That secondhand black operatop shift and
+        eh? Ho! ho! I have to laugh! <Annotation annotationId="080016shelbourne">That secondhand black operatop shift and
         short trunkleg naughties all split up the stitches at her last rape that
         Mrs Miriam Dandrade sold you from the Shelbourne hotel</Annotation>, eh?
       </p>
@@ -6305,7 +6305,7 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <p>
         <i>(Her hands and features working.)</i> It was Gerald converted me to
-        be a true corsetlover when I was female impersonator in the <Annotation annotationId="050020highschool" visited={visitedNotes.has("050020highschool")} annotationSelect={() => {openNote("050020highschool"); addToVisited("050020highschool")}} activeAnnotationId={currentNoteId}>High School</Annotation>
+        be a true corsetlover when I was female impersonator in the <Annotation annotationId="050020highschool">High School</Annotation>
         play <i>Vice Versa</i>. It was dear Gerald. He got <span data-edition="ed1961" data-page="536"> </span>that kink, fascinated by
         sister's stays. Now dearest Gerald uses pinky greasepaint and gilds his
         eyelids. Cult of the beautiful.
@@ -6315,7 +6315,7 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <p>
         <i>(With wicked glee.)</i> Beautiful! Give us a breather! When you
-        took your seat with womanish care, <Annotation annotationId="010086maryann" visited={visitedNotes.has("010086maryann")} annotationSelect={() => {openNote("010086maryann"); addToVisited("010086maryann")}} activeAnnotationId={currentNoteId}>lifting your billowy flounces, on the
+        took your seat with womanish care, <Annotation annotationId="010086maryann">lifting your billowy flounces, on the
         smoothworn throne</Annotation>.
       </p>
       <p>
@@ -6330,7 +6330,7 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         BELLO
       </p>
       <p>
-        <i>(Sternly.)</i> No insubordination! <Annotation annotationId="080022sawdust" visited={visitedNotes.has("080022sawdust")} annotationSelect={() => {openNote("080022sawdust"); addToVisited("080022sawdust")}} activeAnnotationId={currentNoteId}>The sawdust is there in the
+        <i>(Sternly.)</i> No insubordination! <Annotation annotationId="080022sawdust">The sawdust is there in the
         corner for you.</Annotation> I gave you strict instructions, didn't I? Do it
         standing, sir! I'll teach you to behave like a 
         <span data-edition="ed1939" data-page="379"> </span>
@@ -6368,7 +6368,7 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <p>
         <i>(Mute inhuman faces throng forward, leering, vanishing, gibbering,
-        Booloohoom. <Annotation annotationId="040003nicename" visited={visitedNotes.has("040003nicename")} annotationSelect={() => {openNote("040003nicename"); addToVisited("040003nicename")}} activeAnnotationId={currentNoteId}>Poldy Kock</Annotation>, Bootlaces a penny, Cassidy's hag, blind</i>
+        Booloohoom. <Annotation annotationId="040003nicename">Poldy Kock</Annotation>, Bootlaces a penny, Cassidy's hag, blind</i>
         <span data-edition="ed1986" data-page="438"> </span><i>stripling, Larry Rhinoceros, the girl, the woman, the whore, the other,
         the...)</i>
       </p>
@@ -6420,7 +6420,7 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         with dress pinned up and a dishclout 
         <span data-edition="ed1939" data-page="380"> </span>
         tied to your tail. <span data-edition="ed1961" data-page="538"> </span>Won't that be
-        nice? <i>(He places <Annotation annotationId="040021ruby" visited={visitedNotes.has("040021ruby")} annotationSelect={() => {openNote("040021ruby"); addToVisited("040021ruby")}} activeAnnotationId={currentNoteId}>a ruby ring</Annotation> on her finger.)</i> And there now! With this
+        nice? <i>(He places <Annotation annotationId="040021ruby">a ruby ring</Annotation> on her finger.)</i> And there now! With this
         ring I thee own. Say, thank you, mistress.
       </p>
       <p>
@@ -6497,7 +6497,7 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         stockgetter, due to lay within the hour. His
         sire's milk record was a thousand gallons of whole milk in forty weeks.
         Whoa my jewel! Beg up! Whoa! <i>(He brands his initial C on Bloom's
-        croup.)</i> So! Warranted Cohen! What advance on <Annotation annotationId="010019money" visited={visitedNotes.has("010019money")} annotationSelect={() => {openNote("010019money"); addToVisited("010019money")}} activeAnnotationId={currentNoteId}>two bob</Annotation>, gentlemen?
+        croup.)</i> So! Warranted Cohen! What advance on <Annotation annotationId="010019money">two bob</Annotation>, gentlemen?
       </p>
       <span data-edition="ed1939" data-page="381"> </span>
       <p>
@@ -6510,7 +6510,7 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         VOICES
       </p>
       <p>
-        <i>(Subdued.)</i> For <Annotation annotationId="030055samedream" visited={visitedNotes.has("030055samedream")} annotationSelect={() => {openNote("030055samedream"); addToVisited("030055samedream")}} activeAnnotationId={currentNoteId}>the Caliph. Haroun Al Raschid.</Annotation>
+        <i>(Subdued.)</i> For <Annotation annotationId="030055samedream">the Caliph. Haroun Al Raschid.</Annotation>
       </p>
       <p>
         BELLO
@@ -6563,7 +6563,7 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         <span data-edition="ed1922" data-page="506"> </span>
         bolt, I can tell you! Foot to foot, knee to knee,
         belly to belly, bubs to breast! He's no eunuch. A shock of red hair he
-        has sticking out of him behind like <Annotation annotationId="120008gorse" visited={visitedNotes.has("120008gorse")} annotationSelect={() => {openNote("120008gorse"); addToVisited("120008gorse")}} activeAnnotationId={currentNoteId}>a furzebush</Annotation>! Wait for nine months,
+        has sticking out of him behind like <Annotation annotationId="120008gorse">a furzebush</Annotation>! Wait for nine months,
         my lad! Holy ginger, it's kicking and coughing up and down in her guts
         already! That makes you wild, don't it? Touches the spot? <i>(He spits in
         contempt.)</i> Spittoon!
@@ -6622,7 +6622,7 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <p>
         <i>(Laughs mockingly.)</i> That's your daughter, you owl, with a
-        <Annotation annotationId="010126mullingar" visited={visitedNotes.has("010126mullingar")} annotationSelect={() => {openNote("010126mullingar"); addToVisited("010126mullingar")}} activeAnnotationId={currentNoteId}>Mullingar student</Annotation>.
+        <Annotation annotationId="010126mullingar">Mullingar student</Annotation>.
       </p>
       <span data-edition="ed1932" data-page="472"> </span>
       <p>
@@ -6662,7 +6662,7 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       <p>
         <i>(Cuttingly.)</i> Their heelmarks will stamp the Brusselette carpet
         you bought at Wren's auction. In their horseplay with Moll the romp to
-        find the buck flea in her breeches they will deface <Annotation annotationId="080005venus" visited={visitedNotes.has("080005venus")} annotationSelect={() => {openNote("080005venus"); addToVisited("080005venus")}} activeAnnotationId={currentNoteId}>the little statue
+        find the buck flea in her breeches they will deface <Annotation annotationId="080005venus">the little statue
         you carried home</Annotation> in the rain for art for art's sake. They will violate
         the secrets of your bottom drawer. Pages will be torn from your handbook
         of astronomy to make them pipespills. And they will spit in your ten
@@ -6712,7 +6712,7 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         about you. I can give you a rare old wine that'll send <span data-edition="ed1961" data-page="543"> </span>you
         skipping to hell and back. Sign a will and leave us any coin you have!
         If you have none see you damn well get it, steal it, rob it! We'll bury
-        you in our shrubbery jakes where you'll be dead and dirty with old <Annotation annotationId="040093cuckstool" visited={visitedNotes.has("040093cuckstool")} annotationSelect={() => {openNote("040093cuckstool"); addToVisited("040093cuckstool")}} activeAnnotationId={currentNoteId}>Cuck
+        you in our shrubbery jakes where you'll be dead and dirty with old <Annotation annotationId="040093cuckstool">Cuck
         Cohen</Annotation>, my stepnephew I married, the bloody old gouty procurator and
         sodomite with a crick in his neck, and my other ten or eleven husbands,
         whatever the buggers' names were, suffocated in the one cesspool. <i>(He
@@ -6724,7 +6724,7 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         BLOOM
       </p>
       <p>
-        <i>(Clasps his head.)</i> My willpower! Memory! <Annotation annotationId="050033eccehomo" visited={visitedNotes.has("050033eccehomo")} annotationSelect={() => {openNote("050033eccehomo"); addToVisited("050033eccehomo")}} activeAnnotationId={currentNoteId}>I have sinned! I have
+        <i>(Clasps his head.)</i> My willpower! Memory! <Annotation annotationId="050033eccehomo">I have sinned! I have
         suff...</Annotation>
       </p>
       <p>
@@ -6762,8 +6762,8 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <p>
         <i>(From the suttee pyre the flame of gum camphire ascends. The pall of
-        incense smoke screens and disperses. <Annotation annotationId="040048slimmer" visited={visitedNotes.has("040048slimmer")} annotationSelect={() => {openNote("040048slimmer"); addToVisited("040048slimmer")}} activeAnnotationId={currentNoteId}>Out of her oakframe a nymph with
-        hair unbound, lightly clad in</Annotation></i> <span data-edition="ed1961" data-page="544"> </span><Annotation annotationId="040048slimmer" visited={visitedNotes.has("040048slimmer")} annotationSelect={() => {openNote("040048slimmer"); addToVisited("040048slimmer")}} activeAnnotationId={currentNoteId}><i>teabrown artcolours</i></Annotation>, <i>descends from her
+        incense smoke screens and disperses. <Annotation annotationId="040048slimmer">Out of her oakframe a nymph with
+        hair unbound, lightly clad in</Annotation></i> <span data-edition="ed1961" data-page="544"> </span><Annotation annotationId="040048slimmer"><i>teabrown artcolours</i></Annotation>, <i>descends from her
         grotto and passing under interlacing yews stands over Bloom.)</i>
       </p>
       <span data-edition="ed1939" data-page="384"> </span>
@@ -6794,7 +6794,7 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <p>
         Mortal! You found me in evil company, highkickers, coster
-        picnicmakers, pugilists, popular generals, immoral <Annotation annotationId="010077pantomime" visited={visitedNotes.has("010077pantomime")} annotationSelect={() => {openNote("010077pantomime"); addToVisited("010077pantomime")}} activeAnnotationId={currentNoteId}>panto boys</Annotation> in
+        picnicmakers, pugilists, popular generals, immoral <Annotation annotationId="010077pantomime">panto boys</Annotation> in
         fleshtights and the nifty shimmy dancers, La Aurora and Karini, musical
         act, the hit of the century. I was hidden in cheap pink paper that smelt
         of rock oil. I was surrounded <span data-edition="ed1986" data-page="444"> </span>by the stale smut of clubmen, stories to
@@ -6823,7 +6823,7 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         BLOOM
       </p>
       <p>
-        You mean <Annotation annotationId="040034photobits" visited={visitedNotes.has("040034photobits")} annotationSelect={() => {openNote("040034photobits"); addToVisited("040034photobits")}} activeAnnotationId={currentNoteId}><i>Photo Bits?</i></Annotation>
+        You mean <Annotation annotationId="040034photobits"><i>Photo Bits?</i></Annotation>
       </p>
       <p>
         THE NYMPH
@@ -6896,7 +6896,7 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <p>
         <i>(Apologetically.)</i> I know. Soiled personal linen, wrong side up
-        with care. <Annotation annotationId="040085brassquoits" visited={visitedNotes.has("040085brassquoits")} annotationSelect={() => {openNote("040085brassquoits"); addToVisited("040085brassquoits")}} activeAnnotationId={currentNoteId}>The quoits are loose. From Gibraltar by long sea long ago.</Annotation>
+        with care. <Annotation annotationId="040085brassquoits">The quoits are loose. From Gibraltar by long sea long ago.</Annotation>
       </p>
       <p>
         THE NYMPH
@@ -6909,9 +6909,9 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <p>
         <i>(Reflects precautiously.)</i> That antiquated commode. It wasn't her
-        weight. She scaled just eleven stone nine. <Annotation annotationId="040048slimmer" visited={visitedNotes.has("040048slimmer")} annotationSelect={() => {openNote("040048slimmer"); addToVisited("040048slimmer")}} activeAnnotationId={currentNoteId}>She put on nine pounds
+        weight. She scaled just eleven stone nine. <Annotation annotationId="040048slimmer">She put on nine pounds
         after weaning.</Annotation> It was a crack and want of glue. Eh? And that absurd
-        <Annotation annotationId="040057orangekeyed" visited={visitedNotes.has("040057orangekeyed")} annotationSelect={() => {openNote("040057orangekeyed"); addToVisited("040057orangekeyed")}} activeAnnotationId={currentNoteId}>orangekeyed utensil</Annotation> which has only one handle.
+        <Annotation annotationId="040057orangekeyed">orangekeyed utensil</Annotation> which has only one handle.
       </p>
       <p>
         <i>(The sound of a waterfall is heard in bright cascade.)</i>
@@ -6945,7 +6945,7 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         THE YEWS
       </p>
       <p>
-        <i>(Murmuring.)</i> Who came to Poulaphouca with the <Annotation annotationId="050020highschool" visited={visitedNotes.has("050020highschool")} annotationSelect={() => {openNote("050020highschool"); addToVisited("050020highschool")}} activeAnnotationId={currentNoteId}>High School
+        <i>(Murmuring.)</i> Who came to Poulaphouca with the <Annotation annotationId="050020highschool">High School
         excursion</Annotation>? Who left his nutquesting classmates to seek our shade?
       </p>
       <span data-edition="ed1939" data-page="386"> </span>
@@ -7088,7 +7088,7 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <p>
         <i>(Hatless, flushed, covered with burrs of thistledown and
-        <Annotation annotationId="120008gorse" visited={visitedNotes.has("120008gorse")} annotationSelect={() => {openNote("120008gorse"); addToVisited("120008gorse")}} activeAnnotationId={currentNoteId}>gorsespine</Annotation>.)</i> Regularly 
+        <Annotation annotationId="120008gorse">gorsespine</Annotation>.)</i> Regularly 
         <span data-edition="ed1922" data-page="513"> </span>
         engaged. Circumstances alter cases. <i>(He gazes
         intently downwards on the water.)</i> Thirtytwo head over heels per second.
@@ -7104,11 +7104,11 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         Bbbbblllllblblblblodschbg?
       </p>
       <p>
-        <Annotation annotationId="030013kishlightship" visited={visitedNotes.has("030013kishlightship")} annotationSelect={() => {openNote("030013kishlightship"); addToVisited("030013kishlightship")}} activeAnnotationId={currentNoteId}><i>(Far out in the bay between Bailey and Kish lights the Erin's King sails</i></Annotation><i>, sending a broadening plume of coalsmoke from her funnel towards
+        <Annotation annotationId="030013kishlightship"><i>(Far out in the bay between Bailey and Kish lights the Erin's King sails</i></Annotation><i>, sending a broadening plume of coalsmoke from her funnel towards
         the land.)</i>
       </p>
       <p>
-        <Annotation annotationId="070019nannetti" visited={visitedNotes.has("070019nannetti")} annotationSelect={() => {openNote("070019nannetti"); addToVisited("070019nannetti")}} activeAnnotationId={currentNoteId}>COUNCILLOR NANNETTI</Annotation>
+        <Annotation annotationId="070019nannetti">COUNCILLOR NANNETTI</Annotation>
       </p>
       <p>
         <i>(Alone on deck, in dark alpaca, yellowkitefaced,
@@ -7127,7 +7127,7 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         THE NYMPH
       </p>
       <p>
-        <i>(Loftily.)</i> <Annotation annotationId="150015nohairthere" visited={visitedNotes.has("150015nohairthere")} annotationSelect={() => {openNote("150015nohairthere"); addToVisited("150015nohairthere")}} activeAnnotationId={currentNoteId}>We immortals, as you saw today, have not such
+        <i>(Loftily.)</i> <Annotation annotationId="150015nohairthere">We immortals, as you saw today, have not such
         a place and no hair there either. We are stonecold and pure. We eat
         electric light.</Annotation> <i>(She arches her body in lascivious crispation, placing
         her forefinger in her mouth.)</i> Spoke to me. Heard from behind. How then
@@ -7597,7 +7597,7 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         STEPHEN
       </p>
       <p>
-        How is that? <i>Le distrait</i> or <Annotation annotationId="090001absentminded" visited={visitedNotes.has("090001absentminded")} annotationSelect={() => {openNote("090001absentminded"); addToVisited("090001absentminded")}} activeAnnotationId={currentNoteId}>absentminded beggar</Annotation>. <i>(He
+        How is that? <i>Le distrait</i> or <Annotation annotationId="090001absentminded">absentminded beggar</Annotation>. <i>(He
         fumbles again in his pocket and draws out a handful of coins. An object
         falls.)</i> That fell.
       </p>
@@ -7611,7 +7611,7 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         STEPHEN
       </p>
       <p>
-        <Annotation annotationId="150013matches" visited={visitedNotes.has("150013matches")} annotationSelect={() => {openNote("150013matches"); addToVisited("150013matches")}} activeAnnotationId={currentNoteId}>Lucifer.</Annotation> Thanks.
+        <Annotation annotationId="150013matches">Lucifer.</Annotation> Thanks.
       </p>
       <span data-edition="ed1986" data-page="455"> </span><span data-edition="ed1961" data-page="558"> </span>
       <p>
@@ -7639,15 +7639,15 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         STEPHEN
       </p>
       <p>
-        Why striking eleven? Proparoxyton. <Annotation annotationId="030009laocoon" visited={visitedNotes.has("030009laocoon")} annotationSelect={() => {openNote("030009laocoon"); addToVisited("030009laocoon")}} activeAnnotationId={currentNoteId}>Moment before the next
-        Lessing says.</Annotation> Thirsty fox. <i>(He laughs loudly.)</i> <Annotation annotationId="020009ghoststory" visited={visitedNotes.has("020009ghoststory")} annotationSelect={() => {openNote("020009ghoststory"); addToVisited("020009ghoststory")}} activeAnnotationId={currentNoteId}>Burying his grandmother.
+        Why striking eleven? Proparoxyton. <Annotation annotationId="030009laocoon">Moment before the next
+        Lessing says.</Annotation> Thirsty fox. <i>(He laughs loudly.)</i> <Annotation annotationId="020009ghoststory">Burying his grandmother.
         Probably he killed her.</Annotation>
       </p>
       <p>
         BLOOM
       </p>
       <p>
-        That is <Annotation annotationId="020035owenothing" visited={visitedNotes.has("020035owenothing")} annotationSelect={() => {openNote("020035owenothing"); addToVisited("020035owenothing")}} activeAnnotationId={currentNoteId}>one pound six and eleven</Annotation>. One pound seven, say.
+        That is <Annotation annotationId="020035owenothing">one pound six and eleven</Annotation>. One pound seven, say.
       </p>
       <p>
         STEPHEN
@@ -7769,7 +7769,7 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         ZOE
       </p>
       <p>
-        <i>(Turns.)</i> Ask my ballocks that I haven't got. <i>(To Stephen.)</i> <Annotation annotationId="070010seeitin" visited={visitedNotes.has("070010seeitin")} annotationSelect={() => {openNote("070010seeitin"); addToVisited("070010seeitin")}} activeAnnotationId={currentNoteId}>I see
+        <i>(Turns.)</i> Ask my ballocks that I haven't got. <i>(To Stephen.)</i> <Annotation annotationId="070010seeitin">I see
         it in your face.</Annotation> The eye, like that. <i>(She frowns with lowered head.)</i>
       </p>
       <span data-edition="ed1986" data-page="457"> </span>
@@ -7787,11 +7787,11 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         FATHER DOLAN
       </p>
       <p>
-        <Annotation annotationId="070010seeitin" visited={visitedNotes.has("070010seeitin")} annotationSelect={() => {openNote("070010seeitin"); addToVisited("070010seeitin")}} activeAnnotationId={currentNoteId}>Any boy want flogging? Broke his glasses? Lazy idle little
+        <Annotation annotationId="070010seeitin">Any boy want flogging? Broke his glasses? Lazy idle little
         schemer. See it in your eye.</Annotation>
       </p>
       <p>
-        <i>(Mild, benign, rectorial, reproving, the head of <Annotation annotationId="050052conmee" visited={visitedNotes.has("050052conmee")} annotationSelect={() => {openNote("050052conmee"); addToVisited("050052conmee")}} activeAnnotationId={currentNoteId}>Don John Conmee</Annotation> rises
+        <i>(Mild, benign, rectorial, reproving, the head of <Annotation annotationId="050052conmee">Don John Conmee</Annotation> rises
         from the pianola coffin.)</i>
       </p>
       <p>
@@ -7832,7 +7832,7 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         ZOE
       </p>
       <p>
-        <Annotation annotationId="010121applause" visited={visitedNotes.has("010121applause")} annotationSelect={() => {openNote("010121applause"); addToVisited("010121applause")}} activeAnnotationId={currentNoteId}>Thursday's child has far to go.</Annotation> <i>(She traces lines on his hand.)</i>
+        <Annotation annotationId="010121applause">Thursday's child has far to go.</Annotation> <i>(She traces lines on his hand.)</i>
         Line of fate. Influential friends.
       </p>
       <p>
@@ -7918,10 +7918,10 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         STEPHEN
       </p>
       <p>
-        See? <Annotation annotationId="020067onegreatgoal" visited={visitedNotes.has("020067onegreatgoal")} annotationSelect={() => {openNote("020067onegreatgoal"); addToVisited("020067onegreatgoal")}} activeAnnotationId={currentNoteId}>Moves to one great goal.</Annotation> I am twentytwo. Sixteen years ago
+        See? <Annotation annotationId="020067onegreatgoal">Moves to one great goal.</Annotation> I am twentytwo. Sixteen years ago
         he was twentytwo too. Sixteen years ago I twentytwo tumbled. Twentytwo
         years ago he sixteen fell off his hobbyhorse. <i>(He winces.)</i> Hurt my hand
-        somewhere. <Annotation annotationId="010130toothless" visited={visitedNotes.has("010130toothless")} annotationSelect={() => {openNote("010130toothless"); addToVisited("010130toothless")}} activeAnnotationId={currentNoteId}>Must see a dentist.</Annotation> Money?
+        somewhere. <Annotation annotationId="010130toothless">Must see a dentist.</Annotation> Money?
       </p>
       <p>
         <i>(Zoe whispers to Florry. They giggle. Bloom releases his hand and
@@ -7935,9 +7935,9 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         What?
       </p>
       <p>
-        <i><Annotation annotationId="050013jauntingcar" visited={visitedNotes.has("050013jauntingcar")} annotationSelect={() => {openNote("050013jauntingcar"); addToVisited("050013jauntingcar")}} activeAnnotationId={currentNoteId}>A hackneycar, number three hundred and twentyfour</Annotation>, with a
+        <i><Annotation annotationId="050013jauntingcar">A hackneycar, number three hundred and twentyfour</Annotation>, with a
         gallantbuttocked mare, driven by James Barton, Harmony</i> <span data-edition="ed1961" data-page="563"> </span><i>Avenue,
-        <Annotation annotationId="050022donnybrook" visited={visitedNotes.has("050022donnybrook")} annotationSelect={() => {openNote("050022donnybrook"); addToVisited("050022donnybrook")}} activeAnnotationId={currentNoteId}>Donnybrook</Annotation>, trots past. Blazes Boylan and Lenehan sprawl swaying on the
+        <Annotation annotationId="050022donnybrook">Donnybrook</Annotation>, trots past. Blazes Boylan and Lenehan sprawl swaying on the
         sideseats. The Ormond boots crouches behind on the axle. Sadly over the
         crossblind Lydia Douce and Mina Kennedy gaze.)</i>
       </p>
@@ -8021,7 +8021,7 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         BLOOM
       </p>
       <p>
-        <i>(<Annotation annotationId="150002applyeye" visited={visitedNotes.has("150002applyeye")} annotationSelect={() => {openNote("150002applyeye"); addToVisited("150002applyeye")}} activeAnnotationId={currentNoteId}>In flunkey's prune plush coat and kneebreeches</Annotation>, buff stockings
+        <i>(<Annotation annotationId="150002applyeye">In flunkey's prune plush coat and kneebreeches</Annotation>, buff stockings
         and powdered wig.)</i> I'm afraid not, sir. The last articles...
       </p>
       <p>
@@ -8036,7 +8036,7 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         BLOOM
       </p>
       <p>
-        Thank you, sir. Yes, sir. <Annotation annotationId="040056mrsmarion" visited={visitedNotes.has("040056mrsmarion")} annotationSelect={() => {openNote("040056mrsmarion"); addToVisited("040056mrsmarion")}} activeAnnotationId={currentNoteId}>Madam Tweedy</Annotation> is in her bath, sir.
+        Thank you, sir. Yes, sir. <Annotation annotationId="040056mrsmarion">Madam Tweedy</Annotation> is in her bath, sir.
       </p>
       <span data-edition="ed1922" data-page="526"> </span>
       <p>
@@ -8068,7 +8068,7 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         MARION
       </p>
       <p>
-        Let him look, the <Annotation annotationId="120015pishogue" visited={visitedNotes.has("120015pishogue")} annotationSelect={() => {openNote("120015pishogue"); addToVisited("120015pishogue")}} activeAnnotationId={currentNoteId}>pishogue</Annotation>! Pimp! And scourge himself! I'll
+        Let him look, the <Annotation annotationId="120015pishogue">pishogue</Annotation>! Pimp! And scourge himself! I'll
         write to a powerful prostitute or Bartholomona, the bearded woman, to
         raise weals out on him an inch thick and make him bring me back a signed
         and stamped receipt.
@@ -8091,7 +8091,7 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         BOYLAN
       </p>
       <p>
-        <i>(To Bloom, over his shoulder.)</i> You can <Annotation annotationId="150002applyeye" visited={visitedNotes.has("150002applyeye")} annotationSelect={() => {openNote("150002applyeye"); addToVisited("150002applyeye")}} activeAnnotationId={currentNoteId}>apply your eye to the
+        <i>(To Bloom, over his shoulder.)</i> You can <Annotation annotationId="150002applyeye">apply your eye to the
         keyhole</Annotation> and play with yourself while I just go through her a few times.
       </p>
       <p>
@@ -8099,7 +8099,7 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <p>
         Thank you, sir. I will, sir. May I bring two men chums to witness
-        the deed and <Annotation annotationId="150002applyeye" visited={visitedNotes.has("150002applyeye")} annotationSelect={() => {openNote("150002applyeye"); addToVisited("150002applyeye")}} activeAnnotationId={currentNoteId}>take a snapshot</Annotation>? <i>(He holds out an ointment jar.)</i> Vaseline,
+        the deed and <Annotation annotationId="150002applyeye">take a snapshot</Annotation>? <i>(He holds out an ointment jar.)</i> Vaseline,
         sir? Orangeflower...? Lukewarm water...?
       </p>
       <p>
@@ -8154,7 +8154,7 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         BLOOM
       </p>
       <p>
-        <i>(His eyes wildly dilated, clasps himself.)</i> <Annotation annotationId="150002applyeye" visited={visitedNotes.has("150002applyeye")} annotationSelect={() => {openNote("150002applyeye"); addToVisited("150002applyeye")}} activeAnnotationId={currentNoteId}>Show! Hide! Show!
+        <i>(His eyes wildly dilated, clasps himself.)</i> <Annotation annotationId="150002applyeye">Show! Hide! Show!
         Plough her! More! Shoot!</Annotation>
       </p>
       <span data-edition="ed1986" data-page="462"> </span>
@@ -8182,7 +8182,7 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <p>
         <i>(In dignified ventriloquy.)</i> 'Tis the loud laugh bespeaks
-        the vacant mind. <i>(To Bloom.)</i> <Annotation annotationId="010078invisibility" visited={visitedNotes.has("010078invisibility")} annotationSelect={() => {openNote("010078invisibility"); addToVisited("010078invisibility")}} activeAnnotationId={currentNoteId}>Thou thoughtest as how thou wastest
+        the vacant mind. <i>(To Bloom.)</i> <Annotation annotationId="010078invisibility">Thou thoughtest as how thou wastest
         invisible.</Annotation> Gaze. <i>(He crows with a black capon's laugh.)</i> Iagogo! How my
         Oldfellow chokit his Thursdaymornun. Iagogogo!
       </p>
@@ -8214,7 +8214,7 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         her bonnet awry, rouging and powdering her cheeks, lips and nose, a
         pen chivvying her brood of cygnets. Beneath her skirt appear her late
         husband's everyday trousers and turnedup boots, large eights. She holds
-        <Annotation annotationId="130007scottishwidows" visited={visitedNotes.has("130007scottishwidows")} annotationSelect={() => {openNote("130007scottishwidows"); addToVisited("130007scottishwidows")}} activeAnnotationId={currentNoteId}>a Scottish widows' insurance policy</Annotation> and a large marquee umbrella under
+        <Annotation annotationId="130007scottishwidows">a Scottish widows' insurance policy</Annotation> and a large marquee umbrella under
         which her brood run with her, Patsy hopping on one shod foot, his collar
         loose, a hank of porksteaks dangling, Freddy whimpering, Susy with a
         crying cod's mouth, Alice struggling with the baby. She cuffs them on,
@@ -8240,7 +8240,7 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         <i>(With paralytic rage.)</i> Weda seca whokilla farst.
       </p>
       <p>
-        <i>(<Annotation annotationId="060034martincunningham" visited={visitedNotes.has("060034martincunningham")} annotationSelect={() => {openNote("060034martincunningham"); addToVisited("060034martincunningham")}} activeAnnotationId={currentNoteId}>The face of Martin Cunningham, bearded, refeatures Shakespeare's
+        <i>(<Annotation annotationId="060034martincunningham">The face of Martin Cunningham, bearded, refeatures Shakespeare's
         beardless face.</Annotation> The marquee umbrella sways drunkenly, the children run
         aside. Under the umbrella appears Mrs Cunningham in Merry Widow hat and
         kimono gown. She glides sidling and bowing, twirling japanesily.)</i>
@@ -8269,10 +8269,10 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         STEPHEN
       </p>
       <p>
-        <i>Et exaltabuntur cornua iusti.</i> <Annotation annotationId="010020ancientgreek" visited={visitedNotes.has("010020ancientgreek")} annotationSelect={() => {openNote("010020ancientgreek"); addToVisited("010020ancientgreek")}} activeAnnotationId={currentNoteId}>Queens lay with prize bulls.
+        <i>Et exaltabuntur cornua iusti.</i> <Annotation annotationId="010020ancientgreek">Queens lay with prize bulls.
         Remember Pasiphae for whose lust my grandoldgrossfather made the first
         confessionbox.</Annotation> Forget not Madam Grissel Steevens nor the suine scions
-        of the house of Lambert. <Annotation annotationId="080025musteredandbred" visited={visitedNotes.has("080025musteredandbred")} annotationSelect={() => {openNote("080025musteredandbred"); addToVisited("080025musteredandbred")}} activeAnnotationId={currentNoteId}>And Noah was drunk with wine. And his ark was
+        of the house of Lambert. <Annotation annotationId="080025musteredandbred">And Noah was drunk with wine. And his ark was
         open.</Annotation>
       </p>
       <p>
@@ -8320,7 +8320,7 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         with mortuary candles and they tears silver which occur every night.
         Perfectly shocking terrific of religion's things mockery seen in
         universal world. All chic womans which arrive full of modesty then
-        disrobe and squeal loud to <Annotation annotationId="030149vampire" visited={visitedNotes.has("030149vampire")} annotationSelect={() => {openNote("030149vampire"); addToVisited("030149vampire")}} activeAnnotationId={currentNoteId}>see vampire man debauch nun very fresh young
+        disrobe and squeal loud to <Annotation annotationId="030149vampire">see vampire man debauch nun very fresh young
         with <i>dessous troublants</i></Annotation>. <i>(He clacks his tongue loudly.)</i> <i>Ho, la la!
         Ce pif qu'il a!</i>
       </p>
@@ -8415,7 +8415,7 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <p>
         <i>(Extending his arms.)</i> It was here. Street of harlots. In
-        <Annotation annotationId="030077serpentine" visited={visitedNotes.has("030077serpentine")} annotationSelect={() => {openNote("030077serpentine"); addToVisited("030077serpentine")}} activeAnnotationId={currentNoteId}>Serpentine avenue</Annotation> Beelzebub showed me her, a fubsy widow. <Annotation annotationId="030055samedream" visited={visitedNotes.has("030055samedream")} annotationSelect={() => {openNote("030055samedream"); addToVisited("030055samedream")}} activeAnnotationId={currentNoteId}>Where's the
+        <Annotation annotationId="030077serpentine">Serpentine avenue</Annotation> Beelzebub showed me her, a fubsy widow. <Annotation annotationId="030055samedream">Where's the
         red carpet spread?</Annotation>
       </p>
       <p>
@@ -8429,8 +8429,8 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         STEPHEN
       </p>
       <p>
-        No, I flew. My foes beneath me. <Annotation annotationId="020025asitwas" visited={visitedNotes.has("020025asitwas")} annotationSelect={() => {openNote("020025asitwas"); addToVisited("020025asitwas")}} activeAnnotationId={currentNoteId}>And ever shall be. World
-        without end.</Annotation> <i>(He cries.)</i> <Annotation annotationId="010020ancientgreek" visited={visitedNotes.has("010020ancientgreek")} annotationSelect={() => {openNote("010020ancientgreek"); addToVisited("010020ancientgreek")}} activeAnnotationId={currentNoteId}><i>Pater! </i> Free!</Annotation>
+        No, I flew. My foes beneath me. <Annotation annotationId="020025asitwas">And ever shall be. World
+        without end.</Annotation> <i>(He cries.)</i> <Annotation annotationId="010020ancientgreek"><i>Pater! </i> Free!</Annotation>
       </p>
       <p>
         BLOOM
@@ -8443,7 +8443,7 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         STEPHEN
       </p>
       <p>
-        <Annotation annotationId="010001buckmulligan" visited={visitedNotes.has("010001buckmulligan")} annotationSelect={() => {openNote("010001buckmulligan"); addToVisited("010001buckmulligan")}} activeAnnotationId={currentNoteId}>Break my spirit, will he?</Annotation> <i>O merde alors! (He cries, his
+        <Annotation annotationId="010001buckmulligan">Break my spirit, will he?</Annotation> <i>O merde alors! (He cries, his
         vulture talons sharpened.)</i> Hola! Hillyho!
       </p>
       <p>
@@ -8463,7 +8463,7 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <p>
         <i>(The fronds and spaces of the wallpaper file rapidly across country.
-        <Annotation annotationId="020009ghoststory" visited={visitedNotes.has("020009ghoststory")} annotationSelect={() => {openNote("020009ghoststory"); addToVisited("020009ghoststory")}} activeAnnotationId={currentNoteId}>A stout fox, drawn from covert, brush pointed, having buried his
+        <Annotation annotationId="020009ghoststory">A stout fox, drawn from covert, brush pointed, having buried his
         grandmother</Annotation>, runs swift for the open, brighteyed, seeking badger earth,
         under the leaves. The pack of staghounds follows, nose to the ground,
         sniffing their quarry, beaglebaying, burblbrbling to be blooded. Ward
@@ -8495,16 +8495,16 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         <i>(A dark horse, riderless, bolts like a phantom past the winningpost,
         his mane moonfoaming, his eyeballs stars. The field follows, a bunch of
         bucking mounts. Skeleton horses, Sceptre, Maximum the Second, Zinfandel,
-        <Annotation annotationId="020050vanishedhorses" visited={visitedNotes.has("020050vanishedhorses")} annotationSelect={() => {openNote("020050vanishedhorses"); addToVisited("020050vanishedhorses")}} activeAnnotationId={currentNoteId}>the Duke of Westminster's Shotover, Repulse, the Duke of Beaufort's
+        <Annotation annotationId="020050vanishedhorses">the Duke of Westminster's Shotover, Repulse, the Duke of Beaufort's
         Ceylon, prix de Paris</Annotation>. Dwarfs ride them, rusty armoured, leaping, leaping
         in their saddles. Last in a drizzle of rain on a brokenwinded
         isabelle nag, Cock of the North, the favourite, honey cap, green jacket,
         orange sleeves, Garrett Deasy up, gripping the reins, a hockeystick at
-        the ready. His nag, stumbling on whitegaitered feet jogs along the <Annotation annotationId="020048rockyroad" visited={visitedNotes.has("020048rockyroad")} annotationSelect={() => {openNote("020048rockyroad"); addToVisited("020048rockyroad")}} activeAnnotationId={currentNoteId}>rocky
+        the ready. His nag, stumbling on whitegaitered feet jogs along the <Annotation annotationId="020048rockyroad">rocky
         road</Annotation>.)</i>
       </p>
       <p>
-        <Annotation annotationId="020040orangelodges" visited={visitedNotes.has("020040orangelodges")} annotationSelect={() => {openNote("020040orangelodges"); addToVisited("020040orangelodges")}} activeAnnotationId={currentNoteId}>THE ORANGE LODGES</Annotation>
+        <Annotation annotationId="020040orangelodges">THE ORANGE LODGES</Annotation>
       </p>
       <p>
         <i>(Jeering.)</i> Get down and push, mister. Last lap!
@@ -8522,7 +8522,7 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <br/>
       <p>
-        <Annotation annotationId="020047johnblackwood" visited={visitedNotes.has("020047johnblackwood")} annotationSelect={() => {openNote("020047johnblackwood"); addToVisited("020047johnblackwood")}} activeAnnotationId={currentNoteId}><i>Per vias rectas!</i></Annotation>
+        <Annotation annotationId="020047johnblackwood"><i>Per vias rectas!</i></Annotation>
       </p>
       <p>
         <i>(A yoke of buckets leopards all over him and his rearing nag a torrent
@@ -8535,7 +8535,7 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         THE GREEN LODGES
       </p>
       <p>
-        <Annotation annotationId="020049softday" visited={visitedNotes.has("020049softday")} annotationSelect={() => {openNote("020049softday"); addToVisited("020049softday")}} activeAnnotationId={currentNoteId}>Soft day, sir John!</Annotation> Soft day, your honour! 
+        <Annotation annotationId="020049softday">Soft day, sir John!</Annotation> Soft day, your honour! 
       </p>
       <p>
         <i>(Private Carr, Private Compton and Cissy Caffrey pass beneath the
@@ -8545,7 +8545,7 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         STEPHEN
       </p>
       <p>
-        Hark! Our friend <Annotation annotationId="020069streetshout" visited={visitedNotes.has("020069streetshout")} annotationSelect={() => {openNote("020069streetshout"); addToVisited("020069streetshout")}} activeAnnotationId={currentNoteId}>noise in the street</Annotation>.
+        Hark! Our friend <Annotation annotationId="020069streetshout">noise in the street</Annotation>.
       </p>
       <p>
         ZOE
@@ -8557,7 +8557,7 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         PRIVATE CARR, PRIVATE COMPTON AND CISSY CAFFREY
       </p>
       <p>
-        <Annotation annotationId="100004yorkshiregirl" visited={visitedNotes.has("100004yorkshiregirl")} annotationSelect={() => {openNote("100004yorkshiregirl"); addToVisited("100004yorkshiregirl")}} activeAnnotationId={currentNoteId}>Yet I've a sort a <br/>
+        <Annotation annotationId="100004yorkshiregirl">Yet I've a sort a <br/>
         Yorkshire relish for...</Annotation>
       </p>
       <p>
@@ -8584,9 +8584,9 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         STEPHEN
       </p>
       <p>
-        <i>(Cracking his fingers impatiently.)</i> Quick! Quick! Where's <Annotation annotationId="010099ashplant" visited={visitedNotes.has("010099ashplant")} annotationSelect={() => {openNote("010099ashplant"); addToVisited("010099ashplant")}} activeAnnotationId={currentNoteId}>my
+        <i>(Cracking his fingers impatiently.)</i> Quick! Quick! Where's <Annotation annotationId="010099ashplant">my
         augur's rod</Annotation>? <i>(He runs to the piano and takes his ashplant, beating his
-        foot in <Annotation annotationId="030102viditdeus" visited={visitedNotes.has("030102viditdeus")} annotationSelect={() => {openNote("030102viditdeus"); addToVisited("030102viditdeus")}} activeAnnotationId={currentNoteId}>tripudium</Annotation>.)</i>
+        foot in <Annotation annotationId="030102viditdeus">tripudium</Annotation>.)</i>
       </p>
       <p>
         ZOE
@@ -8596,8 +8596,8 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <p>
         <i>(She drops two pennies in the slot. Gold, pink and violet lights
-        start forth. The drum turns purring in low hesitation</i> <span data-edition="ed1961" data-page="574"> </span><i>waltz. <Annotation annotationId="040092professorgoodwin" visited={visitedNotes.has("040092professorgoodwin")} annotationSelect={() => {openNote("040092professorgoodwin"); addToVisited("040092professorgoodwin")}} activeAnnotationId={currentNoteId}>Professor</Annotation></i>
-        <span data-edition="ed1986" data-page="468"> </span><i><Annotation annotationId="040092professorgoodwin" visited={visitedNotes.has("040092professorgoodwin")} annotationSelect={() => {openNote("040092professorgoodwin"); addToVisited("040092professorgoodwin")}} activeAnnotationId={currentNoteId}>Goodwin, in a bowknotted periwig, in court dress, wearing a stained
+        start forth. The drum turns purring in low hesitation</i> <span data-edition="ed1961" data-page="574"> </span><i>waltz. <Annotation annotationId="040092professorgoodwin">Professor</Annotation></i>
+        <span data-edition="ed1986" data-page="468"> </span><i><Annotation annotationId="040092professorgoodwin">Goodwin, in a bowknotted periwig, in court dress, wearing a stained
         inverness cape, bent in two from incredible age, totters across the
         room, his hands fluttering.</Annotation> He sits tinily on the pianostool and lifts
         and beats handless sticks of arms on the keyboard, nodding with damsel's
@@ -8614,7 +8614,7 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <p>
         <i>(The pianola with changing lights plays in waltz time the prelude of</i>
-        <Annotation annotationId="100004yorkshiregirl" visited={visitedNotes.has("100004yorkshiregirl")} annotationSelect={() => {openNote("100004yorkshiregirl"); addToVisited("100004yorkshiregirl")}} activeAnnotationId={currentNoteId}>My Girl's a Yorkshire Girl</Annotation>. <i>Stephen throws his ashplant on the table
+        <Annotation annotationId="100004yorkshiregirl">My Girl's a Yorkshire Girl</Annotation>. <i>Stephen throws his ashplant on the table
         and seizes Zoe round the waist. Florry and Bella push the table towards
         the fireplace. Stephen, arming Zoe with exaggerated grace, begins to
         waltz her round the room. Bloom stands aside. Her sleeve, falling from
@@ -8902,7 +8902,7 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       <p>
         THE CHOIR
       </p>
-      <p><Annotation annotationId="010082liliatarutilantium" visited={visitedNotes.has("010082liliatarutilantium")} annotationSelect={() => {openNote("010082liliatarutilantium"); addToVisited("010082liliatarutilantium")}} activeAnnotationId={currentNoteId}>Liliata rutilantium te confessorum... <br/>
+      <p><Annotation annotationId="010082liliatarutilantium">Liliata rutilantium te confessorum... <br/>
         Iubilantium te virginum...</Annotation>
       </p>
       <p>
@@ -8914,8 +8914,8 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         BUCK MULLIGAN
       </p>
       <p>
-        She's <Annotation annotationId="010059pulsesbeating" visited={visitedNotes.has("010059pulsesbeating")} annotationSelect={() => {openNote("010059pulsesbeating"); addToVisited("010059pulsesbeating")}} activeAnnotationId={currentNoteId}>beastly dead</Annotation>. The pity of it! Mulligan meets the
-        afflicted mother. <i>(He upturns his eyes.)</i> <Annotation annotationId="010021malachi" visited={visitedNotes.has("010021malachi")} annotationSelect={() => {openNote("010021malachi"); addToVisited("010021malachi")}} activeAnnotationId={currentNoteId}>Mercurial Malachi!</Annotation>
+        She's <Annotation annotationId="010059pulsesbeating">beastly dead</Annotation>. The pity of it! Mulligan meets the
+        afflicted mother. <i>(He upturns his eyes.)</i> <Annotation annotationId="010021malachi">Mercurial Malachi!</Annotation>
       </p>
       <p>
         THE MOTHER
@@ -8935,18 +8935,18 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         BUCK MULLIGAN
       </p>
       <p>
-        <i>(Shakes his curling capbell.)</i> <Annotation annotationId="010154mockery" visited={visitedNotes.has("010154mockery")} annotationSelect={() => {openNote("010154mockery"); addToVisited("010154mockery")}} activeAnnotationId={currentNoteId}>The mockery</Annotation> of it! <Annotation annotationId="010007kinch" visited={visitedNotes.has("010007kinch")} annotationSelect={() => {openNote("010007kinch"); addToVisited("010007kinch")}} activeAnnotationId={currentNoteId}>Kinch</Annotation>
-        killed her <Annotation annotationId="010047dogsbody" visited={visitedNotes.has("010047dogsbody")} annotationSelect={() => {openNote("010047dogsbody"); addToVisited("010047dogsbody")}} activeAnnotationId={currentNoteId}>dogsbody</Annotation> 
+        <i>(Shakes his curling capbell.)</i> <Annotation annotationId="010154mockery">The mockery</Annotation> of it! <Annotation annotationId="010007kinch">Kinch</Annotation>
+        killed her <Annotation annotationId="010047dogsbody">dogsbody</Annotation> 
         <span data-edition="ed1922" data-page="539"> </span>
         bitchbody. She kicked the bucket. <i>(Tears of molten
-        butter fall from his eyes on to the scone.)</i> Our <Annotation annotationId="010032sweetmother" visited={visitedNotes.has("010032sweetmother")} annotationSelect={() => {openNote("010032sweetmother"); addToVisited("010032sweetmother")}} activeAnnotationId={currentNoteId}>great sweet mother</Annotation>! <Annotation annotationId="010033epioinopaponton" visited={visitedNotes.has("010033epioinopaponton")} annotationSelect={() => {openNote("010033epioinopaponton"); addToVisited("010033epioinopaponton")}} activeAnnotationId={currentNoteId}><i>Epi
+        butter fall from his eyes on to the scone.)</i> Our <Annotation annotationId="010032sweetmother">great sweet mother</Annotation>! <Annotation annotationId="010033epioinopaponton"><i>Epi
         oinopa ponton.</i></Annotation>
       </p>
       <p>
         THE MOTHER
       </p>
       <p>
-        <i>(Comes nearer, breathing upon him softly <Annotation annotationId="010045waxandrosewood" visited={visitedNotes.has("010045waxandrosewood")} annotationSelect={() => {openNote("010045waxandrosewood"); addToVisited("010045waxandrosewood")}} activeAnnotationId={currentNoteId}>her breath of wetted ashes</Annotation>.)</i> All must go through it, Stephen. More women than men in
+        <i>(Comes nearer, breathing upon him softly <Annotation annotationId="010045waxandrosewood">her breath of wetted ashes</Annotation>.)</i> All must go through it, Stephen. More women than men in
         the world. You too. Time will come.
       </p>
       <span data-edition="ed1986" data-page="473"> </span>
@@ -8954,7 +8954,7 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         STEPHEN
       </p>
       <p>
-        <i>(Choking with fright, remorse and horror.)</i> <Annotation annotationId="010042prayforme" visited={visitedNotes.has("010042prayforme")} annotationSelect={() => {openNote("010042prayforme"); addToVisited("010042prayforme")}} activeAnnotationId={currentNoteId}>They say I killed
+        <i>(Choking with fright, remorse and horror.)</i> <Annotation annotationId="010042prayforme">They say I killed
         you, mother.</Annotation> He offended your memory. Cancer did it, not I. Destiny.
       </p>
       <span data-edition="ed1939" data-page="408"> </span>
@@ -8964,13 +8964,13 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <p>
         <i>(A green rill of bile trickling from a side of her mouth.)</i>
-        <Annotation annotationId="010072bittermystery" visited={visitedNotes.has("010072bittermystery")} annotationSelect={() => {openNote("010072bittermystery"); addToVisited("010072bittermystery")}} activeAnnotationId={currentNoteId}>You sang that song to me. <i>Love's bitter mystery.</i></Annotation>
+        <Annotation annotationId="010072bittermystery">You sang that song to me. <i>Love's bitter mystery.</i></Annotation>
       </p>
       <p>
         STEPHEN
       </p>
       <p>
-        <i>(Eagerly.)</i> Tell me the word, mother, if you know now. <Annotation annotationId="010044painfretted" visited={visitedNotes.has("010044painfretted")} annotationSelect={() => {openNote("010044painfretted"); addToVisited("010044painfretted")}} activeAnnotationId={currentNoteId}>The word
+        <i>(Eagerly.)</i> Tell me the word, mother, if you know now. <Annotation annotationId="010044painfretted">The word
         known to all men.</Annotation>
       </p>
       <span data-edition="ed1932" data-page="500"> </span>
@@ -8981,13 +8981,13 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         Who saved you the night you jumped into the train at
         Dalkey with Paddy Lee? Who had pity for you when you were sad among the
         strangers? Prayer is allpowerful. Prayer for the suffering souls in the
-        Ursuline manual and forty days' indulgence. <Annotation annotationId="010042prayforme" visited={visitedNotes.has("010042prayforme")} annotationSelect={() => {openNote("010042prayforme"); addToVisited("010042prayforme")}} activeAnnotationId={currentNoteId}>Repent, Stephen.</Annotation>
+        Ursuline manual and forty days' indulgence. <Annotation annotationId="010042prayforme">Repent, Stephen.</Annotation>
       </p>
       <p>
         STEPHEN
       </p>
       <p>
-        <Annotation annotationId="010062ghoul" visited={visitedNotes.has("010062ghoul")} annotationSelect={() => {openNote("010062ghoul"); addToVisited("010062ghoul")}} activeAnnotationId={currentNoteId}>The ghoul! Hyena!</Annotation>
+        <Annotation annotationId="010062ghoul">The ghoul! Hyena!</Annotation>
       </p>
       <p>
         THE MOTHER
@@ -9026,7 +9026,7 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         STEPHEN
       </p>
       <p>
-        <i>(Panting.)</i> His noncorrosive sublimate! <Annotation annotationId="010041killergod" visited={visitedNotes.has("010041killergod")} annotationSelect={() => {openNote("010041killergod"); addToVisited("010041killergod")}} activeAnnotationId={currentNoteId}>The corpsechewer!</Annotation> Raw
+        <i>(Panting.)</i> His noncorrosive sublimate! <Annotation annotationId="010041killergod">The corpsechewer!</Annotation> Raw
         head and bloody bones.
       </p>
       <span data-edition="ed1986" data-page="474"> </span><span data-edition="ed1961" data-page="581"> </span>
@@ -9059,7 +9059,7 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <p>
         <i>Ah non, par exemple!</i> The intellectual imagination! With me
-        <Annotation annotationId="030115allornotatall" visited={visitedNotes.has("030115allornotatall")} annotationSelect={() => {openNote("030115allornotatall"); addToVisited("030115allornotatall")}} activeAnnotationId={currentNoteId}>all or not at all</Annotation>. <Annotation annotationId="010114stateandchurch" visited={visitedNotes.has("010114stateandchurch")} annotationSelect={() => {openNote("010114stateandchurch"); addToVisited("010114stateandchurch")}} activeAnnotationId={currentNoteId}><i>Non serviam!</i></Annotation>
+        <Annotation annotationId="030115allornotatall">all or not at all</Annotation>. <Annotation annotationId="010114stateandchurch"><i>Non serviam!</i></Annotation>
       </p>
       <p>
         FLORRY
@@ -9102,7 +9102,7 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <p>
         <i>(He lifts his ashplant high with both hands and smashes the chandelier.
-        <Annotation annotationId="020003daughtersofmemory" visited={visitedNotes.has("020003daughtersofmemory")} annotationSelect={() => {openNote("020003daughtersofmemory"); addToVisited("020003daughtersofmemory")}} activeAnnotationId={currentNoteId}>Time's livid final flame leaps and, in the following darkness, ruin of
+        <Annotation annotationId="020003daughtersofmemory">Time's livid final flame leaps and, in the following darkness, ruin of
         all space, shattered glass and toppling masonry.</Annotation>)</i>
       </p>
       <span data-edition="ed1986" data-page="475"> </span>
@@ -9287,13 +9287,13 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         <i>(He hurries out through the hall. The whores point. Florry follows,
         spilling water from her tilted tumbler. On the doorstep all the whores
         clustered talk volubly, pointing to the right where the fog has cleared
-        off. From the left arrives <Annotation annotationId="050013jauntingcar" visited={visitedNotes.has("050013jauntingcar")} annotationSelect={() => {openNote("050013jauntingcar"); addToVisited("050013jauntingcar")}} activeAnnotationId={currentNoteId}>a jingling hackney car</Annotation>. It slows to in front
+        off. From the left arrives <Annotation annotationId="050013jauntingcar">a jingling hackney car</Annotation>. It slows to in front
         of the house. Bloom at the halldoor perceives Corny Kelleher who is
         about to dismount from the car with two silent lechers. He averts
         his face. Bella from within the hall urges on her</i> <span data-edition="ed1961" data-page="585"> </span><i>whores. They blow
         ickylickysticky yumyum kisses. Corny Kelleher replies with a ghastly
         lewd smile. The silent lechers turn to pay the jarvey. Zoe and Kitty
-        still point right. Bloom, parting them swiftly, <Annotation annotationId="030055samedream" visited={visitedNotes.has("030055samedream")} annotationSelect={() => {openNote("030055samedream"); addToVisited("030055samedream")}} activeAnnotationId={currentNoteId}>draws his caliph's hood
+        still point right. Bloom, parting them swiftly, <Annotation annotationId="030055samedream">draws his caliph's hood
         and poncho and hurries down the steps with sideways face. Incog Haroun
         al Raschid</Annotation> he flits behind the silent lechers and hastens on by the
         railings with fleet step of a pard strewing the drag behind him, torn
@@ -9305,25 +9305,25 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         runs, zigzags,</i> 
         <span data-edition="ed1922" data-page="544"> </span>
         <i>gallops, lugs laid back. He is pelted with gravel,
-        cabbagestumps, biscuitboxes, eggs, potatoes, dead codfish, <Annotation annotationId="060045slipperslapper" visited={visitedNotes.has("060045slipperslapper")} annotationSelect={() => {openNote("060045slipperslapper"); addToVisited("060045slipperslapper")}} activeAnnotationId={currentNoteId}> woman's
+        cabbagestumps, biscuitboxes, eggs, potatoes, dead codfish, <Annotation annotationId="060045slipperslapper"> woman's
         slipperslappers</Annotation>. After him, freshfound, the hue and cry zigzag gallops
         in hot pursuit of follow my leader: 65 C 66 C, night watch, John Henry
         Menton, Wisdom Hely, V. B. Dillon, Councillor Nannetti, Alexander Keyes,
         Larry O'Rourke, Joe Cuffe, Mrs O'Dowd, Pisser Burke, The Nameless One,
-        <Annotation annotationId="060015riordan" visited={visitedNotes.has("060015riordan")} annotationSelect={() => {openNote("060015riordan"); addToVisited("060015riordan")}} activeAnnotationId={currentNoteId}>Mrs Riordan</Annotation>, The Citizen, Garryowen, Whodoyoucallhim, Strangeface,</i>
+        <Annotation annotationId="060015riordan">Mrs Riordan</Annotation>, The Citizen, Garryowen, Whodoyoucallhim, Strangeface,</i>
         <span data-edition="ed1932" data-page="504"> </span><i>Fellowthatslike, Sawhimbefore, Chapwithawen, Chris Callinan, Sir
         Charles Cameron, Benjamin Dollard, Lenehan, Bartell d'Arcy, Joe Hynes,
         red Murray, editor Brayden, T. M. Healy, Mr Justice Fitzgibbon, John
         Howard Parnell, the reverend Tinned Salmon, Professor Joly, Mrs
         Breen, Denis Breen, Theodore Purefoy, Mina Purefoy, the Westland
-        Row postmistress, <Annotation annotationId="040079mcoy" visited={visitedNotes.has("040079mcoy")} annotationSelect={() => {openNote("040079mcoy"); addToVisited("040079mcoy")}} activeAnnotationId={currentNoteId}>C. P. M'Coy</Annotation>, friend of Lyons, <Annotation annotationId="050028hoppy" visited={visitedNotes.has("050028hoppy")} annotationSelect={() => {openNote("050028hoppy"); addToVisited("050028hoppy")}} activeAnnotationId={currentNoteId}>Hoppy Holohan</Annotation>,
+        Row postmistress, <Annotation annotationId="040079mcoy">C. P. M'Coy</Annotation>, friend of Lyons, <Annotation annotationId="050028hoppy">Hoppy Holohan</Annotation>,
         maninthestreet, othermaninthestreet, Footballboots, pugnosed driver,
         rich protestant lady, Davy Byrne, Mrs Ellen M'Guinness,</i> <span data-edition="ed1986" data-page="478"> </span><i>Mrs Joe
         Gallaher, </i>
         <span data-edition="ed1939" data-page="412"> </span>
         <i>George Lidwell, Jimmy Henry on corns, Superintendent Laracy,
-        Father Cowley, Crofton out of the Collector General's, <Annotation annotationId="060037dandawson" visited={visitedNotes.has("060037dandawson")} annotationSelect={() => {openNote("060037dandawson"); addToVisited("060037dandawson")}} activeAnnotationId={currentNoteId}>Dan Dawson</Annotation>,
-        dental surgeon Bloom with tweezers, <Annotation annotationId="050038bobdoran" visited={visitedNotes.has("050038bobdoran")} annotationSelect={() => {openNote("050038bobdoran"); addToVisited("050038bobdoran")}} activeAnnotationId={currentNoteId}>Mrs Bob Doran</Annotation>, Mrs Kennefick, Mrs
+        Father Cowley, Crofton out of the Collector General's, <Annotation annotationId="060037dandawson">Dan Dawson</Annotation>,
+        dental surgeon Bloom with tweezers, <Annotation annotationId="050038bobdoran">Mrs Bob Doran</Annotation>, Mrs Kennefick, Mrs
         Wyse Nolan, John Wyse Nolan, handsomemarriedwomanrubbedagainstwidebehindinClonskeatram, the bookseller of</i> Sweets of Sin, <i>Miss
         Dubedatandshedidbedad, Mesdames Gerald and Stanislaus Moran of Roebuck,
         the managing clerk of Drimmie's, colonel Hayes, Mastiansky,
@@ -9351,8 +9351,8 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         <i>(With elaborate gestures, breathing deeply and slowly.)</i> You
         are my guests. 
         <span data-edition="ed1922" data-page="545"> </span>
-        Uninvited. By virtue of <Annotation annotationId="020079kingedward" visited={visitedNotes.has("020079kingedward")} annotationSelect={() => {openNote("020079kingedward"); addToVisited("020079kingedward")}} activeAnnotationId={currentNoteId}>the fifth of George and seventh
-        of Edward</Annotation>. <Annotation annotationId="010141blamehistory" visited={visitedNotes.has("010141blamehistory")} annotationSelect={() => {openNote("010141blamehistory"); addToVisited("010141blamehistory")}} activeAnnotationId={currentNoteId}>History to blame.</Annotation> <Annotation annotationId="020003daughtersofmemory" visited={visitedNotes.has("020003daughtersofmemory")} annotationSelect={() => {openNote("020003daughtersofmemory"); addToVisited("020003daughtersofmemory")}} activeAnnotationId={currentNoteId}>Fabled by mothers of memory.</Annotation>
+        Uninvited. By virtue of <Annotation annotationId="020079kingedward">the fifth of George and seventh
+        of Edward</Annotation>. <Annotation annotationId="010141blamehistory">History to blame.</Annotation> <Annotation annotationId="020003daughtersofmemory">Fabled by mothers of memory.</Annotation>
       </p>
       <p>
         PRIVATE CARR
@@ -9423,8 +9423,8 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         LORD TENNYSON
       </p>
       <p>
-        <i>(Gentleman poet in Union Jack blazer and <Annotation annotationId="050041cricket" visited={visitedNotes.has("050041cricket")} annotationSelect={() => {openNote("050041cricket"); addToVisited("050041cricket")}} activeAnnotationId={currentNoteId}>cricket
-        flannels</Annotation>, bareheaded, flowingbearded.)</i> <Annotation annotationId="030088tennyson" visited={visitedNotes.has("030088tennyson")} annotationSelect={() => {openNote("030088tennyson"); addToVisited("030088tennyson")}} activeAnnotationId={currentNoteId}>Theirs not to reason why.</Annotation>
+        <i>(Gentleman poet in Union Jack blazer and <Annotation annotationId="050041cricket">cricket
+        flannels</Annotation>, bareheaded, flowingbearded.)</i> <Annotation annotationId="030088tennyson">Theirs not to reason why.</Annotation>
       </p>
       <p>
         PRIVATE COMPTON
@@ -9518,7 +9518,7 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         forgotten the trick. Let us sit down somewhere and discuss. Struggle
         for life is the law of existence but human philirenists, notably the
         tsar and the king of England, have invented arbitration. <i>(He taps his
-        brow.)</i> But <Annotation annotationId="030141masterslave" visited={visitedNotes.has("030141masterslave")} annotationSelect={() => {openNote("030141masterslave"); addToVisited("030141masterslave")}} activeAnnotationId={currentNoteId}>in here it is</Annotation> I must kill <Annotation annotationId="010114stateandchurch" visited={visitedNotes.has("010114stateandchurch")} annotationSelect={() => {openNote("010114stateandchurch"); addToVisited("010114stateandchurch")}} activeAnnotationId={currentNoteId}>the priest and the king</Annotation>.
+        brow.)</i> But <Annotation annotationId="030141masterslave">in here it is</Annotation> I must kill <Annotation annotationId="010114stateandchurch">the priest and the king</Annotation>.
       </p>
       <span data-edition="ed1961" data-page="589"> </span>
       <p>
@@ -9557,13 +9557,13 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <span data-edition="ed1986" data-page="481"> </span><span data-edition="ed1932" data-page="507"> </span>
       <p>
-        <i>(<Annotation annotationId="020079kingedward" visited={visitedNotes.has("020079kingedward")} annotationSelect={() => {openNote("020079kingedward"); addToVisited("020079kingedward")}} activeAnnotationId={currentNoteId}>Edward the Seventh appears</Annotation> in <Annotation annotationId="030024archway" visited={visitedNotes.has("030024archway")} annotationSelect={() => {openNote("030024archway"); addToVisited("030024archway")}} activeAnnotationId={currentNoteId}>an archway</Annotation>. He wears a white jersey on
+        <i>(<Annotation annotationId="020079kingedward">Edward the Seventh appears</Annotation> in <Annotation annotationId="030024archway">an archway</Annotation>. He wears a white jersey on
         which an image of the Sacred Heart is stitched with the insignia of
         Garter and Thistle, Golden Fleece, Elephant of Denmark, Skinner's
         and Probyn's horse, Lincoln's Inns' bencher and ancient and honourable
-        artillery company of Massachusetts. <Annotation annotationId="080017grahamlemons" visited={visitedNotes.has("080017grahamlemons")} annotationSelect={() => {openNote("080017grahamlemons"); addToVisited("080017grahamlemons")}} activeAnnotationId={currentNoteId}>He sucks a red jujube.</Annotation> He is robed
+        artillery company of Massachusetts. <Annotation annotationId="080017grahamlemons">He sucks a red jujube.</Annotation> He is robed
         as a grand elect perfect and sublime mason with trowel and apron,
-        marked</i> made in Germany. <i>In his left hand he holds</i> <Annotation annotationId="170005dustbuckets" visited={visitedNotes.has("170005dustbuckets")} annotationSelect={() => {openNote("170005dustbuckets"); addToVisited("170005dustbuckets")}} activeAnnotationId={currentNoteId}><i>a plasterer's bucket
+        marked</i> made in Germany. <i>In his left hand he holds</i> <Annotation annotationId="170005dustbuckets"><i>a plasterer's bucket
         on which is printed</i> Défense d'uriner.</Annotation> <i>A roar of welcome greets him.)</i>
       </p>
       <p>
@@ -9611,7 +9611,7 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         face.)</i>
       </p>
       <p>
-        <Annotation annotationId="010110jokingjesus" visited={visitedNotes.has("010110jokingjesus")} annotationSelect={() => {openNote("010110jokingjesus"); addToVisited("010110jokingjesus")}} activeAnnotationId={currentNoteId}>My methods are new and are causing surprise. <br/>
+        <Annotation annotationId="010110jokingjesus">My methods are new and are causing surprise. <br/>
         To make the blind see I throw dust in their eyes.</Annotation>
       </p>
       <p>
@@ -9635,7 +9635,7 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <p>
         <i>(To the privates, softly.)</i> He doesn't know what he's saying.
-        Taken a little more than is good for him. <Annotation annotationId="030045absinthe" visited={visitedNotes.has("030045absinthe")} annotationSelect={() => {openNote("030045absinthe"); addToVisited("030045absinthe")}} activeAnnotationId={currentNoteId}>Absinthe. Greeneyed monster.</Annotation> I
+        Taken a little more than is good for him. <Annotation annotationId="030045absinthe">Absinthe. Greeneyed monster.</Annotation> I
         know him. He's a gentleman, a poet. It's all right.
       </p>
       <span data-edition="ed1961" data-page="591"> </span>
@@ -9666,32 +9666,32 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         I seem to annoy them. Green rag to a bull.
       </p>
       <p>
-        <i>(<Annotation annotationId="030051kevinegan" visited={visitedNotes.has("030051kevinegan")} annotationSelect={() => {openNote("030051kevinegan"); addToVisited("030051kevinegan")}} activeAnnotationId={currentNoteId}>Kevin Egan of Paris</Annotation> in black Spanish tasselled shirt and <Annotation annotationId="020043corpses" visited={visitedNotes.has("020043corpses")} annotationSelect={() => {openNote("020043corpses"); addToVisited("020043corpses")}} activeAnnotationId={currentNoteId}>peep-o'-day
+        <i>(<Annotation annotationId="030051kevinegan">Kevin Egan of Paris</Annotation> in black Spanish tasselled shirt and <Annotation annotationId="020043corpses">peep-o'-day
         boy's hat</Annotation> signs to Stephen.)</i>
       </p>
       <p>
         KEVIN EGAN
       </p>
       <p>
-        H'lo! <i>Bonjour!</i> <Annotation annotationId="030022chaussons" visited={visitedNotes.has("030022chaussons")} annotationSelect={() => {openNote("030022chaussons"); addToVisited("030022chaussons")}} activeAnnotationId={currentNoteId}>The <i>vieille ogresse</i> with the <i>dents
+        H'lo! <i>Bonjour!</i> <Annotation annotationId="030022chaussons">The <i>vieille ogresse</i> with the <i>dents
         jaunes</i>.</Annotation>
       </p>
       <p>
-        <i>(Patrice Egan peeps from behind, his <Annotation annotationId="030005lapped" visited={visitedNotes.has("030005lapped")} annotationSelect={() => {openNote("030005lapped"); addToVisited("030005lapped")}} activeAnnotationId={currentNoteId}>rabbitface</Annotation> nibbling a quince
+        <i>(Patrice Egan peeps from behind, his <Annotation annotationId="030005lapped">rabbitface</Annotation> nibbling a quince
         leaf.)</i>
       </p>
       <p>
         PATRICE
       </p>
       <p>
-        <Annotation annotationId="030005lapped" visited={visitedNotes.has("030005lapped")} annotationSelect={() => {openNote("030005lapped"); addToVisited("030005lapped")}} activeAnnotationId={currentNoteId}><i>Socialiste!</i></Annotation>
+        <Annotation annotationId="030005lapped"><i>Socialiste!</i></Annotation>
       </p>
       <span data-edition="ed1939" data-page="416"> </span>
       <p>
-        <Annotation annotationId="030027wildgoose" visited={visitedNotes.has("030027wildgoose")} annotationSelect={() => {openNote("030027wildgoose"); addToVisited("030027wildgoose")}} activeAnnotationId={currentNoteId}>DON EMILE PATRIZIO FRANZ RUPERT POPE HENNESSY</Annotation>
+        <Annotation annotationId="030027wildgoose">DON EMILE PATRIZIO FRANZ RUPERT POPE HENNESSY</Annotation>
       </p>
       <p>
-        <i><Annotation annotationId="030027wildgoose" visited={visitedNotes.has("030027wildgoose")} annotationSelect={() => {openNote("030027wildgoose"); addToVisited("030027wildgoose")}} activeAnnotationId={currentNoteId}>(In medieval hauberk,
+        <i><Annotation annotationId="030027wildgoose">(In medieval hauberk,
         two wild geese volant on his helm,</Annotation> with noble indignation points a
         mailed hand against the privates.)</i> Werf those eykes to footboden, big
         grand porcos of johnyellows todos covered of gravy!
@@ -9735,7 +9735,7 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         A ROUGH
       </p>
       <p>
-        <i>(Laughs.)</i> <Annotation annotationId="080021joechamberlain" visited={visitedNotes.has("080021joechamberlain")} annotationSelect={() => {openNote("080021joechamberlain"); addToVisited("080021joechamberlain")}} activeAnnotationId={currentNoteId}>Ay! Hands up to De Wet.</Annotation>
+        <i>(Laughs.)</i> <Annotation annotationId="080021joechamberlain">Ay! Hands up to De Wet.</Annotation>
       </p>
       <p>
         THE CITIZEN
@@ -9751,14 +9751,14 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         That hanged our Irish leaders.
       </p>
       <p>
-        <Annotation annotationId="110007croppyboy" visited={visitedNotes.has("110007croppyboy")} annotationSelect={() => {openNote("110007croppyboy"); addToVisited("110007croppyboy")}} activeAnnotationId={currentNoteId}>THE CROPPY BOY</Annotation>
+        <Annotation annotationId="110007croppyboy">THE CROPPY BOY</Annotation>
       </p>
       <p>
         <i>(The ropenoose round his neck, gripes in his issuing
         bowels with both hands.)</i>
       </p>
       <p>
-        <Annotation annotationId="110007croppyboy" visited={visitedNotes.has("110007croppyboy")} annotationSelect={() => {openNote("110007croppyboy"); addToVisited("110007croppyboy")}} activeAnnotationId={currentNoteId}>I bear no hate to a living thing, <br/>
+        <Annotation annotationId="110007croppyboy">I bear no hate to a living thing, <br/>
         But I love my country beyond the king.</Annotation>
       </p>
       <p>
@@ -9813,7 +9813,7 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         sings with soft contentment.)</i>
       </p>
       <p>
-        <Annotation annotationId="010029coronation" visited={visitedNotes.has("010029coronation")} annotationSelect={() => {openNote("010029coronation"); addToVisited("010029coronation")}} activeAnnotationId={currentNoteId}>On coronation day, on coronation day, <br/>
+        <Annotation annotationId="010029coronation">On coronation day, on coronation day, <br/>
         O, won't we have a merry time, <br/>
         Drinking whisky, beer and wine!</Annotation>
       </p>
@@ -9849,7 +9849,7 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <p>
         <i>(The women's heads coalesce. Old Gummy Granny in sugarloaf hat appears
-        seated on a toadstool, the deathflower of the <Annotation annotationId="020039famine" visited={visitedNotes.has("020039famine")} annotationSelect={() => {openNote("020039famine"); addToVisited("020039famine")}} activeAnnotationId={currentNoteId}>potato blight</Annotation> on her
+        seated on a toadstool, the deathflower of the <Annotation annotationId="020039famine">potato blight</Annotation> on her
         breast.)</i>
       </p>
       <span data-edition="ed1986" data-page="485"> </span>
@@ -9857,7 +9857,7 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         STEPHEN
       </p>
       <p>
-        Aha! I know you, gammer! Hamlet, revenge! <Annotation annotationId="010156crazyqueen" visited={visitedNotes.has("010156crazyqueen")} annotationSelect={() => {openNote("010156crazyqueen"); addToVisited("010156crazyqueen")}} activeAnnotationId={currentNoteId}>The old sow that eats
+        Aha! I know you, gammer! Hamlet, revenge! <Annotation annotationId="010156crazyqueen">The old sow that eats
         her farrow!</Annotation>
       </p>
       <p>
@@ -9865,11 +9865,11 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <p>
         <i>(Rocking to and fro.)</i> Ireland's sweetheart, the king
-        of Spain's daughter, alanna. <Annotation annotationId="010024stranger" visited={visitedNotes.has("010024stranger")} annotationSelect={() => {openNote("010024stranger"); addToVisited("010024stranger")}} activeAnnotationId={currentNoteId}>Strangers in my house</Annotation>, bad manners to them!
+        of Spain's daughter, alanna. <Annotation annotationId="010024stranger">Strangers in my house</Annotation>, bad manners to them!
         <i>(She keens with banshee</i> 
         <span data-edition="ed1922" data-page="552"> </span>
-        <i>woe.)</i> Ochone! Ochone! <Annotation annotationId="010090shanvanvocht" visited={visitedNotes.has("010090shanvanvocht")} annotationSelect={() => {openNote("010090shanvanvocht"); addToVisited("010090shanvanvocht")}} activeAnnotationId={currentNoteId}>Silk of the kine! <i>(She
-        wails.)</i> You met with poor old Ireland</Annotation> and <Annotation annotationId="030106nappertandy" visited={visitedNotes.has("030106nappertandy")} annotationSelect={() => {openNote("030106nappertandy"); addToVisited("030106nappertandy")}} activeAnnotationId={currentNoteId}>how does she stand?</Annotation>
+        <i>woe.)</i> Ochone! Ochone! <Annotation annotationId="010090shanvanvocht">Silk of the kine! <i>(She
+        wails.)</i> You met with poor old Ireland</Annotation> and <Annotation annotationId="030106nappertandy">how does she stand?</Annotation>
       </p>
       <span data-edition="ed1939" data-page="418"> </span>
       <p>
@@ -9934,7 +9934,7 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         BLOOM
       </p>
       <p>
-        <i>(To the redcoats.)</i> <Annotation annotationId="030118royaldublins" visited={visitedNotes.has("030118royaldublins")} annotationSelect={() => {openNote("030118royaldublins"); addToVisited("030118royaldublins")}} activeAnnotationId={currentNoteId}>We fought for you in South Africa, Irish
+        <i>(To the redcoats.)</i> <Annotation annotationId="030118royaldublins">We fought for you in South Africa, Irish
         missile troops. Isn't that history? Royal Dublin Fusiliers.</Annotation> Honoured by
         our monarch.
       </p>
@@ -9947,7 +9947,7 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <p>
         <i>(Casqued halberdiers in armour thrust forward a pentice of gutted
-        spearpoints. Major Tweedy, moustached like <Annotation annotationId="010077pantomime" visited={visitedNotes.has("010077pantomime")} annotationSelect={() => {openNote("010077pantomime"); addToVisited("010077pantomime")}} activeAnnotationId={currentNoteId}>Turko the terrible</Annotation>, in</i>
+        spearpoints. Major Tweedy, moustached like <Annotation annotationId="010077pantomime">Turko the terrible</Annotation>, in</i>
         <span data-edition="ed1986" data-page="486"> </span><i>bearskin</i> 
         <span data-edition="ed1922" data-page="553"> </span>
         <i>cap with hackleplume and accoutrements, with epaulettes, gilt
@@ -10009,7 +10009,7 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         STEPHEN
       </p>
       <p>
-        <Annotation annotationId="020059oldengland" visited={visitedNotes.has("020059oldengland")} annotationSelect={() => {openNote("020059oldengland"); addToVisited("020059oldengland")}} activeAnnotationId={currentNoteId}>The harlot's cry from street to street <br/>
+        <Annotation annotationId="020059oldengland">The harlot's cry from street to street <br/>
         Shall weave Old Ireland's windingsheet.</Annotation>
       </p>
       <span data-edition="ed1986" data-page="487"> </span>
@@ -10044,7 +10044,7 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       <p>
         <i>(Ecstatically, to Cissy Caffrey.)</i>
       </p>
-      <p><Annotation annotationId="030079strollingmort" visited={visitedNotes.has("030079strollingmort")} annotationSelect={() => {openNote("030079strollingmort"); addToVisited("030079strollingmort")}} activeAnnotationId={currentNoteId}>White thy fambles, red thy gan <br/>
+      <p><Annotation annotationId="030079strollingmort">White thy fambles, red thy gan <br/>
         And thy quarrons dainty is.</Annotation>
       </p>
       <p>
@@ -10071,7 +10071,7 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         cormorants, vultures, goshawks, climbing woodcocks, peregrines, merlins,
         blackgrouse,</i> <span data-edition="ed1932" data-page="513"> </span><i>sea eagles, gulls, albatrosses, barnacle geese. The
         midnight sun is darkened. The earth trembles. The dead of Dublin
-        from <Annotation annotationId="060035prospect" visited={visitedNotes.has("060035prospect")} annotationSelect={() => {openNote("060035prospect"); addToVisited("060035prospect")}} activeAnnotationId={currentNoteId}>Prospect</Annotation> and Mount Jerome in white sheepskin overcoats and black
+        from <Annotation annotationId="060035prospect">Prospect</Annotation> and Mount Jerome in white sheepskin overcoats and black
         goatfell cloaks arise and appear to many. A chasm opens with a noiseless
         yawn. Tom Rochford, winner, in athlete's singlet and breeches, arrives
         at the head of the national hurdle handicap and leaps into the void.
@@ -10079,24 +10079,24 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         spring from the brink. Their bodies plunge. Factory lasses with fancy
         clothes toss redhot Yorkshire baraabombs. Society ladies lift their
         skirts above their heads to protect themselves. Laughing witches in red
-        cutty sarks ride through the air on broomsticks. <Annotation annotationId="090004quakerlibrarian" visited={visitedNotes.has("090004quakerlibrarian")} annotationSelect={() => {openNote("090004quakerlibrarian"); addToVisited("090004quakerlibrarian")}} activeAnnotationId={currentNoteId}>Quakerlyster</Annotation> plasters
+        cutty sarks ride through the air on broomsticks. <Annotation annotationId="090004quakerlibrarian">Quakerlyster</Annotation> plasters
         blisters. It rains dragons' teeth.</i> <span data-edition="ed1986" data-page="488"> </span><i>Armed heroes spring up from furrows.
         They exchange</i> <span data-edition="ed1961" data-page="598"> </span><i>in amity</i> 
         <span data-edition="ed1922" data-page="555"> </span>
         <i>the pass of knights of the red cross and fight
-        duels with cavalry sabres: Wolfe Tone against Henry Grattan, <Annotation annotationId="040031smithobrien" visited={visitedNotes.has("040031smithobrien")} annotationSelect={() => {openNote("040031smithobrien"); addToVisited("040031smithobrien")}} activeAnnotationId={currentNoteId}>Smith
-        O'Brien</Annotation> against <Annotation annotationId="020038oconnell" visited={visitedNotes.has("020038oconnell")} annotationSelect={() => {openNote("020038oconnell"); addToVisited("020038oconnell")}} activeAnnotationId={currentNoteId}>Daniel O'Connell</Annotation>, Michael Davitt against Isaac Butt,
-        Justin M'Carthy against Parnell, <Annotation annotationId="030037griffith" visited={visitedNotes.has("030037griffith")} annotationSelect={() => {openNote("030037griffith"); addToVisited("030037griffith")}} activeAnnotationId={currentNoteId}>Arthur Griffith</Annotation> against John Redmond,
+        duels with cavalry sabres: Wolfe Tone against Henry Grattan, <Annotation annotationId="040031smithobrien">Smith
+        O'Brien</Annotation> against <Annotation annotationId="020038oconnell">Daniel O'Connell</Annotation>, Michael Davitt against Isaac Butt,
+        Justin M'Carthy against Parnell, <Annotation annotationId="030037griffith">Arthur Griffith</Annotation> against John Redmond,
         John O'Leary against Lear O'Johnny, Lord Edward Fitzgerald against Lord
         Gerald Fitzedward, The O'Donoghue of the Glens against The Glens of The
-        O'Donoghue. On an eminence, the <Annotation annotationId="010065omphalos" visited={visitedNotes.has("010065omphalos")} annotationSelect={() => {openNote("010065omphalos"); addToVisited("010065omphalos")}} activeAnnotationId={currentNoteId}>centre of the earth</Annotation>, rises the field altar
+        O'Donoghue. On an eminence, the <Annotation annotationId="010065omphalos">centre of the earth</Annotation>, rises the field altar
         of Saint Barbara. Black candles rise from its gospel and epistle horns.
-        <Annotation annotationId="010085towerlivingroom" visited={visitedNotes.has("010085towerlivingroom")} annotationSelect={() => {openNote("010085towerlivingroom"); addToVisited("010085towerlivingroom")}} activeAnnotationId={currentNoteId}>From the high barbacans of the tower two shafts of light fall on the
-        smokepalled altarstone.</Annotation> <Annotation annotationId="010014genuinechristine" visited={visitedNotes.has("010014genuinechristine")} annotationSelect={() => {openNote("010014genuinechristine"); addToVisited("010014genuinechristine")}} activeAnnotationId={currentNoteId}>On the altarstone Mrs Mina Purefoy, goddess of
+        <Annotation annotationId="010085towerlivingroom">From the high barbacans of the tower two shafts of light fall on the
+        smokepalled altarstone.</Annotation> <Annotation annotationId="010014genuinechristine">On the altarstone Mrs Mina Purefoy, goddess of
         unreason, lies, naked, fettered, a chalice resting on her swollen belly.</Annotation>
-        Father <Annotation annotationId="010021malachi" visited={visitedNotes.has("010021malachi")} annotationSelect={() => {openNote("010021malachi"); addToVisited("010021malachi")}} activeAnnotationId={currentNoteId}>Malachi</Annotation> O'Flynn in a lace petticoat and reversed chasuble, his
+        Father <Annotation annotationId="010021malachi">Malachi</Annotation> O'Flynn in a lace petticoat and reversed chasuble, his
         two left feet back to the front, celebrates camp mass. The Reverend Mr
-        Hugh C <Annotation annotationId="010023haines" visited={visitedNotes.has("010023haines")} annotationSelect={() => {openNote("010023haines"); addToVisited("010023haines")}} activeAnnotationId={currentNoteId}>Haines Love</Annotation> M. A. in a plain cassock and mortarboard, his head
+        Hugh C <Annotation annotationId="010023haines">Haines Love</Annotation> M. A. in a plain cassock and mortarboard, his head
         and collar back to the front, holds over the celebrant's head an open
         umbrella.)</i>
       </p>
@@ -10104,19 +10104,19 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         FATHER MALACHI O'FLYNN
       </p>
       <p>
-        <Annotation annotationId="010006introibo" visited={visitedNotes.has("010006introibo")} annotationSelect={() => {openNote("010006introibo"); addToVisited("010006introibo")}} activeAnnotationId={currentNoteId}><i>Introibo ad altare diaboli.</i></Annotation>
+        <Annotation annotationId="010006introibo"><i>Introibo ad altare diaboli.</i></Annotation>
       </p>
       <p>
         THE REVEREND MR HAINES LOVE
       </p>
       <p>
-        <Annotation annotationId="010006introibo" visited={visitedNotes.has("010006introibo")} annotationSelect={() => {openNote("010006introibo"); addToVisited("010006introibo")}} activeAnnotationId={currentNoteId}>To the devil which hath made glad my young days.</Annotation>
+        <Annotation annotationId="010006introibo">To the devil which hath made glad my young days.</Annotation>
       </p>
       <p>
         FATHER MALACHI O'FLYNN
       </p>
       <p>
-        <Annotation annotationId="010014genuinechristine" visited={visitedNotes.has("010014genuinechristine")} annotationSelect={() => {openNote("010014genuinechristine"); addToVisited("010014genuinechristine")}} activeAnnotationId={currentNoteId}><i>(Takes from the chalice and elevates a
+        <Annotation annotationId="010014genuinechristine"><i>(Takes from the chalice and elevates a
         blooddripping host.) Corpus meum.</i></Annotation>
       </p>
       <p>
@@ -10141,7 +10141,7 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         ADONAI
       </p>
       <p>
-        <Annotation annotationId="010047dogsbody" visited={visitedNotes.has("010047dogsbody")} annotationSelect={() => {openNote("010047dogsbody"); addToVisited("010047dogsbody")}} activeAnnotationId={currentNoteId}>Dooooooooooog!</Annotation>
+        <Annotation annotationId="010047dogsbody">Dooooooooooog!</Annotation>
       </p>
       <span data-edition="ed1939" data-page="421"> </span>
       <span data-edition="ed1922" data-page="556"> </span>
@@ -10394,7 +10394,7 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         BLOOM
       </p>
       <p>
-        <i>(Peering over the crowd.)</i> <Annotation annotationId="050013jauntingcar" visited={visitedNotes.has("050013jauntingcar")} annotationSelect={() => {openNote("050013jauntingcar"); addToVisited("050013jauntingcar")}} activeAnnotationId={currentNoteId}>I just see a car there.</Annotation> If you give me
+        <i>(Peering over the crowd.)</i> <Annotation annotationId="050013jauntingcar">I just see a car there.</Annotation> If you give me
         a hand a second, sergeant...
       </p>
       <span data-edition="ed1986" data-page="492"> </span>
@@ -10656,7 +10656,7 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         Good night. I'll just wait and take him along in a few...
       </p>
       <p>
-        <i>(Corny Kelleher <Annotation annotationId="050013jauntingcar" visited={visitedNotes.has("050013jauntingcar")} annotationSelect={() => {openNote("050013jauntingcar"); addToVisited("050013jauntingcar")}} activeAnnotationId={currentNoteId}>returns to the outside car and mounts it. The horse
+        <i>(Corny Kelleher <Annotation annotationId="050013jauntingcar">returns to the outside car and mounts it. The horse
         harness jingles.</Annotation>)</i>
       </p>
       <p>
@@ -10702,10 +10702,10 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         STEPHEN
       </p>
       <p>
-        <i>(Groans.)</i> Who? <Annotation annotationId="030149vampire" visited={visitedNotes.has("030149vampire")} annotationSelect={() => {openNote("030149vampire"); addToVisited("030149vampire")}} activeAnnotationId={currentNoteId}>Black panther. Vampire.</Annotation> <i>(He sighs and
+        <i>(Groans.)</i> Who? <Annotation annotationId="030149vampire">Black panther. Vampire.</Annotation> <i>(He sighs and
         stretches himself, then murmurs thickly with prolonged vowels.)</i>
       </p>
-      <p><Annotation annotationId="010072bittermystery" visited={visitedNotes.has("010072bittermystery")} annotationSelect={() => {openNote("010072bittermystery"); addToVisited("010072bittermystery")}} activeAnnotationId={currentNoteId}>Who... drive... Fergus now <br/>
+      <p><Annotation annotationId="010072bittermystery">Who... drive... Fergus now <br/>
         And pierce... wood's woven shade?...</Annotation>
       </p>
       <p>
@@ -10745,7 +10745,7 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       <p>
         <i>(Communes with the night.)</i> Face reminds me of his poor mother.
         In the shady wood. The deep white breast. Ferguson, I think I caught. A
-        girl. Some girl. Best thing could happen him. <i>(He murmurs.)</i>... <Annotation annotationId="080026blackandwhite" visited={visitedNotes.has("080026blackandwhite")} annotationSelect={() => {openNote("080026blackandwhite"); addToVisited("080026blackandwhite")}} activeAnnotationId={currentNoteId}>swear
+        girl. Some girl. Best thing could happen him. <i>(He murmurs.)</i>... <Annotation annotationId="080026blackandwhite">swear
         that I will always hail, ever conceal, never reveal, any part or parts,
         art or arts...</Annotation> <i>(He murmurs.)</i>... in the rough sands of the sea... a
         cabletow's length from the shore... where the tide ebbs... and flows
@@ -10771,8 +10771,8 @@ const Circe = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <p>
         <i>(Gazes, unseeing, into Bloom's eyes and goes on reading, kissing,
-        smiling. <Annotation annotationId="020080mauve" visited={visitedNotes.has("020080mauve")} annotationSelect={() => {openNote("020080mauve"); addToVisited("020080mauve")}} activeAnnotationId={currentNoteId}>He has a delicate mauve face.</Annotation> On his suit he has diamond and
-        <Annotation annotationId="040021ruby" visited={visitedNotes.has("040021ruby")} annotationSelect={() => {openNote("040021ruby"); addToVisited("040021ruby")}} activeAnnotationId={currentNoteId}>ruby buttons.</Annotation> In his free left hand he holds a slim ivory cane with a
+        smiling. <Annotation annotationId="020080mauve">He has a delicate mauve face.</Annotation> On his suit he has diamond and
+        <Annotation annotationId="040021ruby">ruby buttons.</Annotation> In his free left hand he holds a slim ivory cane with a
         violet bowknot. A white lambkin peeps out of his waistcoat pocket.)</i>
       </p>
       <br/><br/><br/>

--- a/src/content/chapters/Cyclops.js
+++ b/src/content/chapters/Cyclops.js
@@ -1,16 +1,16 @@
 import Annotation from "../../components/Annotation";
 
 
-const Cyclops = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
+const Cyclops = () => {
   return (
     <div>
       <p></p>
       <center><font size="+2">[12]</font></center>
       <br/>
-      <Annotation annotationId="120006iwasjust" visited={visitedNotes.has("120006iwasjust")} annotationSelect={() => {openNote("120006iwasjust"); addToVisited("120006iwasjust")}} activeAnnotationId={currentNoteId}>I was just</Annotation> passing the time of day with <Annotation annotationId="120012denistroy" visited={visitedNotes.has("120012denistroy")} annotationSelect={() => {openNote("120012denistroy"); addToVisited("120012denistroy")}} activeAnnotationId={currentNoteId}>old Troy of the D. M. P.</Annotation> at <Annotation annotationId="120011arbourhill" visited={visitedNotes.has("120011arbourhill")} annotationSelect={() => {openNote("120011arbourhill"); addToVisited("120011arbourhill")}} activeAnnotationId={currentNoteId}>the
+      <Annotation annotationId="120006iwasjust">I was just</Annotation> passing the time of day with <Annotation annotationId="120012denistroy">old Troy of the D. M. P.</Annotation> at <Annotation annotationId="120011arbourhill">the
       corner of Arbour hill there</Annotation> and be damned but a bloody sweep came along
-      and <Annotation annotationId="120003intomyeye" visited={visitedNotes.has("120003intomyeye")} annotationSelect={() => {openNote("120003intomyeye"); addToVisited("120003intomyeye")}} activeAnnotationId={currentNoteId}>he near drove his gear into my eye</Annotation>. I turned around to let him have
-      the weight of my tongue when who should I see dodging along <Annotation annotationId="120011arbourhill" visited={visitedNotes.has("120011arbourhill")} annotationSelect={() => {openNote("120011arbourhill"); addToVisited("120011arbourhill")}} activeAnnotationId={currentNoteId}>Stony Batter</Annotation>
+      and <Annotation annotationId="120003intomyeye">he near drove his gear into my eye</Annotation>. I turned around to let him have
+      the weight of my tongue when who should I see dodging along <Annotation annotationId="120011arbourhill">Stony Batter</Annotation>
       only Joe Hynes. 
       <p></p>
       <p>
@@ -60,10 +60,10 @@ const Cyclops = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         teas. He eat me my sugars. Because he no pay me my moneys?</i>
       </p>
       <p>
-        For nonperishable goods bought of Moses Herzog, of 13 <Annotation annotationId="040049pleasantoldtimes" visited={visitedNotes.has("040049pleasantoldtimes")} annotationSelect={() => {openNote("040049pleasantoldtimes"); addToVisited("040049pleasantoldtimes")}} activeAnnotationId={currentNoteId}>Saint Kevin's
+        For nonperishable goods bought of Moses Herzog, of 13 <Annotation annotationId="040049pleasantoldtimes">Saint Kevin's
         parade</Annotation> in the city of Dublin, Wood quay ward, merchant, hereinafter
         called the vendor, and sold and delivered to Michael E. <span data-edition="ed1986" data-page="240"> </span>Geraghty,
-        esquire, of <Annotation annotationId="120011arbourhill" visited={visitedNotes.has("120011arbourhill")} annotationSelect={() => {openNote("120011arbourhill"); addToVisited("120011arbourhill")}} activeAnnotationId={currentNoteId}>29 Arbour hill</Annotation> in the city of Dublin, Arran quay ward,
+        esquire, of <Annotation annotationId="120011arbourhill">29 Arbour hill</Annotation> in the city of Dublin, Arran quay ward,
         gentleman, hereinafter called the purchaser, videlicet, five pounds
         avoirdupois of first choice tea at three 
         <span data-edition="ed1961" data-page="292"> </span>shillings per
@@ -94,7 +94,7 @@ const Cyclops = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         —{" "}What about paying our respects to our friend? says Joe.
       </p>
       <p>
-        —{" "}Who? says I. Sure, he's <Annotation annotationId="120004kiernans" visited={visitedNotes.has("120004kiernans")} annotationSelect={() => {openNote("120004kiernans"); addToVisited("120004kiernans")}} activeAnnotationId={currentNoteId}>out in John of God's off his head</Annotation>, poor man.
+        —{" "}Who? says I. Sure, he's <Annotation annotationId="120004kiernans">out in John of God's off his head</Annotation>, poor man.
       </p>
       <p>
         —{" "}Drinking his own stuff? says Joe.
@@ -103,23 +103,23 @@ const Cyclops = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         —{" "}Ay, says I. Whisky and water on the brain.
       </p>
       <p>
-        —{" "}Come around to <Annotation annotationId="120004kiernans" visited={visitedNotes.has("120004kiernans")} annotationSelect={() => {openNote("120004kiernans"); addToVisited("120004kiernans")}} activeAnnotationId={currentNoteId}>Barney Kiernan's</Annotation>, says Joe. I want to see the citizen.
+        —{" "}Come around to <Annotation annotationId="120004kiernans">Barney Kiernan's</Annotation>, says Joe. I want to see the citizen.
       </p>
       <p>
         —{" "}Barney mavourneen's be it, says I. Anything strange or wonderful, Joe?
       </p>
       <p>
-        —{" "}Not a word, says Joe. I was up at that meeting in the <Annotation annotationId="020066cityarms" visited={visitedNotes.has("020066cityarms")} annotationSelect={() => {openNote("020066cityarms"); addToVisited("020066cityarms")}} activeAnnotationId={currentNoteId}>City Arms</Annotation>.
+        —{" "}Not a word, says Joe. I was up at that meeting in the <Annotation annotationId="020066cityarms">City Arms</Annotation>.
       </p>
       <p>
         —{" "}What was that, Joe? says I.
       </p>
       <p>
-        —{" "}Cattle traders, says Joe, about the <Annotation annotationId="020054footandmouth" visited={visitedNotes.has("020054footandmouth")} annotationSelect={() => {openNote("020054footandmouth"); addToVisited("020054footandmouth")}} activeAnnotationId={currentNoteId}>foot and mouth disease</Annotation>. I want to
+        —{" "}Cattle traders, says Joe, about the <Annotation annotationId="020054footandmouth">foot and mouth disease</Annotation>. I want to
         give the citizen the hard word about it.
       </p>
       <p>
-        So we went around by the <Annotation annotationId="010013barracks" visited={visitedNotes.has("010013barracks")} annotationSelect={() => {openNote("010013barracks"); addToVisited("010013barracks")}} activeAnnotationId={currentNoteId}>Linenhall barracks</Annotation> and the back of the
+        So we went around by the <Annotation annotationId="010013barracks">Linenhall barracks</Annotation> and the back of the
         courthouse talking of one thing or another. Decent fellow Joe when he
         has it but sure like that he never has it. Jesus, I couldn't get over
         that bloody foxy Geraghty, the daylight robber. For trading without a
@@ -181,7 +181,7 @@ const Cyclops = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         premiated milchcows and beeves: and there is ever heard a <span data-edition="ed1961" data-page="294"> </span>trampling,
         cackling, roaring, lowing, bleating, bellowing, rumbling, grunting,
         champing, chewing, of sheep and pigs and heavyhooved kine from
-        pasturelands of Lusk and Rush and Carrickmines and from <Annotation annotationId="030086dalcassians" visited={visitedNotes.has("030086dalcassians")} annotationSelect={() => {openNote("030086dalcassians"); addToVisited("030086dalcassians")}} activeAnnotationId={currentNoteId}>the streamy
+        pasturelands of Lusk and Rush and Carrickmines and from <Annotation annotationId="030086dalcassians">the streamy
         vales of Thomond</Annotation>, from the M'Gillicuddy's reeks the inaccessible and
         lordly Shannon the unfathomable, and from the gentle declivities of the
         place of the race of Kiar, their udders distended with superabundance of
@@ -266,7 +266,7 @@ const Cyclops = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <span data-edition="ed1961" data-page="295"> </span>
       <p>
-        —{" "}Never better, <Annotation annotationId="120015pishogue" visited={visitedNotes.has("120015pishogue")} annotationSelect={() => {openNote("120015pishogue"); addToVisited("120015pishogue")}} activeAnnotationId={currentNoteId}><i>a chara</i></Annotation>, says he. What Garry? Are we going to win? Eh?
+        —{" "}Never better, <Annotation annotationId="120015pishogue"><i>a chara</i></Annotation>, says he. What Garry? Are we going to win? Eh?
       </p>
       <p>
         And with that he took the bloody old towser by the scruff of the neck
@@ -280,7 +280,7 @@ const Cyclops = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         hero. From shoulder to shoulder he measured several ells <span data-edition="ed1932" data-page="266"> </span>and his
         rocklike mountainous knees were covered, as was likewise the rest of his
         body wherever visible, with a strong growth of tawny prickly hair in
-        hue and toughness similar to <Annotation annotationId="120008gorse" visited={visitedNotes.has("120008gorse")} annotationSelect={() => {openNote("120008gorse"); addToVisited("120008gorse")}} activeAnnotationId={currentNoteId}>the mountain gorse (<i>Ulex Europeus</i>)</Annotation>.
+        hue and toughness similar to <Annotation annotationId="120008gorse">the mountain gorse (<i>Ulex Europeus</i>)</Annotation>.
         The widewinged nostrils, from which bristles of the same tawny hue
         projected, were of such capaciousness that within their cavernous
         obscurity the fieldlark might easily have lodged her nest. The eyes
@@ -297,8 +297,8 @@ const Cyclops = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         to the knees in a loose kilt and this was bound about his middle by
         a girdle of plaited straw and rushes. Beneath this he wore trews of
         deerskin, roughly <span data-edition="ed1986" data-page="243"> </span>stitched with gut. His nether extremities were encased
-        in high Balbriggan buskins dyed in  <Annotation annotationId="020080mauve" visited={visitedNotes.has("020080mauve")} annotationSelect={() => {openNote("020080mauve"); addToVisited("020080mauve")}} activeAnnotationId={currentNoteId}>lichen purple</Annotation>, the feet being shod
-        with <Annotation annotationId="020076brogues" visited={visitedNotes.has("020076brogues")} annotationSelect={() => {openNote("020076brogues"); addToVisited("020076brogues")}} activeAnnotationId={currentNoteId}>brogues</Annotation> of salted cowhide laced with the windpipe of the same
+        in high Balbriggan buskins dyed in  <Annotation annotationId="020080mauve">lichen purple</Annotation>, the feet being shod
+        with <Annotation annotationId="020076brogues">brogues</Annotation> of salted cowhide laced with the windpipe of the same
         beast. From his girdle hung a row of seastones which jangled at every
         movement of his portentous frame and on these were graven with rude
         yet striking art the tribal images of many Irish heroes and heroines of
@@ -323,7 +323,7 @@ const Cyclops = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         Beethoven, the <span data-edition="ed1932" data-page="267"> </span>Colleen Bawn, Waddler Healy, Angus the Culdee, Dolly
         Mount, Sidney Parade, Ben Howth, Valentine Greatrakes, Adam and Eve,
         Arthur Wellesley, Boss Croker, Herodotus, Jack the Giantkiller, Gautama
-        Buddha, Lady Godiva, The Lily of Killarney, <Annotation annotationId="120007balor" visited={visitedNotes.has("120007balor")} annotationSelect={() => {openNote("120007balor"); addToVisited("120007balor")}} activeAnnotationId={currentNoteId}>Balor of the Evil Eye</Annotation>,
+        Buddha, Lady Godiva, The Lily of Killarney, <Annotation annotationId="120007balor">Balor of the Evil Eye</Annotation>,
         the Queen of Sheba, Acky Nagle, Joe 
         <span data-edition="ed1939" data-page="216"> </span>
         Nagle, Alessandro Volta, Jeremiah
@@ -361,9 +361,9 @@ const Cyclops = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         prudent soul.
       </p>
       <p>
-        —{" "}For <Annotation annotationId="040006homerulesun" visited={visitedNotes.has("040006homerulesun")} annotationSelect={() => {openNote("040006homerulesun"); addToVisited("040006homerulesun")}} activeAnnotationId={currentNoteId}>the old woman of Prince's street</Annotation>, says the citizen, the <span data-edition="ed1961" data-page="297"> </span>subsidised
+        —{" "}For <Annotation annotationId="040006homerulesun">the old woman of Prince's street</Annotation>, says the citizen, the <span data-edition="ed1961" data-page="297"> </span>subsidised
         organ. The pledgebound party on the floor of the house. And look at this
-        blasted rag, says he. Look at this, says he. <Annotation annotationId="120009irishindependent" visited={visitedNotes.has("120009irishindependent")} annotationSelect={() => {openNote("120009irishindependent"); addToVisited("120009irishindependent")}} activeAnnotationId={currentNoteId}><i>The Irish Independent,</i> if
+        blasted rag, says he. Look at this, says he. <Annotation annotationId="120009irishindependent"><i>The Irish Independent,</i> if
         you please, founded by Parnell to be the workingman's friend. Listen to
         the births and deaths in the <i>Irish all for Ireland Independent,</i> and
         I'll thank you and the marriages.</Annotation>
@@ -379,7 +379,7 @@ const Cyclops = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         late George Alfred Gillett, 179 Clapham road, Stockwell, Playwood and
         Ridsdale at Saint Jude's, Kensington by the very reverend Dr Forrest,
         dean of Worcester. Eh? Deaths. Bristow, at Whitehall lane, London: Carr,
-        Stoke Newington, of gastritis and heart disease: <Annotation annotationId="120014cockburn" visited={visitedNotes.has("120014cockburn")} annotationSelect={() => {openNote("120014cockburn"); addToVisited("120014cockburn")}} activeAnnotationId={currentNoteId}>Cockburn</Annotation>, at the Moat
+        Stoke Newington, of gastritis and heart disease: <Annotation annotationId="120014cockburn">Cockburn</Annotation>, at the Moat
         house, Chepstow...
       </p>
       <p>
@@ -390,7 +390,7 @@ const Cyclops = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         —{" "}Cockburn. Dimsey, wife of David Dimsey, late of the admiralty: Miller,
         Tottenham, aged eightyfive: Welsh, June 12, at 35 Canning street,
         Liverpool, Isabella Helen. How's that for a national press, eh, my brown
-        son! How's that for <Annotation annotationId="120002martinmurphy" visited={visitedNotes.has("120002martinmurphy")} annotationSelect={() => {openNote("120002martinmurphy"); addToVisited("120002martinmurphy")}} activeAnnotationId={currentNoteId}>Martin Murphy, the Bantry jobber</Annotation>?
+        son! How's that for <Annotation annotationId="120002martinmurphy">Martin Murphy, the Bantry jobber</Annotation>?
       </p>
       <p>
         —{" "}Ah, well, says Joe, handing round the boose. Thanks be to God they had
@@ -415,7 +415,7 @@ const Cyclops = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <p>
         Little Alf Bergan popped in round the door and hid behind Barney's
-        snug, squeezed up with the laughing. <Annotation annotationId="050038bobdoran" visited={visitedNotes.has("050038bobdoran")} annotationSelect={() => {openNote("050038bobdoran"); addToVisited("050038bobdoran")}} activeAnnotationId={currentNoteId}>And who was sitting up there in
+        snug, squeezed up with the laughing. <Annotation annotationId="050038bobdoran">And who was sitting up there in
         the corner that I hadn't seen snoring drunk blind to the world only Bob
         Doran.</Annotation> I didn't know what 
         <span data-edition="ed1939" data-page="217"> </span>
@@ -426,7 +426,7 @@ const Cyclops = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         poodle. I thought Alf would split.
       </p>
       <p>
-        —{" "}Look at him, says he. Breen. He's traipsing all round Dublin with <Annotation annotationId="080010upup" visited={visitedNotes.has("080010upup")} annotationSelect={() => {openNote("080010upup"); addToVisited("080010upup")}} activeAnnotationId={currentNoteId}>a
+        —{" "}Look at him, says he. Breen. He's traipsing all round Dublin with <Annotation annotationId="080010upup">a
         postcard someone sent him with u. p.: up on it</Annotation> to take a li...
       </p>
       <p>
@@ -448,7 +448,7 @@ const Cyclops = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         seeing something was up but the citizen gave him a kick in the ribs.
       </p>
       <p>
-        —{" "}<Annotation annotationId="120015pishogue" visited={visitedNotes.has("120015pishogue")} annotationSelect={() => {openNote("120015pishogue"); addToVisited("120015pishogue")}} activeAnnotationId={currentNoteId}><i>Bi i dho husht,</i></Annotation> says he.
+        —{" "}<Annotation annotationId="120015pishogue"><i>Bi i dho husht,</i></Annotation> says he.
       </p>
       <p>
         —{" "}Who? says Joe.
@@ -546,7 +546,7 @@ const Cyclops = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <span data-edition="ed1932" data-page="270"> </span>
       <p>
-        —{" "}I don't know, says Alf I saw him just now in <Annotation annotationId="040043capelstreet" visited={visitedNotes.has("040043capelstreet")} annotationSelect={() => {openNote("040043capelstreet"); addToVisited("040043capelstreet")}} activeAnnotationId={currentNoteId}>Capel street</Annotation> with Paddy
+        —{" "}I don't know, says Alf I saw him just now in <Annotation annotationId="040043capelstreet">Capel street</Annotation> with Paddy
         Dignam. Only I was running after that...
       </p>
       <p>
@@ -714,7 +714,7 @@ const Cyclops = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       <p>
         The tear is bloody near your eye. Talking through his bloody hat. Fitter
         for him go home to the little sleepwalking bitch he married, Mooney, the
-        bumbailiff's daughter, mother kept <Annotation annotationId="160005dosshouse" visited={visitedNotes.has("160005dosshouse")} annotationSelect={() => {openNote("160005dosshouse"); addToVisited("160005dosshouse")}} activeAnnotationId={currentNoteId}>a kip in Hardwicke street</Annotation>, that
+        bumbailiff's daughter, mother kept <Annotation annotationId="160005dosshouse">a kip in Hardwicke street</Annotation>, that
         used to be stravaging about the landings Bantam Lyons told me that was
         stopping there at two in the morning without a stitch on her, exposing
         her person, open to all comers, fair field and no favour.
@@ -737,7 +737,7 @@ const Cyclops = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <p>
         So Bloom slopes in with his cod's eye on the dog and he asks Terry was
-        <Annotation annotationId="060034martincunningham" visited={visitedNotes.has("060034martincunningham")} annotationSelect={() => {openNote("060034martincunningham"); addToVisited("060034martincunningham")}} activeAnnotationId={currentNoteId}>Martin Cunningham</Annotation> there.
+        <Annotation annotationId="060034martincunningham">Martin Cunningham</Annotation> there.
       </p>
       <p>
         —{" "}O, Christ M'Keown, says Joe, reading one of the letters. Listen to
@@ -903,17 +903,17 @@ const Cyclops = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         mongrel.
       </p>
       <p>
-        And the citizen and Bloom having an argument about the point, <Annotation annotationId="120011arbourhill" visited={visitedNotes.has("120011arbourhill")} annotationSelect={() => {openNote("120011arbourhill"); addToVisited("120011arbourhill")}} activeAnnotationId={currentNoteId}>the
+        And the citizen and Bloom having an argument about the point, <Annotation annotationId="120011arbourhill">the
         brothers Sheares and Wolfe Tone beyond on Arbour Hill</Annotation> and Robert Emmet
         and die for your country, the Tommy Moore touch about Sara Curran and
-        she's far from the land. And Bloom, of course, with his <Annotation annotationId="120003intomyeye" visited={visitedNotes.has("120003intomyeye")} annotationSelect={() => {openNote("120003intomyeye"); addToVisited("120003intomyeye")}} activeAnnotationId={currentNoteId}>knockmedown
+        she's far from the land. And Bloom, of course, with his <Annotation annotationId="120003intomyeye">knockmedown
         cigar</Annotation> putting on swank with his lardy face. Phenomenon! The fat heap he
         married is a nice old phenomenon with a back on her like a ballalley.
-        Time they were stopping up in the <Annotation annotationId="020066cityarms" visited={visitedNotes.has("020066cityarms")} annotationSelect={() => {openNote("020066cityarms"); addToVisited("020066cityarms")}} activeAnnotationId={currentNoteId}><i>City Arms</i></Annotation> pisser Burke told me there
+        Time they were stopping up in the <Annotation annotationId="020066cityarms"><i>City Arms</i></Annotation> pisser Burke told me there
         was an old one there with a cracked loodheramaun 
         <span data-edition="ed1939" data-page="222"> </span>
         of a nephew and Bloom
-        trying to get the soft side <span data-edition="ed1961" data-page="305"> </span>of her <Annotation annotationId="060015riordan" visited={visitedNotes.has("060015riordan")} annotationSelect={() => {openNote("060015riordan"); addToVisited("060015riordan")}} activeAnnotationId={currentNoteId}>doing the mollycoddle playing bézique to come in for a bit of the wampum in her will and not eating meat of a</Annotation>
+        trying to get the soft side <span data-edition="ed1961" data-page="305"> </span>of her <Annotation annotationId="060015riordan">doing the mollycoddle playing bézique to come in for a bit of the wampum in her will and not eating meat of a</Annotation>
         Friday because the old one was always thumping her craw and taking the
         lout out for a walk. And one time he <span data-edition="ed1932" data-page="275"> </span>led him the rounds of Dublin and,
         by the holy farmer, he never cried crack till he brought him home as
@@ -938,7 +938,7 @@ const Cyclops = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         —{" "}You don't grasp my point, says Bloom. What I mean is...
       </p>
       <p>
-        —{" "}<i>Sinn Fein!</i> says the citizen. <Annotation annotationId="120015pishogue" visited={visitedNotes.has("120015pishogue")} annotationSelect={() => {openNote("120015pishogue"); addToVisited("120015pishogue")}} activeAnnotationId={currentNoteId}><i>Sinn Fein amhain!</i></Annotation> The friends we love
+        —{" "}<i>Sinn Fein!</i> says the citizen. <Annotation annotationId="120015pishogue"><i>Sinn Fein amhain!</i></Annotation> The friends we love
         are by our side and the foes we hate before us.
       </p>
       <p>
@@ -962,7 +962,7 @@ const Cyclops = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         and upholstered charabancs had been provided for the comfort of our
         country <span data-edition="ed1961" data-page="306"> </span>cousins of whom there were large contingents. Considerable
         amusement was caused by the favourite Dublin streetsingers L-n-h-n and
-        M-ll-g-n who sang <Annotation annotationId="040081boldlarry" visited={visitedNotes.has("040081boldlarry")} annotationSelect={() => {openNote("040081boldlarry"); addToVisited("040081boldlarry")}} activeAnnotationId={currentNoteId}><i>The Night before Larry was stretched</i></Annotation> in their usual
+        M-ll-g-n who sang <Annotation annotationId="040081boldlarry"><i>The Night before Larry was stretched</i></Annotation> in their usual
         mirth-provoking fashion. Our two inimitable drolls did a roaring trade
         with their broadsheets among lovers of the comedy element and nobody
         who has a corner in his heart for real Irish fun without vulgarity
@@ -1003,7 +1003,7 @@ const Cyclops = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         MacFadden, summoned by special courier from Booterstown, quickly
         restored order and with lightning promptitude proposed the seventeenth
         of the month as a solution equally honourable for both contending
-        parties. The readywitted <Annotation annotationId="040084sizeable" visited={visitedNotes.has("040084sizeable")} annotationSelect={() => {openNote("040084sizeable"); addToVisited("040084sizeable")}} activeAnnotationId={currentNoteId}>ninefooter</Annotation>'s suggestion at once appealed to all
+        parties. The readywitted <Annotation annotationId="040084sizeable">ninefooter</Annotation>'s suggestion at once appealed to all
         and was unanimously accepted. Constable MacFadden was heartily
         congratulated by all the F. O. T. E. I., several of whom were bleeding
         profusely. Commendatore Beninobenone having been extricated from
@@ -1119,7 +1119,7 @@ const Cyclops = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         I thinks of my old mashtub what's waiting for me down Limehouse way.
       </p>
       <p>
-        So then the citizen begins talking about the Irish language and <Annotation annotationId="060033corporation" visited={visitedNotes.has("060033corporation")} annotationSelect={() => {openNote("060033corporation"); addToVisited("060033corporation")}} activeAnnotationId={currentNoteId}>the
+        So then the citizen begins talking about the Irish language and <Annotation annotationId="060033corporation">the
         corporation meeting</Annotation> and all to that and the shoneens that can't speak
         their own language and Joe chipping in because he stuck someone for a
         quid and Bloom putting in his <span data-edition="ed1961" data-page="310"> </span>old goo with his twopenny stump that
@@ -1185,7 +1185,7 @@ const Cyclops = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         the verse recited and has found it bears a <i>striking</i> resemblance 
         <span data-edition="ed1922" data-page="298"> </span>
         (the italics are ours) to the ranns of ancient Celtic bards. We are not
-        speaking so much of <Annotation annotationId="090003hyde" visited={visitedNotes.has("090003hyde")} annotationSelect={() => {openNote("090003hyde"); addToVisited("090003hyde")}} activeAnnotationId={currentNoteId}>those delightful lovesongs with which the writer who
+        speaking so much of <Annotation annotationId="090003hyde">those delightful lovesongs with which the writer who
         conceals his identity under the graceful pseudonym of the Little
         Sweet Branch has familiarised the bookloving world</Annotation> but rather (as
         a contributor D. O. C. points out in an interesting communication
@@ -1242,7 +1242,7 @@ const Cyclops = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <p>
         —{" "}Thank you, no, says Bloom. As a matter of fact I just wanted to meet
-        Martin Cunningham, don't you see, about <Annotation annotationId="130007scottishwidows" visited={visitedNotes.has("130007scottishwidows")} annotationSelect={() => {openNote("130007scottishwidows"); addToVisited("130007scottishwidows")}} activeAnnotationId={currentNoteId}>this insurance of poor Dignam's</Annotation>.
+        Martin Cunningham, don't you see, about <Annotation annotationId="130007scottishwidows">this insurance of poor Dignam's</Annotation>.
         Martin asked me to go to the house. You see, he, Dignam, I mean, didn't
         serve any notice of the assignment on the company at the time and
         nominally under the act the mortgagee can't recover on the policy.
@@ -1306,11 +1306,11 @@ const Cyclops = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       <p>
         And off with him and out trying to walk straight. Boosed at five
         o'clock. Night he was near being lagged only Paddy Leonard knew the
-        bobby, 14A. Blind to the world up in a shebeen in <Annotation annotationId="030023bridestreet" visited={visitedNotes.has("030023bridestreet")} annotationSelect={() => {openNote("030023bridestreet"); addToVisited("030023bridestreet")}} activeAnnotationId={currentNoteId}>Bride street</Annotation> after
+        bobby, 14A. Blind to the world up in a shebeen in <Annotation annotationId="030023bridestreet">Bride street</Annotation> after
         closing time, fornicating with two shawls and a bully on guard, drinking
         porter out of teacups. And calling himself a Frenchy for the shawls,
         Joseph Manuo, and talking against the Catholic religion, and he serving
-        <Annotation annotationId="070024differentchurches" visited={visitedNotes.has("070024differentchurches")} annotationSelect={() => {openNote("070024differentchurches"); addToVisited("070024differentchurches")}} activeAnnotationId={currentNoteId}>mass in Adam and Eve's</Annotation> when he was young with his eyes shut, who wrote
+        <Annotation annotationId="070024differentchurches">mass in Adam and Eve's</Annotation> when he was young with his eyes shut, who wrote
         the new testament, and the old testament, and hugging and smugging. And
         the two shawls killed with the laughing, picking his pockets, the bloody
         fool and he spilling the porter all over the bed and the two shawls
@@ -1332,7 +1332,7 @@ const Cyclops = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         —{" "}Here, says Joe, doing the honours. Here, citizen.
       </p>
       <p>
-        —{" "}<Annotation annotationId="120015pishogue" visited={visitedNotes.has("120015pishogue")} annotationSelect={() => {openNote("120015pishogue"); addToVisited("120015pishogue")}} activeAnnotationId={currentNoteId}><i>Slan leat</i></Annotation>, says he.
+        —{" "}<Annotation annotationId="120015pishogue"><i>Slan leat</i></Annotation>, says he.
       </p>
       <p>
         —{" "}Fortune, Joe, says I. Good health, citizen.
@@ -1342,19 +1342,19 @@ const Cyclops = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         fortune to keep him in drinks.
       </p>
       <p>
-        —{" "}Who is the long fellow <Annotation annotationId="070019nannetti" visited={visitedNotes.has("070019nannetti")} annotationSelect={() => {openNote("070019nannetti"); addToVisited("070019nannetti")}} activeAnnotationId={currentNoteId}>running for the mayoralty</Annotation>, Alf? says Joe.
+        —{" "}Who is the long fellow <Annotation annotationId="070019nannetti">running for the mayoralty</Annotation>, Alf? says Joe.
       </p>
       <p>
         —{" "}Friend of yours, says Alf.
       </p>
       <p>
-        —{" "}Nannan? says Joe. The <Annotation annotationId="070019nannetti" visited={visitedNotes.has("070019nannetti")} annotationSelect={() => {openNote("070019nannetti"); addToVisited("070019nannetti")}} activeAnnotationId={currentNoteId}>mimber</Annotation>?
+        —{" "}Nannan? says Joe. The <Annotation annotationId="070019nannetti">mimber</Annotation>?
       </p>
       <p>
         —{" "}I won't mention any names, says Alf.
       </p>
       <p>
-        —{" "}I thought so, says Joe. I saw him up at that meeting now with <Annotation annotationId="020074blackwoodprice" visited={visitedNotes.has("020074blackwoodprice")} annotationSelect={() => {openNote("020074blackwoodprice"); addToVisited("020074blackwoodprice")}} activeAnnotationId={currentNoteId}>William
+        —{" "}I thought so, says Joe. I saw him up at that meeting now with <Annotation annotationId="020074blackwoodprice">William
         Field, M. P.</Annotation>, the cattle traders.
       </p>
       <span data-edition="ed1961" data-page="314"> </span>
@@ -1369,7 +1369,7 @@ const Cyclops = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         <span data-edition="ed1922" data-page="301"> </span>
         to the rightabout and Bloom coming out with his
         sheepdip for the scab and a hoose drench for coughing calves and the
-        guaranteed remedy for timber tongue. Because he was up one time <Annotation annotationId="040037cattlemarket" visited={visitedNotes.has("040037cattlemarket")} annotationSelect={() => {openNote("040037cattlemarket"); addToVisited("040037cattlemarket")}} activeAnnotationId={currentNoteId}>in a
+        guaranteed remedy for timber tongue. Because he was up one time <Annotation annotationId="040037cattlemarket">in a
         knacker's yard. Walking about with his book and pencil</Annotation> here's my head
         and my heels are coming till Joe Cuffe gave him the order of the boot
         for giving lip to a grazier. Mister Knowall. Teach your grandmother how
@@ -1398,14 +1398,14 @@ const Cyclops = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <span data-edition="ed1932" data-page="284"> </span>
       <p>
-        —{" "}Well, he's going off <Annotation annotationId="010036mailboat" visited={visitedNotes.has("010036mailboat")} annotationSelect={() => {openNote("010036mailboat"); addToVisited("010036mailboat")}} activeAnnotationId={currentNoteId}>by the mailboat</Annotation>, says Joe, tonight.
+        —{" "}Well, he's going off <Annotation annotationId="010036mailboat">by the mailboat</Annotation>, says Joe, tonight.
       </p>
       <p>
         —{" "}That's too bad, says Bloom. I wanted particularly. Perhaps only Mr
         Field is going. I couldn't phone. No. You're sure?
       </p>
       <p>
-        —{" "}<Annotation annotationId="070019nannetti" visited={visitedNotes.has("070019nannetti")} annotationSelect={() => {openNote("070019nannetti"); addToVisited("070019nannetti")}} activeAnnotationId={currentNoteId}>Nannan</Annotation>'s going too, says Joe. The league told him to ask a question
+        —{" "}<Annotation annotationId="070019nannetti">Nannan</Annotation>'s going too, says Joe. The league told him to ask a question
         tomorrow about the commissioner of police forbidding Irish games in the
         park. What do you think of that, citizen? <i>The Sluagh na h-Eireann</i>.
       </p>
@@ -1455,12 +1455,12 @@ const Cyclops = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <p>
         —{" "}There's the man, says Joe, that made the Gaelic sports revival. There
-        he is sitting there. <Annotation annotationId="020073fenians" visited={visitedNotes.has("020073fenians")} annotationSelect={() => {openNote("020073fenians"); addToVisited("020073fenians")}} activeAnnotationId={currentNoteId}>The man that got away James Stephens.</Annotation> The champion
+        he is sitting there. <Annotation annotationId="020073fenians">The man that got away James Stephens.</Annotation> The champion
         of all Ireland at putting the sixteen pound shot. What was your best
         throw, citizen?
       </p>
       <p>
-        —{" "}<Annotation annotationId="120015pishogue" visited={visitedNotes.has("120015pishogue")} annotationSelect={() => {openNote("120015pishogue"); addToVisited("120015pishogue")}} activeAnnotationId={currentNoteId}><i>Na bacleis</i></Annotation>, says the citizen, letting on to be modest. There was a
+        —{" "}<Annotation annotationId="120015pishogue"><i>Na bacleis</i></Annotation>, says the citizen, letting on to be modest. There was a
         time I was as good as the next fellow anyhow.
       </p>
       <p>
@@ -1478,9 +1478,9 @@ const Cyclops = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         lawn tennis and about hurley and putting the stone and racy of the soil
         and building up a nation once again and all to that. And of course Bloom
         had to have his say too about if a fellow had a rower's heart <span data-edition="ed1932" data-page="285"> </span>violent
-        exercise was bad. I declare to my antimacassar if you took up <Annotation annotationId="080022sawdust" visited={visitedNotes.has("080022sawdust")} annotationSelect={() => {openNote("080022sawdust"); addToVisited("080022sawdust")}} activeAnnotationId={currentNoteId}>a straw
-        from the bloody floor</Annotation> and if you said to Bloom: <i>Look at, Bloom. <Annotation annotationId="080008parallax" visited={visitedNotes.has("080008parallax")} annotationSelect={() => {openNote("080008parallax"); addToVisited("080008parallax")}} activeAnnotationId={currentNoteId}>Do you
-        see that straw? That's a straw.</Annotation></i><Annotation annotationId="080008parallax" visited={visitedNotes.has("080008parallax")} annotationSelect={() => {openNote("080008parallax"); addToVisited("080008parallax")}} activeAnnotationId={currentNoteId}> Declare to my aunt he'd talk about it
+        exercise was bad. I declare to my antimacassar if you took up <Annotation annotationId="080022sawdust">a straw
+        from the bloody floor</Annotation> and if you said to Bloom: <i>Look at, Bloom. <Annotation annotationId="080008parallax">Do you
+        see that straw? That's a straw.</Annotation></i><Annotation annotationId="080008parallax"> Declare to my aunt he'd talk about it
         for an hour so he would and talk steady.</Annotation>
       </p>
       <p>
@@ -1608,7 +1608,7 @@ const Cyclops = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         lamb suddenly waded in all over his man and landed a terrific left to
         Battling Bennett's stomach, flooring him flat. It was a knockout clean and 
         <span data-edition="ed1922" data-page="305"> </span>
-        clever. Amid tense expectation the <Annotation annotationId="010013barracks" visited={visitedNotes.has("010013barracks")} annotationSelect={() => {openNote("010013barracks"); addToVisited("010013barracks")}} activeAnnotationId={currentNoteId}>Portobello</Annotation> bruiser was being
+        clever. Amid tense expectation the <Annotation annotationId="010013barracks">Portobello</Annotation> bruiser was being
         counted out when Bennett's second Ole Pfotts Wettstein threw in the
         towel and the Santry boy was declared victor to the frenzied cheers of
         the public who broke through the ringropes and fairly mobbed him with
@@ -1639,7 +1639,7 @@ const Cyclops = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         Hoho begob says I to myself says I. That explains the milk in the
         cocoanut and absence of hair on the animal's chest. Blazes doing the
         tootle on the flute. Concert tour. Dirty Dan the dodger's son off Island
-        bridge that <Annotation annotationId="010058bloodyswindle" visited={visitedNotes.has("010058bloodyswindle")} annotationSelect={() => {openNote("010058bloodyswindle"); addToVisited("010058bloodyswindle")}} activeAnnotationId={currentNoteId}>sold the same horses twice over to the government to fight
+        bridge that <Annotation annotationId="010058bloodyswindle">sold the same horses twice over to the government to fight
         the Boers</Annotation>. Old Whatwhat. I called about the poor and water rate, Mr
         Boylan. You what? The water rate, Mr Boylan. You whatwhat? That's the
         bucko that'll organise her, take my tip. 'Twixt me and you Caddareesh.
@@ -1764,7 +1764,7 @@ const Cyclops = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         —{" "}Nor good red herring, says Joe.
       </p>
       <p>
-        —{" "}That what's I mean, says the citizen. A <Annotation annotationId="120015pishogue" visited={visitedNotes.has("120015pishogue")} annotationSelect={() => {openNote("120015pishogue"); addToVisited("120015pishogue")}} activeAnnotationId={currentNoteId}>pishogue</Annotation>, if you know what
+        —{" "}That what's I mean, says the citizen. A <Annotation annotationId="120015pishogue">pishogue</Annotation>, if you know what
         that is.
       </p>
       <p>
@@ -1833,7 +1833,7 @@ const Cyclops = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         —{" "}Recorder, says Ned.
       </p>
       <p>
-        —{" "}<Annotation annotationId="080002sirfrederick" visited={visitedNotes.has("080002sirfrederick")} annotationSelect={() => {openNote("080002sirfrederick"); addToVisited("080002sirfrederick")}} activeAnnotationId={currentNoteId}>Poor old sir Frederick</Annotation>, says Alf, you can cod him <Annotation annotationId="080008parallax" visited={visitedNotes.has("080008parallax")} annotationSelect={() => {openNote("080008parallax"); addToVisited("080008parallax")}} activeAnnotationId={currentNoteId}>up to the two eyes</Annotation>.
+        —{" "}<Annotation annotationId="080002sirfrederick">Poor old sir Frederick</Annotation>, says Alf, you can cod him <Annotation annotationId="080008parallax">up to the two eyes</Annotation>.
       </p>
       <p>
         —{" "}Heart as big as a lion, says Ned. Tell him a tale of woe about arrears 
@@ -1844,7 +1844,7 @@ const Cyclops = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       <p>
         —{" "}Ay, says Alf. Reuben J. was bloody lucky he didn't clap him in the dock
         the other day for suing poor little Gumley that's minding stones, for
-        <Annotation annotationId="060033corporation" visited={visitedNotes.has("060033corporation")} annotationSelect={() => {openNote("060033corporation"); addToVisited("060033corporation")}} activeAnnotationId={currentNoteId}>the corporation</Annotation> there near <Annotation annotationId="070015buttbridge" visited={visitedNotes.has("070015buttbridge")} annotationSelect={() => {openNote("070015buttbridge"); addToVisited("070015buttbridge")}} activeAnnotationId={currentNoteId}>Butt bridge</Annotation>.
+        <Annotation annotationId="060033corporation">the corporation</Annotation> there near <Annotation annotationId="070015buttbridge">Butt bridge</Annotation>.
       </p>
       <p>
         And he starts taking off the old recorder letting on to cry:
@@ -1902,7 +1902,7 @@ const Cyclops = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         against him for he was a malefactor.
       </p>
       <p>
-        —{" "}Those are nice things, says the citizen, <Annotation annotationId="120013whiteeyedkaffir" visited={visitedNotes.has("120013whiteeyedkaffir")} annotationSelect={() => {openNote("120013whiteeyedkaffir"); addToVisited("120013whiteeyedkaffir")}} activeAnnotationId={currentNoteId}>coming over here to Ireland
+        —{" "}Those are nice things, says the citizen, <Annotation annotationId="120013whiteeyedkaffir">coming over here to Ireland
         filling the country with bugs</Annotation>.
       </p>
       <p>
@@ -1920,7 +1920,7 @@ const Cyclops = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <p>
         —{" "}Swindling the peasants, says the citizen, and the poor of Ireland. We
-        want no more <Annotation annotationId="010024stranger" visited={visitedNotes.has("010024stranger")} annotationSelect={() => {openNote("010024stranger"); addToVisited("010024stranger")}} activeAnnotationId={currentNoteId}>strangers</Annotation> in our house.
+        want no more <Annotation annotationId="010024stranger">strangers</Annotation> in our house.
       </p>
       <p>
         —{" "}O, I'm sure that will be all right, Hynes, says Bloom. It's just that
@@ -1936,7 +1936,7 @@ const Cyclops = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <p>
         —{" "}The strangers, says the citizen. Our own fault. We let them come in.
-        We brought them in. <Annotation annotationId="020070womansin" visited={visitedNotes.has("020070womansin")} annotationSelect={() => {openNote("020070womansin"); addToVisited("020070womansin")}} activeAnnotationId={currentNoteId}>The adulteress and her paramour brought the Saxon
+        We brought them in. <Annotation annotationId="020070womansin">The adulteress and her paramour brought the Saxon
         robbers here.</Annotation>
       </p>
       <p>
@@ -1985,7 +1985,7 @@ const Cyclops = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <p>
         —{" "}Well, says the citizen, what's the latest from the scene of action?
-        What did those <Annotation annotationId="030078tinkers" visited={visitedNotes.has("030078tinkers")} annotationSelect={() => {openNote("030078tinkers"); addToVisited("030078tinkers")}} activeAnnotationId={currentNoteId}>tinkers</Annotation> in the <Annotation annotationId="060033corporation" visited={visitedNotes.has("060033corporation")} annotationSelect={() => {openNote("060033corporation"); addToVisited("060033corporation")}} activeAnnotationId={currentNoteId}>city hall</Annotation> at their caucus meeting decide
+        What did those <Annotation annotationId="030078tinkers">tinkers</Annotation> in the <Annotation annotationId="060033corporation">city hall</Annotation> at their caucus meeting decide
         about the Irish language?
       </p>
       <p>
@@ -1999,7 +1999,7 @@ const Cyclops = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <p>
         —{" "}It's on the march, says the citizen. To hell with the bloody brutal
-        <Annotation annotationId="010024stranger" visited={visitedNotes.has("010024stranger")} annotationSelect={() => {openNote("010024stranger"); addToVisited("010024stranger")}} activeAnnotationId={currentNoteId}>Sassenachs</Annotation> and their <i>patois.</i>
+        <Annotation annotationId="010024stranger">Sassenachs</Annotation> and their <i>patois.</i>
       </p>
       <span data-edition="ed1961" data-page="324"> </span>
       <p>
@@ -2010,7 +2010,7 @@ const Cyclops = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         their colonies and their civilisation.
       </p>
       <p>
-        —{" "}<Annotation annotationId="120014cockburn" visited={visitedNotes.has("120014cockburn")} annotationSelect={() => {openNote("120014cockburn"); addToVisited("120014cockburn")}} activeAnnotationId={currentNoteId}>Their syphilisation</Annotation>, you mean, says the citizen. To hell with
+        —{" "}<Annotation annotationId="120014cockburn">Their syphilisation</Annotation>, you mean, says the citizen. To hell with
         them! The curse of a goodfornothing God light sideways on the bloody
         thicklugged <span data-edition="ed1986" data-page="266"> </span>sons of whores' gets! No music and no art and no literature
         worthy of the name. Any civilisation they have they stole from us.
@@ -2020,15 +2020,15 @@ const Cyclops = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         —{" "}The European family, says J. J....
       </p>
       <p>
-        —{" "}They're not European, says the citizen. I was in Europe with <Annotation annotationId="030051kevinegan" visited={visitedNotes.has("030051kevinegan")} annotationSelect={() => {openNote("030051kevinegan"); addToVisited("030051kevinegan")}} activeAnnotationId={currentNoteId}>Kevin</Annotation>
-        <span data-edition="ed1932" data-page="293"> </span><Annotation annotationId="030051kevinegan" visited={visitedNotes.has("030051kevinegan")} annotationSelect={() => {openNote("030051kevinegan"); addToVisited("030051kevinegan")}} activeAnnotationId={currentNoteId}>Egan of Paris</Annotation>. You wouldn't see a trace of them or their language
+        —{" "}They're not European, says the citizen. I was in Europe with <Annotation annotationId="030051kevinegan">Kevin</Annotation>
+        <span data-edition="ed1932" data-page="293"> </span><Annotation annotationId="030051kevinegan">Egan of Paris</Annotation>. You wouldn't see a trace of them or their language
         anywhere in Europe except in a <i>cabinet d'aisance.</i>
       </p>
       <p>
         And says John Wyse:
       </p>
       <p>
-        —{" "}<Annotation annotationId="060005churchyard" visited={visitedNotes.has("060005churchyard")} annotationSelect={() => {openNote("060005churchyard"); addToVisited("060005churchyard")}} activeAnnotationId={currentNoteId}>Full many a flower is born to blush unseen.</Annotation>
+        —{" "}<Annotation annotationId="060005churchyard">Full many a flower is born to blush unseen.</Annotation>
       </p>
       <p>
         And says Lenehan that knows a bit of the lingo:
@@ -2041,7 +2041,7 @@ const Cyclops = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         He said and then lifted he in his rude great brawny strengthy hands the
         medher of dark strong foamy ale and, uttering his tribal slogan <i>Lamh
         Dearg Abu</i>, he drank to the undoing of his foes, a race of mighty
-        valorous heroes, <Annotation annotationId="010107seasruler" visited={visitedNotes.has("010107seasruler")} annotationSelect={() => {openNote("010107seasruler"); addToVisited("010107seasruler")}} activeAnnotationId={currentNoteId}>rulers of the waves</Annotation>, who sit on thrones of alabaster
+        valorous heroes, <Annotation annotationId="010107seasruler">rulers of the waves</Annotation>, who sit on thrones of alabaster
         silent as the deathless gods.
       </p>
       <p>
@@ -2089,14 +2089,14 @@ const Cyclops = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <p>
         And J. J. and the citizen arguing about law and history with Bloom
-        <Annotation annotationId="120003intomyeye" visited={visitedNotes.has("120003intomyeye")} annotationSelect={() => {openNote("120003intomyeye"); addToVisited("120003intomyeye")}} activeAnnotationId={currentNoteId}>sticking in an odd word</Annotation>.
+        <Annotation annotationId="120003intomyeye">sticking in an odd word</Annotation>.
       </p>
       <p>
         —{" "}Some people, says Bloom, can see the mote in others' eyes but they
         can't see the beam in their own.
       </p>
       <p>
-        —{" "}<Annotation annotationId="120015pishogue" visited={visitedNotes.has("120015pishogue")} annotationSelect={() => {openNote("120015pishogue"); addToVisited("120015pishogue")}} activeAnnotationId={currentNoteId}><i>Raimeis</i></Annotation>, says the citizen. There's no-one as blind as the fellow
+        —{" "}<Annotation annotationId="120015pishogue"><i>Raimeis</i></Annotation>, says the citizen. There's no-one as blind as the fellow
         that won't see, if you know what that means. Where are our missing
         twenty millions of Irish should be here today instead of four, our lost
         tribes? And our potteries and textiles, the finest in the whole world!
@@ -2109,13 +2109,13 @@ const Cyclops = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         Greek merchants that came through the pillars of Hercules, 
         <span data-edition="ed1922" data-page="312"> </span>
         the Gibraltar
-        now grabbed by the foe of mankind, with gold and <Annotation annotationId="020080mauve" visited={visitedNotes.has("020080mauve")} annotationSelect={() => {openNote("020080mauve"); addToVisited("020080mauve")}} activeAnnotationId={currentNoteId}>Tyrian purple</Annotation> to
+        now grabbed by the foe of mankind, with gold and <Annotation annotationId="020080mauve">Tyrian purple</Annotation> to
         sell in Wexford at the fair of Carmen? Read Tacitus and Ptolemy, even
-        Giraldus Cambrensis. Wine, peltries, <Annotation annotationId="170019localities" visited={visitedNotes.has("170019localities")} annotationSelect={() => {openNote("170019localities"); addToVisited("170019localities")}} activeAnnotationId={currentNoteId}>Connemara marble</Annotation>, silver from
+        Giraldus Cambrensis. Wine, peltries, <Annotation annotationId="170019localities">Connemara marble</Annotation>, silver from
         Tipperary, second to none, our farfamed horses even today, the Irish
         hobbies, with king Philip of Spain offering to pay customs duties for
         the right to fish in our waters. What do the yellowjohns of Anglia owe
-        us for our ruined trade and our ruined hearths? <Annotation annotationId="060036bogs" visited={visitedNotes.has("060036bogs")} annotationSelect={() => {openNote("060036bogs"); addToVisited("060036bogs")}} activeAnnotationId={currentNoteId}>And the beds of the
+        us for our ruined trade and our ruined hearths? <Annotation annotationId="060036bogs">And the beds of the
         Barrow and Shannon they won't deepen with millions of acres of marsh and
         bog to make us all die of consumption?</Annotation>
       </p>
@@ -2126,7 +2126,7 @@ const Cyclops = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         reading a report of lord Castletown's...
       </p>
       <p>
-        —{" "}Save them, says the citizen, the giant ash of Galway and <Annotation annotationId="170019localities" visited={visitedNotes.has("170019localities")} annotationSelect={() => {openNote("170019localities"); addToVisited("170019localities")}} activeAnnotationId={currentNoteId}>the chieftain
+        —{" "}Save them, says the citizen, the giant ash of Galway and <Annotation annotationId="170019localities">the chieftain
         elm of Kildare with a fortyfoot bole and an acre of foliage</Annotation>. Save the
         trees of Ireland for the future men of Ireland on the fair hills of
         Eire, O.
@@ -2141,7 +2141,7 @@ const Cyclops = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         ranger of the Irish National Foresters, with Miss Fir Conifer of Pine
         Valley. Lady Sylvester Elmshade, Mrs Barbara Lovebirch, Mrs Poll Ash,
         Mrs Holly Hazeleyes, Miss Daphne Bays, Miss Dorothy Canebrake, Mrs Clyde
-        Twelvetrees, Mrs Rowan Greene, Mrs Helen  <Annotation annotationId="020010lycidas" visited={visitedNotes.has("020010lycidas")} annotationSelect={() => {openNote("020010lycidas"); addToVisited("020010lycidas")}} activeAnnotationId={currentNoteId}>Vinegadding</Annotation>, Miss Virginia
+        Twelvetrees, Mrs Rowan Greene, Mrs Helen  <Annotation annotationId="020010lycidas">Vinegadding</Annotation>, Miss Virginia
         Creeper, Miss Gladys Beech, Miss Olive Garth, Miss Blanche Maple, Mrs
         Maud Mahogany, Miss Myra Myrtle, Miss Priscilla Elderflower, Miss
         Bee Honeysuckle, Miss Grace Poplar, Miss O Mimosa San, Miss Rachel
@@ -2155,7 +2155,7 @@ const Cyclops = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         green mercerised silk, moulded on an underslip
         of gloaming grey, sashed with a yoke of broad emerald and finished <span data-edition="ed1932" data-page="295"> </span>with
         a triple flounce of darkerhued fringe, the scheme being relieved by
-        <Annotation annotationId="120016bretelles" visited={visitedNotes.has("120016bretelles")} annotationSelect={() => {openNote("120016bretelles"); addToVisited("120016bretelles")}} activeAnnotationId={currentNoteId}>bretelles and hip insertions of acorn bronze</Annotation>. The maids of honour, Miss
+        <Annotation annotationId="120016bretelles">bretelles and hip insertions of acorn bronze</Annotation>. The maids of honour, Miss
         Larch Conifer and Miss Spruce Conifer, sisters of the bride, wore very
         becoming costumes in the same tone, a dainty <i>motif</i> of plume rose being
         worked into the pleats in a pinstripe and repeated capriciously 
@@ -2173,7 +2173,7 @@ const Cyclops = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       <p>
         —{" "}And our eyes are on Europe, says the citizen. We had our trade with
         Spain and the French and with the Flemings before those mongrels were
-        pupped, Spanish ale in Galway, the winebark on <Annotation annotationId="010033epioinopaponton" visited={visitedNotes.has("010033epioinopaponton")} annotationSelect={() => {openNote("010033epioinopaponton"); addToVisited("010033epioinopaponton")}} activeAnnotationId={currentNoteId}>the winedark waterway</Annotation>.
+        pupped, Spanish ale in Galway, the winebark on <Annotation annotationId="010033epioinopaponton">the winedark waterway</Annotation>.
       </p>
       <p>
         —{" "}And will again, says Joe.
@@ -2188,7 +2188,7 @@ const Cyclops = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         the emperor Charles the Fifth himself. And will again, says he, when the
         first Irish battleship is seen breasting the waves with our own flag to
         the fore, none of your Henry Tudor's harps, no, the oldest flag afloat,
-        the flag of <Annotation annotationId="030086dalcassians" visited={visitedNotes.has("030086dalcassians")} annotationSelect={() => {openNote("030086dalcassians"); addToVisited("030086dalcassians")}} activeAnnotationId={currentNoteId}>the province of Desmond and Thomond, three crowns on a blue
+        the flag of <Annotation annotationId="030086dalcassians">the province of Desmond and Thomond, three crowns on a blue
         field</Annotation>, the three sons of Milesius.
       </p>
       <p>
@@ -2245,7 +2245,7 @@ const Cyclops = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         a gun.
       </p>
       <p>
-        —{" "}A rump and dozen, says the citizen, was what that old ruffian <Annotation annotationId="160007shipofthestreet" visited={visitedNotes.has("160007shipofthestreet")} annotationSelect={() => {openNote("160007shipofthestreet"); addToVisited("160007shipofthestreet")}} activeAnnotationId={currentNoteId}>sir John
+        —{" "}A rump and dozen, says the citizen, was what that old ruffian <Annotation annotationId="160007shipofthestreet">sir John
         Beresford</Annotation> called it but the modern God's Englishman calls it caning on
         the breech.
       </p>
@@ -2262,7 +2262,7 @@ const Cyclops = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <p>
         —{" "}That's your glorious British navy, says the citizen, that bosses the
-        earth. The fellows that <Annotation annotationId="010107seasruler" visited={visitedNotes.has("010107seasruler")} annotationSelect={() => {openNote("010107seasruler"); addToVisited("010107seasruler")}} activeAnnotationId={currentNoteId}>never will be slaves</Annotation>, with the only hereditary chamber
+        earth. The fellows that <Annotation annotationId="010107seasruler">never will be slaves</Annotation>, with the only hereditary chamber
         on the face of God's earth and their land in the hands of a dozen
         gamehogs and cottonball barons. That's the great empire they boast about
         of drudges and whipped serfs.
@@ -2283,17 +2283,17 @@ const Cyclops = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         further orders whence he shall come to drudge for a living and be paid.
       </p>
       <p>
-        —{" "}But, says Bloom, isn't discipline the same everywhere. <Annotation annotationId="120013whiteeyedkaffir" visited={visitedNotes.has("120013whiteeyedkaffir")} annotationSelect={() => {openNote("120013whiteeyedkaffir"); addToVisited("120013whiteeyedkaffir")}} activeAnnotationId={currentNoteId}>I mean wouldn't
+        —{" "}But, says Bloom, isn't discipline the same everywhere. <Annotation annotationId="120013whiteeyedkaffir">I mean wouldn't
         it be the same here if you put force against force?
         <span data-edition="ed1922" data-page="315"> </span>
         </Annotation>
       </p>
-      <p><Annotation annotationId="120013whiteeyedkaffir" visited={visitedNotes.has("120013whiteeyedkaffir")} annotationSelect={() => {openNote("120013whiteeyedkaffir"); addToVisited("120013whiteeyedkaffir")}} activeAnnotationId={currentNoteId}>
+      <p><Annotation annotationId="120013whiteeyedkaffir">
         Didn't I tell you? As true as I'm drinking this porter if he was at his
         last gasp he'd try to downface you that dying was living.
         </Annotation>
       </p>
-      <Annotation annotationId="120013whiteeyedkaffir" visited={visitedNotes.has("120013whiteeyedkaffir")} annotationSelect={() => {openNote("120013whiteeyedkaffir"); addToVisited("120013whiteeyedkaffir")}} activeAnnotationId={currentNoteId}>
+      <Annotation annotationId="120013whiteeyedkaffir">
         <p>
           —{" "}We'll put force against force, says the citizen. We have our greater
           Ireland beyond the sea. They were driven out of house and home in the
@@ -2313,15 +2313,15 @@ const Cyclops = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         </p>
         <span data-edition="ed1986" data-page="270"> </span>
       </Annotation>
-      <p><Annotation annotationId="120013whiteeyedkaffir" visited={visitedNotes.has("120013whiteeyedkaffir")} annotationSelect={() => {openNote("120013whiteeyedkaffir"); addToVisited("120013whiteeyedkaffir")}} activeAnnotationId={currentNoteId}>
-        —{" "}We are a long time waiting for that day, citizen, says Ned. </Annotation><Annotation annotationId="010101frenchonsea" visited={visitedNotes.has("010101frenchonsea")} annotationSelect={() => {openNote("010101frenchonsea"); addToVisited("010101frenchonsea")}} activeAnnotationId={currentNoteId}>Since the
+      <p><Annotation annotationId="120013whiteeyedkaffir">
+        —{" "}We are a long time waiting for that day, citizen, says Ned. </Annotation><Annotation annotationId="010101frenchonsea">Since the
         poor old woman told us that the French were on the sea</Annotation> and landed at
         Killala.
       </p>
       <p>
         —{" "}Ay, says John Wyse. We fought for the royal Stuarts that reneged us
         against the Williamites and they betrayed us. Remember Limerick and the
-        broken treatystone. <Annotation annotationId="030027wildgoose" visited={visitedNotes.has("030027wildgoose")} annotationSelect={() => {openNote("030027wildgoose"); addToVisited("030027wildgoose")}} activeAnnotationId={currentNoteId}>We gave our best blood to France and Spain, the
+        broken treatystone. <Annotation annotationId="030027wildgoose">We gave our best blood to France and Spain, the
         wild geese.</Annotation> Fontenoy, eh? And Sarsfield and O'Donnell, duke of Tetuan
         in Spain, and Ulysses Browne of Camus that was fieldmarshal to Maria
         Teresa. But what did we ever get for it?
@@ -2351,10 +2351,10 @@ const Cyclops = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <span data-edition="ed1922" data-page="316"> </span>
       <p>
-        —{" "}Well, says J. J. We have <Annotation annotationId="020079kingedward" visited={visitedNotes.has("020079kingedward")} annotationSelect={() => {openNote("020079kingedward"); addToVisited("020079kingedward")}} activeAnnotationId={currentNoteId}>Edward the peacemaker</Annotation> now.
+        —{" "}Well, says J. J. We have <Annotation annotationId="020079kingedward">Edward the peacemaker</Annotation> now.
       </p>
       <p>
-        —{" "}Tell that to a fool, says the citizen. There's a bloody sight <Annotation annotationId="120014cockburn" visited={visitedNotes.has("120014cockburn")} annotationSelect={() => {openNote("120014cockburn"); addToVisited("120014cockburn")}} activeAnnotationId={currentNoteId}>more pox
+        —{" "}Tell that to a fool, says the citizen. There's a bloody sight <Annotation annotationId="120014cockburn">more pox
         than pax</Annotation> about that boyo. Edward Guelph-Wettin!
       </p>
       <p>
@@ -2426,14 +2426,14 @@ const Cyclops = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         —{" "}That covers my case, says Joe.
       </p>
       <p>
-        —{" "}<Annotation annotationId="010122germanjews" visited={visitedNotes.has("010122germanjews")} annotationSelect={() => {openNote("010122germanjews"); addToVisited("010122germanjews")}} activeAnnotationId={currentNoteId}>What is your nation if I may ask?</Annotation> says the citizen.
+        —{" "}<Annotation annotationId="010122germanjews">What is your nation if I may ask?</Annotation> says the citizen.
       </p>
       <p>
         —{" "}Ireland, says Bloom. I was born here. Ireland.
       </p>
       <p>
         The citizen said nothing only cleared the spit out of his gullet and,
-        gob, he spat a <Annotation annotationId="060020redbank" visited={visitedNotes.has("060020redbank")} annotationSelect={() => {openNote("060020redbank"); addToVisited("060020redbank")}} activeAnnotationId={currentNoteId}>Red bank oyster</Annotation> out of him <Annotation annotationId="080022sawdust" visited={visitedNotes.has("080022sawdust")} annotationSelect={() => {openNote("080022sawdust"); addToVisited("080022sawdust")}} activeAnnotationId={currentNoteId}>right in the corner</Annotation>.
+        gob, he spat a <Annotation annotationId="060020redbank">Red bank oyster</Annotation> out of him <Annotation annotationId="080022sawdust">right in the corner</Annotation>.
       </p>
       <span data-edition="ed1932" data-page="299"> </span>
       <p>
@@ -2453,22 +2453,22 @@ const Cyclops = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         prolonged <span data-edition="ed1961" data-page="331"> </span>admiration. No need to dwell on the legendary beauty of the
         cornerpieces, the acme of art, wherein one can distinctly discern each
         of the four evangelists in turn presenting to each of the four masters
-        his evangelical symbol, a <Annotation annotationId="030062bogoak" visited={visitedNotes.has("030062bogoak")} annotationSelect={() => {openNote("030062bogoak"); addToVisited("030062bogoak")}} activeAnnotationId={currentNoteId}>bogoak</Annotation> sceptre, a North American puma (a far
+        his evangelical symbol, a <Annotation annotationId="030062bogoak">bogoak</Annotation> sceptre, a North American puma (a far
         nobler king of beasts than the British article, be it said in passing),
         a Kerry calf and a golden eagle from Carrantuohill. The scenes depicted
         on the emunctory field, showing our ancient duns and raths and cromlechs
         and grianauns and seats of learning and maledictive stones, are as
         wonderfully beautiful and the pigments as delicate as when the Sligo
         illuminators gave free rein to their artistic fantasy long long ago in
-        the time of the Barmecides. <Annotation annotationId="010010mountains" visited={visitedNotes.has("010010mountains")} annotationSelect={() => {openNote("010010mountains"); addToVisited("010010mountains")}} activeAnnotationId={currentNoteId}>Glendalough</Annotation>, <Annotation annotationId="170019localities" visited={visitedNotes.has("170019localities")} annotationSelect={() => {openNote("170019localities"); addToVisited("170019localities")}} activeAnnotationId={currentNoteId}>the lovely lakes of Killarney</Annotation>,
+        the time of the Barmecides. <Annotation annotationId="010010mountains">Glendalough</Annotation>, <Annotation annotationId="170019localities">the lovely lakes of Killarney</Annotation>,
         the ruins of Clonmacnois, Cong Abbey, Glen Inagh and the Twelve Pins,
-        Ireland's Eye, the Green Hills of Tallaght, <Annotation annotationId="050036saintpatrick" visited={visitedNotes.has("050036saintpatrick")} annotationSelect={() => {openNote("050036saintpatrick"); addToVisited("050036saintpatrick")}} activeAnnotationId={currentNoteId}>Croagh Patrick</Annotation>, the brewery
-        of Messrs Arthur Guinness, Son and Company (Limited), <Annotation annotationId="170019localities" visited={visitedNotes.has("170019localities")} annotationSelect={() => {openNote("170019localities"); addToVisited("170019localities")}} activeAnnotationId={currentNoteId}>Lough Neagh's
+        Ireland's Eye, the Green Hills of Tallaght, <Annotation annotationId="050036saintpatrick">Croagh Patrick</Annotation>, the brewery
+        of Messrs Arthur Guinness, Son and Company (Limited), <Annotation annotationId="170019localities">Lough Neagh's
         banks</Annotation>, the vale of Ovoca, Isolde's tower, the Mapas obelisk, Sir Patrick
         Dun's hospital, Cape Clear, the glen of Aherlow, Lynch's castle, the
         Scotch house, Rathdown Union Workhouse at Loughlinstown, Tullamore jail,
         Castleconnel rapids, Kilballymacshonakill, the cross at Monasterboice,
-        Jury's Hotel, <Annotation annotationId="050036saintpatrick" visited={visitedNotes.has("050036saintpatrick")} annotationSelect={() => {openNote("050036saintpatrick"); addToVisited("050036saintpatrick")}} activeAnnotationId={currentNoteId}>S. Patrick's Purgatory</Annotation>, the <Annotation annotationId="170019localities" visited={visitedNotes.has("170019localities")} annotationSelect={() => {openNote("170019localities"); addToVisited("170019localities")}} activeAnnotationId={currentNoteId}>Salmon Leap</Annotation>, Maynooth college
+        Jury's Hotel, <Annotation annotationId="050036saintpatrick">S. Patrick's Purgatory</Annotation>, the <Annotation annotationId="170019localities">Salmon Leap</Annotation>, Maynooth college
         refectory, Curley's hole, the three birthplaces of the first duke of
         Wellington, the rock of Cashel, the bog of Allen, the Henry Street
         Warehouse, Fingal's Cave—all these moving scenes are still there for us
@@ -2484,7 +2484,7 @@ const Cyclops = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         —{" "}That's mine, says Joe, as the devil said to the dead policeman.
       </p>
       <p>
-        —{" "}And <Annotation annotationId="040083hewasajew" visited={visitedNotes.has("040083hewasajew")} annotationSelect={() => {openNote("040083hewasajew"); addToVisited("040083hewasajew")}} activeAnnotationId={currentNoteId}>I belong to a race</Annotation> too, says Bloom, that is hated and persecuted.
+        —{" "}And <Annotation annotationId="040083hewasajew">I belong to a race</Annotation> too, says Bloom, that is hated and persecuted.
         Also now. This very moment. This very instant.
       </p>
       <p>
@@ -2492,12 +2492,12 @@ const Cyclops = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <p>
         —{" "}Robbed, says he. Plundered. Insulted. Persecuted. Taking what belongs
-        to us by right. <Annotation annotationId="020061wanderers" visited={visitedNotes.has("020061wanderers")} annotationSelect={() => {openNote("020061wanderers"); addToVisited("020061wanderers")}} activeAnnotationId={currentNoteId}>At this very moment, says he, putting up his fist, sold
+        to us by right. <Annotation annotationId="020061wanderers">At this very moment, says he, putting up his fist, sold
         by auction in Morocco like slaves or cattle.</Annotation>
       </p>
       <span data-edition="ed1932" data-page="300"> </span>
       <p>
-        —{" "}<Annotation annotationId="120001jewishstate" visited={visitedNotes.has("120001jewishstate")} annotationSelect={() => {openNote("120001jewishstate"); addToVisited("120001jewishstate")}} activeAnnotationId={currentNoteId}>Are you talking about the new Jerusalem?</Annotation> says the citizen.
+        —{" "}<Annotation annotationId="120001jewishstate">Are you talking about the new Jerusalem?</Annotation> says the citizen.
       </p>
       <p>
         —{" "}I'm talking about injustice, says Bloom.
@@ -2516,7 +2516,7 @@ const Cyclops = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <p>
         —{" "}But it's no use, says he. Force, hatred, history, all that. That's not
-        life for men and women, insult and hatred. And everybody knows that <Annotation annotationId="010044painfretted" visited={visitedNotes.has("010044painfretted")} annotationSelect={() => {openNote("010044painfretted"); addToVisited("010044painfretted")}} activeAnnotationId={currentNoteId}>it's
+        life for men and women, insult and hatred. And everybody knows that <Annotation annotationId="010044painfretted">it's
         the very opposite of that that is really life</Annotation>.
       </p>
       <p>
@@ -2550,7 +2550,7 @@ const Cyclops = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         brown macintosh loves a lady who is dead. His Majesty the King loves Her
         Majesty the Queen. Mrs Norman W. Tupper loves officer Taylor. You love
         a certain person. And this person loves that other person because
-        <Annotation annotationId="010044painfretted" visited={visitedNotes.has("010044painfretted")} annotationSelect={() => {openNote("010044painfretted"); addToVisited("010044painfretted")}} activeAnnotationId={currentNoteId}>everybody loves somebody but God loves everybody</Annotation>.
+        <Annotation annotationId="010044painfretted">everybody loves somebody but God loves everybody</Annotation>.
       </p>
       <p>
         —{" "}Well, Joe, says I, your very good health and song. More power,
@@ -2571,7 +2571,7 @@ const Cyclops = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         What about sanctimonious Cromwell and his ironsides that put the women
         and children of Drogheda to the sword with the bible text <i>God is love</i>
         <span data-edition="ed1986" data-page="273"> </span>pasted round the mouth of his cannon? The bible! Did you read <span data-edition="ed1932" data-page="301"> </span>that skit
-        in the <Annotation annotationId="120010unitedirishman" visited={visitedNotes.has("120010unitedirishman")} annotationSelect={() => {openNote("120010unitedirishman"); addToVisited("120010unitedirishman")}} activeAnnotationId={currentNoteId}><i>United Irishman</i></Annotation> today about that Zulu chief that's visiting
+        in the <Annotation annotationId="120010unitedirishman"><i>United Irishman</i></Annotation> today about that Zulu chief that's visiting
         England?
       </p>
       <span data-edition="ed1922" data-page="319"> </span>
@@ -2614,7 +2614,7 @@ const Cyclops = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         the broadleaved mango flourished exceedingly.
       </p>
       <p>
-        —{" "}Is that by <Annotation annotationId="030037griffith" visited={visitedNotes.has("030037griffith")} annotationSelect={() => {openNote("030037griffith"); addToVisited("030037griffith")}} activeAnnotationId={currentNoteId}>Griffith</Annotation>? says John Wyse.
+        —{" "}Is that by <Annotation annotationId="030037griffith">Griffith</Annotation>? says John Wyse.
       </p>
       <p>
         —{" "}No, says the citizen. It's not signed Shanganagh. It's only
@@ -2653,7 +2653,7 @@ const Cyclops = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         <i>Throwaway</i> and he's gone to gather in the shekels.
       </p>
       <p>
-        —{" "}Is it <Annotation annotationId="120013whiteeyedkaffir" visited={visitedNotes.has("120013whiteeyedkaffir")} annotationSelect={() => {openNote("120013whiteeyedkaffir"); addToVisited("120013whiteeyedkaffir")}} activeAnnotationId={currentNoteId}>that whiteeyed kaffir</Annotation>? says the citizen, that never backed a
+        —{" "}Is it <Annotation annotationId="120013whiteeyedkaffir">that whiteeyed kaffir</Annotation>? says the citizen, that never backed a
         horse in anger in his life?
       </p>
       <p></p>
@@ -2688,10 +2688,10 @@ const Cyclops = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         the last of it) Jerusalem (ah!) cuckoos.
       </p>
       <p>
-        So anyhow when I got back they were at it dingdong, John Wyse saying <Annotation annotationId="080015nolanswife" visited={visitedNotes.has("080015nolanswife")} annotationSelect={() => {openNote("080015nolanswife"); addToVisited("080015nolanswife")}} activeAnnotationId={currentNoteId}>it
+        So anyhow when I got back they were at it dingdong, John Wyse saying <Annotation annotationId="080015nolanswife">it
         was Bloom gave the ideas for Sinn Fein to Griffith to put in his paper
         all kinds of jerrymandering, packed juries and swindling the taxes off
-        of the Government and</Annotation> <span data-edition="ed1961" data-page="335"> </span><Annotation annotationId="080015nolanswife" visited={visitedNotes.has("080015nolanswife")} annotationSelect={() => {openNote("080015nolanswife"); addToVisited("080015nolanswife")}} activeAnnotationId={currentNoteId}>appointing consuls all over the world to walk
+        of the Government and</Annotation> <span data-edition="ed1961" data-page="335"> </span><Annotation annotationId="080015nolanswife">appointing consuls all over the world to walk
         about selling Irish industries</Annotation>. Robbing Peter to pay Paul. Gob, that
         puts the bloody kybosh on it if old sloppy eyes is mucking up the show.
         Give us a bloody chance. God save Ireland from the likes of that bloody
@@ -2711,7 +2711,7 @@ const Cyclops = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       <span data-edition="ed1932" data-page="303"> </span>
       <span data-edition="ed1922" data-page="321"> </span>
       <p>
-        Sure enough <Annotation annotationId="080013dublincastle" visited={visitedNotes.has("080013dublincastle")} annotationSelect={() => {openNote("080013dublincastle"); addToVisited("080013dublincastle")}} activeAnnotationId={currentNoteId}>the castle car</Annotation> drove up with Martin on it and Jack Power
+        Sure enough <Annotation annotationId="080013dublincastle">the castle car</Annotation> drove up with Martin on it and Jack Power
         with him and a fellow named Crofter or Crofton, pensioner out of
         the collector general's, an orangeman Blackburn does have on the
         registration and he drawing his pay or Crawford gallivanting around the
@@ -2815,8 +2815,8 @@ const Cyclops = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         —{" "}We don't want him, says Crofter the Orangeman or presbyterian.
       </p>
       <p>
-        —{" "}<Annotation annotationId="060034martincunningham" visited={visitedNotes.has("060034martincunningham")} annotationSelect={() => {openNote("060034martincunningham"); addToVisited("060034martincunningham")}} activeAnnotationId={currentNoteId}>He's a perverted jew, says Martin</Annotation>, from a place in Hungary and it was
-        he drew up all the plans according to the Hungarian system. <Annotation annotationId="080013dublincastle" visited={visitedNotes.has("080013dublincastle")} annotationSelect={() => {openNote("080013dublincastle"); addToVisited("080013dublincastle")}} activeAnnotationId={currentNoteId}>We know that
+        —{" "}<Annotation annotationId="060034martincunningham">He's a perverted jew, says Martin</Annotation>, from a place in Hungary and it was
+        he drew up all the plans according to the Hungarian system. <Annotation annotationId="080013dublincastle">We know that
         in the castle.</Annotation>
       </p>
       <span data-edition="ed1939" data-page="244"> </span>
@@ -2824,14 +2824,14 @@ const Cyclops = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         —{" "}Isn't he a cousin of Bloom the dentist? says Jack Power.
       </p>
       <p>
-        —{" "}Not at all, says Martin. Only namesakes. <Annotation annotationId="050026henryflower" visited={visitedNotes.has("050026henryflower")} annotationSelect={() => {openNote("050026henryflower"); addToVisited("050026henryflower")}} activeAnnotationId={currentNoteId}>His name was Virag</Annotation>, the
+        —{" "}Not at all, says Martin. Only namesakes. <Annotation annotationId="050026henryflower">His name was Virag</Annotation>, the
         father's name that poisoned himself. He changed it by deedpoll, the
         father did.
       </p>
       <p></p>
       <span data-edition="ed1986" data-page="276"> </span>
       <p>
-        —{" "}That's the new Messiah for Ireland! says the citizen. <Annotation annotationId="030085isleofsaints" visited={visitedNotes.has("030085isleofsaints")} annotationSelect={() => {openNote("030085isleofsaints"); addToVisited("030085isleofsaints")}} activeAnnotationId={currentNoteId}>Island of saints
+        —{" "}That's the new Messiah for Ireland! says the citizen. <Annotation annotationId="030085isleofsaints">Island of saints
         and sages!</Annotation>
       </p>
       <p>
@@ -2884,7 +2884,7 @@ const Cyclops = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       <span data-edition="ed1932" data-page="305"> </span>
       <p>
         —{" "}A wolf in sheep's clothing, says the citizen. That's what he is. Virag
-        from Hungary! <Annotation annotationId="020061wanderers" visited={visitedNotes.has("020061wanderers")} annotationSelect={() => {openNote("020061wanderers"); addToVisited("020061wanderers")}} activeAnnotationId={currentNoteId}>Ahasuerus I call him. Cursed by God.</Annotation>
+        from Hungary! <Annotation annotationId="020061wanderers">Ahasuerus I call him. Cursed by God.</Annotation>
       </p>
       <p>
         —{" "}Have you time for a brief libation, Martin? says Ned.
@@ -2896,7 +2896,7 @@ const Cyclops = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         —{" "}You, Jack? Crofton? Three half ones, Terry.
       </p>
       <p>
-        —{" "}<Annotation annotationId="050036saintpatrick" visited={visitedNotes.has("050036saintpatrick")} annotationSelect={() => {openNote("050036saintpatrick"); addToVisited("050036saintpatrick")}} activeAnnotationId={currentNoteId}>Saint Patrick would want to land again at Ballykinlar and convert us,
+        —{" "}<Annotation annotationId="050036saintpatrick">Saint Patrick would want to land again at Ballykinlar and convert us,
         says the citizen, after allowing things like that to contaminate our
         shores.</Annotation>
       </p>
@@ -2911,7 +2911,7 @@ const Cyclops = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         —{" "}And I'm sure He will, says Joe.
       </p>
       <p>
-        And at the sound of the <Annotation annotationId="030018dringdring" visited={visitedNotes.has("030018dringdring")} annotationSelect={() => {openNote("030018dringdring"); addToVisited("030018dringdring")}} activeAnnotationId={currentNoteId}>sacring bell</Annotation>, headed by a crucifer with
+        And at the sound of the <Annotation annotationId="030018dringdring">sacring bell</Annotation>, headed by a crucifer with
         acolytes, thurifers, boatbearers, readers, ostiarii, deacons and
         subdeacons, the blessed company drew nigh of mitred abbots and priors
         and guardians and monks and friars: the <span data-edition="ed1961" data-page="338"> </span>monks of Benedict of Spoleto,
@@ -2941,20 +2941,20 @@ const Cyclops = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       Synonymous and S. Laurence O'Toole and S. James of Dingle and
       Compostella and S. Columcille and S. Columba and S. Celestine and S.
       Colman and S. Kevin and S. Brendan and S. Frigidian and S. Senan and S.
-      Fachtna and <Annotation annotationId="020018columbanus" visited={visitedNotes.has("020018columbanus")} annotationSelect={() => {openNote("020018columbanus"); addToVisited("020018columbanus")}} activeAnnotationId={currentNoteId}>S. Columbanus</Annotation> and S. Gall and S. Fursey and 
+      Fachtna and <Annotation annotationId="020018columbanus">S. Columbanus</Annotation> and S. Gall and S. Fursey and 
       <span data-edition="ed1922" data-page="324"> </span>
-      S. Fintan and <Annotation annotationId="020018columbanus" visited={visitedNotes.has("020018columbanus")} annotationSelect={() => {openNote("020018columbanus"); addToVisited("020018columbanus")}} activeAnnotationId={currentNoteId}>S.
+      S. Fintan and <Annotation annotationId="020018columbanus">S.
       Fiacre</Annotation> and S. John Nepomuc and S. <span data-edition="ed1932" data-page="306"> </span>Thomas Aquinas and S. Ives of Brittany
       and S. Michan and S. Herman-Joseph and the three patrons of holy youth
       S. Aloysius Gonzaga and S. Stanislaus Kostka and S. John Berchmans
       and the saints Gervasius, Servasius and Bonifacius and S. Bride and S.
-      Kieran and <Annotation annotationId="030067oldkilkenny" visited={visitedNotes.has("030067oldkilkenny")} annotationSelect={() => {openNote("030067oldkilkenny"); addToVisited("030067oldkilkenny")}} activeAnnotationId={currentNoteId}>S. Canice of Kilkenny</Annotation> and S. Jarlath of Tuam and S. Finbarr
+      Kieran and <Annotation annotationId="030067oldkilkenny">S. Canice of Kilkenny</Annotation> and S. Jarlath of Tuam and S. Finbarr
       and S. Pappin of Ballymun and Brother Aloysius Pacificus and Brother
-      Louis Bellicosus and the saints Rose of Lima and of Viterbo and <Annotation annotationId="050027marthamary" visited={visitedNotes.has("050027marthamary")} annotationSelect={() => {openNote("050027marthamary"); addToVisited("050027marthamary")}} activeAnnotationId={currentNoteId}>S.
+      Louis Bellicosus and the saints Rose of Lima and of Viterbo and <Annotation annotationId="050027marthamary">S.
       Martha of Bethany</Annotation> and S. Mary of Egypt and S. Lucy and S. Brigid and
       S. Attracta and S. Dympna and S. Ita and S. Marion Calpensis and
       the Blessed Sister Teresa of the Child Jesus and S. Barbara and S.
-      Scholastica and <Annotation annotationId="010054ursula" visited={visitedNotes.has("010054ursula")} annotationSelect={() => {openNote("010054ursula"); addToVisited("010054ursula")}} activeAnnotationId={currentNoteId}>S. Ursula with eleven thousand virgins</Annotation>. And all came
+      Scholastica and <Annotation annotationId="010054ursula">S. Ursula with eleven thousand virgins</Annotation>. And all came
       with nimbi and aureoles and gloriae, bearing palms and harps and swords
       and olive crowns, in robes <span data-edition="ed1961" data-page="339"> </span>whereon were woven the blessed symbols of
       their efficacies, inkhorns, arrows, loaves, cruses, fetters, axes,
@@ -2963,7 +2963,7 @@ const Cyclops = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       soupladles, stars, snakes, anvils, boxes of vaseline, bells, crutches,
       forceps, stags' horns, watertight boots, hawks, millstones, eyes on a
       dish, wax candles, aspergills, unicorns. And as they wended their way by
-      <Annotation annotationId="070006nelsonspillar" visited={visitedNotes.has("070006nelsonspillar")} annotationSelect={() => {openNote("070006nelsonspillar"); addToVisited("070006nelsonspillar")}} activeAnnotationId={currentNoteId}>Nelson's Pillar</Annotation>, Henry street, Mary street, Capel street, Little Britain
+      <Annotation annotationId="070006nelsonspillar">Nelson's Pillar</Annotation>, Henry street, Mary street, Capel street, Little Britain
       street chanting the introit in <i>Epiphania Domini</i> which beginneth
       <i>Surge, illuminare</i> and thereafter most sweetly the gradual <i>Omnes</i>
       which saith <i>de Saba venient</i> they did divers wonders such as casting
@@ -2972,7 +2972,7 @@ const Cyclops = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       interpreting and fulfilling the scriptures, blessing and prophesying.
       And last, beneath a canopy of cloth of gold came the reverend Father
       O'Flynn attended by Malachi and Patrick. And when the good fathers
-      had reached the appointed place, <Annotation annotationId="120004kiernans" visited={visitedNotes.has("120004kiernans")} annotationSelect={() => {openNote("120004kiernans"); addToVisited("120004kiernans")}} activeAnnotationId={currentNoteId}>the house of Bernard Kiernan and Co,
+      had reached the appointed place, <Annotation annotationId="120004kiernans">the house of Bernard Kiernan and Co,
       limited, 8, 9 and 10 little Britain street,</Annotation> wholesale grocers, wine
       and brandy shippers, licensed for the sale of beer, wine and spirits for
       consumption on the premises, the celebrant 
@@ -3114,7 +3114,7 @@ const Cyclops = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         And all the ragamuffins and sluts of the nation round the door and
         Martin telling the jarvey to drive ahead and the citizen bawling and Alf
         and Joe at him to whisht and he on his high horse about the jews and
-        the loafers calling for a speech and Jack Power <Annotation annotationId="050013jauntingcar" visited={visitedNotes.has("050013jauntingcar")} annotationSelect={() => {openNote("050013jauntingcar"); addToVisited("050013jauntingcar")}} activeAnnotationId={currentNoteId}>trying to get him to sit
+        the loafers calling for a speech and Jack Power <Annotation annotationId="050013jauntingcar">trying to get him to sit
         down on the car</Annotation> and hold his bloody jaw and a loafer with a patch over
         his eye starts singing <i>If the man in the moon was a jew, jew, jew</i> and
         a slut shouts out of her:
@@ -3169,24 +3169,24 @@ const Cyclops = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         struck up the wellknown strains of <i>Come back to Erin</i>, followed
         immediately by <i>Rakoczsy's March</i>. Tarbarrels and bonfires were lighted
         along the coastline of the four seas on the summits of the Hill of
-        Howth, Three Rock Mountain, <Annotation annotationId="010010mountains" visited={visitedNotes.has("010010mountains")} annotationSelect={() => {openNote("010010mountains"); addToVisited("010010mountains")}} activeAnnotationId={currentNoteId}>Sugarloaf</Annotation>, <Annotation annotationId="010066brayhead" visited={visitedNotes.has("010066brayhead")} annotationSelect={() => {openNote("010066brayhead"); addToVisited("010066brayhead")}} activeAnnotationId={currentNoteId}>Bray Head</Annotation>, the mountains of
+        Howth, Three Rock Mountain, <Annotation annotationId="010010mountains">Sugarloaf</Annotation>, <Annotation annotationId="010066brayhead">Bray Head</Annotation>, the mountains of
         Mourne, the Galtees, the Ox and Donegal and Sperrin peaks, the Nagles
-        and the Bograghs, <Annotation annotationId="170019localities" visited={visitedNotes.has("170019localities")} annotationSelect={() => {openNote("170019localities"); addToVisited("170019localities")}} activeAnnotationId={currentNoteId}>the Connemara hills</Annotation>, the reeks of M Gillicuddy, <Annotation annotationId="040073slieve" visited={visitedNotes.has("040073slieve")} annotationSelect={() => {openNote("040073slieve"); addToVisited("040073slieve")}} activeAnnotationId={currentNoteId}>Slieve
+        and the Bograghs, <Annotation annotationId="170019localities">the Connemara hills</Annotation>, the reeks of M Gillicuddy, <Annotation annotationId="040073slieve">Slieve
         Aughty, Slieve Bernagh and Slieve Bloom</Annotation>. Amid cheers that rent the
         welkin, responded to by answering cheers from a big muster of
         henchmen on the distant Cambrian and Caledonian hills, the mastodontic
         pleasureship slowly moved away saluted by a final floral tribute from
         the representatives of the fair sex who were present in large numbers
         while, as it proceeded down the river, escorted by a flotilla of barges,
-        the flags of the <Annotation annotationId="080007ballastoffice" visited={visitedNotes.has("080007ballastoffice")} annotationSelect={() => {openNote("080007ballastoffice"); addToVisited("080007ballastoffice")}} activeAnnotationId={currentNoteId}>Ballast office</Annotation> and Custom House were dipped in salute
-        as were also those of <Annotation annotationId="030004pigeonhouse" visited={visitedNotes.has("030004pigeonhouse")} annotationSelect={() => {openNote("030004pigeonhouse"); addToVisited("030004pigeonhouse")}} activeAnnotationId={currentNoteId}>the electrical power station at the
+        the flags of the <Annotation annotationId="080007ballastoffice">Ballast office</Annotation> and Custom House were dipped in salute
+        as were also those of <Annotation annotationId="030004pigeonhouse">the electrical power station at the
         Pigeonhouse and the Poolbeg Light</Annotation>. <i>Visszontlátásra, kedvès baráton!
         Visszontlátásra!</i> Gone but not forgotten.
       </p>
       <p>
         Gob, the devil wouldn't stop him till he got hold of the bloody tin
         anyhow and out with him and little Alf hanging on to his elbow and he
-        <Annotation annotationId="060032queenstheatre" visited={visitedNotes.has("060032queenstheatre")} annotationSelect={() => {openNote("060032queenstheatre"); addToVisited("060032queenstheatre")}} activeAnnotationId={currentNoteId}>shouting like a stuck pig, as good as any bloody play in the Queen's
+        <Annotation annotationId="060032queenstheatre">shouting like a stuck pig, as good as any bloody play in the Queen's
         royal theatre</Annotation>:
       </p>
       <span data-edition="ed1939" data-page="248"> </span>
@@ -3219,7 +3219,7 @@ const Cyclops = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         observatory of Dunsink registered in all eleven shocks, all of the fifth
         grade of Mercalli's scale, and there is no record extant of a similar
         seismic disturbance in our island since the earthquake of 1534, the year
-        of <Annotation annotationId="030058pretenders" visited={visitedNotes.has("030058pretenders")} annotationSelect={() => {openNote("030058pretenders"); addToVisited("030058pretenders")}} activeAnnotationId={currentNoteId}>the rebellion of Silken Thomas</Annotation>. The epicentre appears to have been
+        of <Annotation annotationId="030058pretenders">the rebellion of Silken Thomas</Annotation>. The epicentre appears to have been
         that part of the metropolis which constitutes the Inn's Quay ward and
         parish of Saint Michan covering a surface of fortyone acres, two roods
         and one square pole or perch. All the lordly residences in the vicinity
@@ -3232,7 +3232,7 @@ const Cyclops = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         headgear since ascertained to belong to the much respected clerk of the
         crown and peace Mr George Fottrell and a silk umbrella with gold handle
         with the engraved initials, crest, coat of arms and house number of
-        the erudite and worshipful chairman of quarter sessions <Annotation annotationId="080002sirfrederick" visited={visitedNotes.has("080002sirfrederick")} annotationSelect={() => {openNote("080002sirfrederick"); addToVisited("080002sirfrederick")}} activeAnnotationId={currentNoteId}>sir Frederick
+        the erudite and worshipful chairman of quarter sessions <Annotation annotationId="080002sirfrederick">sir Frederick
         Falkiner, recorder of Dublin</Annotation>, have been discovered by search parties
         in remote parts of the island respectively, the former on the third
         basaltic ridge of the giant's causeway, the latter embedded to the

--- a/src/content/chapters/Eumaeus.js
+++ b/src/content/chapters/Eumaeus.js
@@ -1,20 +1,20 @@
 import Annotation from "../../components/Annotation";
 
 
-const Eumaeus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
+const Eumaeus = () => {
   return (
     <div>
       <p></p>
       <center><font size="+2">[16]</font></center>
       <br/>
       Preparatory to anything else Mr Bloom brushed off the greater bulk of
-      the shavings and handed Stephen the hat and ashplant and <Annotation annotationId="050045samaritan" visited={visitedNotes.has("050045samaritan")} annotationSelect={() => {openNote("050045samaritan"); addToVisited("050045samaritan")}} activeAnnotationId={currentNoteId}>bucked him up
+      the shavings and handed Stephen the hat and ashplant and <Annotation annotationId="050045samaritan">bucked him up
       generally in orthodox Samaritan fashion which he very badly needed</Annotation>. His
       (Stephen's) mind was not exactly what you would call wandering but a bit
       unsteady and on his expressed desire for some beverage to drink Mr
-      Bloom in view of the hour it was and there being no pump of <Annotation annotationId="010010mountains" visited={visitedNotes.has("010010mountains")} annotationSelect={() => {openNote("010010mountains"); addToVisited("010010mountains")}} activeAnnotationId={currentNoteId}>Vartry water</Annotation>
+      Bloom in view of the hour it was and there being no pump of <Annotation annotationId="010010mountains">Vartry water</Annotation>
       available for their ablutions let alone drinking purposes hit upon an
-      expedient by suggesting, off the reel, the propriety of <Annotation annotationId="050051shelter" visited={visitedNotes.has("050051shelter")} annotationSelect={() => {openNote("050051shelter"); addToVisited("050051shelter")}} activeAnnotationId={currentNoteId}>the cabman's
+      expedient by suggesting, off the reel, the propriety of <Annotation annotationId="050051shelter">the cabman's
       shelter, as it was called, hardly a stonesthrow away near Butt bridge</Annotation>
       where they might hit upon some drinkables in the shape of a milk and
       soda or a mineral. But how to get there was the rub. For the nonce he
@@ -23,7 +23,7 @@ const Eumaeus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       during which Stephen repeatedly yawned. So far as he could see he was
       rather pale in the face so that it occurred to him as highly advisable
       to get a conveyance of some description which would answer in their
-      then condition, both of them being <Annotation annotationId="040082highgradeha" visited={visitedNotes.has("040082highgradeha")} annotationSelect={() => {openNote("040082highgradeha"); addToVisited("040082highgradeha")}} activeAnnotationId={currentNoteId}>e.d.ed</Annotation>, particularly Stephen, always
+      then condition, both of them being <Annotation annotationId="040082highgradeha">e.d.ed</Annotation>, particularly Stephen, always
       assuming that there was such a thing to be found. Accordingly after a
       few such preliminaries as brushing, in spite of his having forgotten
       to take up his rather soapsuddy handkerchief after it had done yeoman
@@ -55,7 +55,7 @@ const Eumaeus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         as it happened, and the temperature refreshing since it
         cleared up after the recent visitation of Jupiter Pluvius, they dandered
         along past by where the empty vehicle was waiting without a fare or a
-        jarvey. As it so happened a <Annotation annotationId="070003tramwaycompany" visited={visitedNotes.has("070003tramwaycompany")} annotationSelect={() => {openNote("070003tramwaycompany"); addToVisited("070003tramwaycompany")}} activeAnnotationId={currentNoteId}>Dublin United Tramways Company</Annotation>'s sandstrewer
+        jarvey. As it so happened a <Annotation annotationId="070003tramwaycompany">Dublin United Tramways Company</Annotation>'s sandstrewer
         happening to be returning the elder man recounted to his companion <i>à 
         propos</i> of the incident his own truly miraculous escape of some little
         while back. They passed the main entrance of the Great Northern railway
@@ -64,13 +64,13 @@ const Eumaeus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         (a not very enticing locality, not to say gruesome to a degree, more
         especially at night) ultimately gained the Dock Tavern and in due course
         turned into Store street, famous for its C division police station.
-        Between this point and the high at present unlit warehouses of <Annotation annotationId="160007shipofthestreet" visited={visitedNotes.has("160007shipofthestreet")} annotationSelect={() => {openNote("160007shipofthestreet"); addToVisited("160007shipofthestreet")}} activeAnnotationId={currentNoteId}>Beresford
+        Between this point and the high at present unlit warehouses of <Annotation annotationId="160007shipofthestreet">Beresford
         place</Annotation> Stephen thought to think of Ibsen, associated with Baird's the
         stonecutter's in his mind somehow in Talbot place, first turning on the
         right, while the other who was acting as his <i>fidus Achates</i> inhaled
         with internal satisfaction the smell of James Rourke's city bakery,
         situated quite close to where they were, the very palatable odour indeed
-        of <Annotation annotationId="040077ourfather" visited={visitedNotes.has("040077ourfather")} annotationSelect={() => {openNote("040077ourfather"); addToVisited("040077ourfather")}} activeAnnotationId={currentNoteId}>our daily bread</Annotation>, of all commodities of the public the primary and
+        of <Annotation annotationId="040077ourfather">our daily bread</Annotation>, of all commodities of the public the primary and
         most indispensable. Bread, the staff of life, earn your bread, O tell me
         where is fancy bread, at Rourke's the baker's it is said.
       </p>
@@ -122,12 +122,12 @@ const Eumaeus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <p>
         Discussing these and kindred topics they made a beeline across the back
-        of the Customhouse and passed under <Annotation annotationId="050006looplinebridge" visited={visitedNotes.has("050006looplinebridge")} annotationSelect={() => {openNote("050006looplinebridge"); addToVisited("050006looplinebridge")}} activeAnnotationId={currentNoteId}>the Loop Line bridge</Annotation> where a brazier
+        of the Customhouse and passed under <Annotation annotationId="050006looplinebridge">the Loop Line bridge</Annotation> where a brazier
         of coke burning in front of a sentrybox or something like one attracted
         their rather lagging footsteps. Stephen of his own accord stopped for
         no special reason to look at the heap of barren cobblestones and by
         the light emanating from the brazier he could just make out the darker
-        figure of the <Annotation annotationId="060033corporation" visited={visitedNotes.has("060033corporation")} annotationSelect={() => {openNote("060033corporation"); addToVisited("060033corporation")}} activeAnnotationId={currentNoteId}>corporation</Annotation> watchman inside the gloom of the <span data-edition="ed1932" data-page="525"> </span>sentrybox. He
+        figure of the <Annotation annotationId="060033corporation">corporation</Annotation> watchman inside the gloom of the <span data-edition="ed1932" data-page="525"> </span>sentrybox. He
         began to remember that this had <span data-edition="ed1961" data-page="615"> </span>happened, or had been mentioned as having
         happened, before but it cost 
         <span data-edition="ed1922" data-page="571"> </span>
@@ -165,7 +165,7 @@ const Eumaeus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         a certain Katherine Brophy, the daughter of a Louth farmer. His
         grandfather Patrick Michael Corley of New Ross had married the widow
         of a publican there whose maiden name had been Katherine (also) Talbot.
-        Rumour had it (though not proved) that <Annotation annotationId="030150malahide" visited={visitedNotes.has("030150malahide")} annotationSelect={() => {openNote("030150malahide"); addToVisited("030150malahide")}} activeAnnotationId={currentNoteId}>she descended from the house of
+        Rumour had it (though not proved) that <Annotation annotationId="030150malahide">she descended from the house of
         the lords Talbot de Malahide in whose mansion, really an unquestionably
         fine residence of its kind and well worth seeing, her mother or aunt or
         some relative, a woman, as the tale went, of extreme beauty, had enjoyed
@@ -176,7 +176,7 @@ const Eumaeus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <p>
         Taking Stephen on one side he had the customary doleful ditty to tell.
-        <Annotation annotationId="010019money" visited={visitedNotes.has("010019money")} annotationSelect={() => {openNote("010019money"); addToVisited("010019money")}} activeAnnotationId={currentNoteId}>Not as much as a farthing</Annotation> to purchase a night's <span data-edition="ed1961" data-page="616"> </span>lodgings. His friends
+        <Annotation annotationId="010019money">Not as much as a farthing</Annotation> to purchase a night's <span data-edition="ed1961" data-page="616"> </span>lodgings. His friends
         had all deserted him. 
         <span data-edition="ed1939" data-page="433"> </span>
         Furthermore he had a row with Lenehan <span data-edition="ed1932" data-page="526"> </span>and called
@@ -211,11 +211,11 @@ const Eumaeus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       <p>
         Corley at the first go-off was inclined to suspect it was something to
         do with Stephen being fired out of his digs for bringing in a bloody
-        tart off the street. There was <Annotation annotationId="160005dosshouse" visited={visitedNotes.has("160005dosshouse")} annotationSelect={() => {openNote("160005dosshouse"); addToVisited("160005dosshouse")}} activeAnnotationId={currentNoteId}>a dosshouse in Marlborough street, Mrs
-        Maloney's</Annotation>, but it was only <Annotation annotationId="010019money" visited={visitedNotes.has("010019money")} annotationSelect={() => {openNote("010019money"); addToVisited("010019money")}} activeAnnotationId={currentNoteId}>a tanner</Annotation> touch and full of undesirables but
+        tart off the street. There was <Annotation annotationId="160005dosshouse">a dosshouse in Marlborough street, Mrs
+        Maloney's</Annotation>, but it was only <Annotation annotationId="010019money">a tanner</Annotation> touch and full of undesirables but
         M'Conachie told him you got a decent enough do in the Brazen Head over
         in Winetavern <span data-edition="ed1986" data-page="504"> </span>street (which was distantly suggestive to the person
-        addressed of friar Bacon) for <Annotation annotationId="010019money" visited={visitedNotes.has("010019money")} annotationSelect={() => {openNote("010019money"); addToVisited("010019money")}} activeAnnotationId={currentNoteId}>a bob</Annotation>. He was starving too though he
+        addressed of friar Bacon) for <Annotation annotationId="010019money">a bob</Annotation>. He was starving too though he
         hadn't said a word about it.
       </p>
       <p>
@@ -246,7 +246,7 @@ const Eumaeus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         as it turned out.
       </p>
       <p>
-        —{" "}<Annotation annotationId="010019money" visited={visitedNotes.has("010019money")} annotationSelect={() => {openNote("010019money"); addToVisited("010019money")}} activeAnnotationId={currentNoteId}>Those are halfcrowns</Annotation>, man, Corley corrected him.
+        —{" "}<Annotation annotationId="010019money">Those are halfcrowns</Annotation>, man, Corley corrected him.
       </p>
       <p>
         And so in point of fact they turned out to be. Stephen anyhow lent him
@@ -270,7 +270,7 @@ const Eumaeus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         that he said Stephen knew well out of Fullam's, the shipchandler's,
         bookkeeper there that used to be often round in Nagle's back with O'Mara
         and a little chap with a stutter the name of Tighe. Anyhow he was lagged
-        the night before last and fined <Annotation annotationId="010019money" visited={visitedNotes.has("010019money")} annotationSelect={() => {openNote("010019money"); addToVisited("010019money")}} activeAnnotationId={currentNoteId}>ten bob</Annotation> for a drunk and disorderly and
+        the night before last and fined <Annotation annotationId="010019money">ten bob</Annotation> for a drunk and disorderly and
         refusing to go with the constable.
       </p>
       <p>
@@ -310,7 +310,7 @@ const Eumaeus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         At this intelligence, in which he seemingly evinced little interest, Mr
         Bloom gazed abstractedly for the space of a half a second or so in the
         direction of a bucketdredger, rejoicing in the farfamed name of Eblana,
-        <Annotation annotationId="070015buttbridge" visited={visitedNotes.has("070015buttbridge")} annotationSelect={() => {openNote("070015buttbridge"); addToVisited("070015buttbridge")}} activeAnnotationId={currentNoteId}>moored alongside Customhouse quay</Annotation> and quite possibly out of repair,
+        <Annotation annotationId="070015buttbridge">moored alongside Customhouse quay</Annotation> and quite possibly out of repair,
         whereupon he observed evasively:
       </p>
       <p>
@@ -383,7 +383,7 @@ const Eumaeus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         knows which side his bread is buttered on though in all probability he
         never realised what it is to be without regular meals. Of course you
         didn't notice as much as I did. But it wouldn't occasion me the least
-        surprise to learn that <Annotation annotationId="100002tobacco" visited={visitedNotes.has("100002tobacco")} annotationSelect={() => {openNote("100002tobacco"); addToVisited("100002tobacco")}} activeAnnotationId={currentNoteId}>a pinch of tobacco or some narcotic</Annotation> was put in
+        surprise to learn that <Annotation annotationId="100002tobacco">a pinch of tobacco or some narcotic</Annotation> was put in
         your drink for some ulterior object.
       </p>
       <p>
@@ -394,7 +394,7 @@ const Eumaeus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         a tony medical practitioner drawing a handsome fee for his services
         in addition to which professional status his rescue of that man from
         certain drowning by artificial respiration and what they call first
-        aid <Annotation annotationId="030150malahide" visited={visitedNotes.has("030150malahide")} annotationSelect={() => {openNote("030150malahide"); addToVisited("030150malahide")}} activeAnnotationId={currentNoteId}>at Skerries, or Malahide was it?</Annotation>, was, he was bound to admit, an
+        aid <Annotation annotationId="030150malahide">at Skerries, or Malahide was it?</Annotation>, was, he was bound to admit, an
         exceedingly plucky deed which he could not too highly praise, so that
         frankly he was utterly at a loss to fathom what earthly reason could be
         at the back of it except he put it down to sheer cussedness or jealousy,
@@ -419,7 +419,7 @@ const Eumaeus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         possessed, he experienced no little difficulty in making both ends meet.
       </p>
       <p>
-        Adjacent to the men's public urinal they perceived <Annotation annotationId="050047hokypoky" visited={visitedNotes.has("050047hokypoky")} annotationSelect={() => {openNote("050047hokypoky"); addToVisited("050047hokypoky")}} activeAnnotationId={currentNoteId}>an icecream car</Annotation> round
+        Adjacent to the men's public urinal they perceived <Annotation annotationId="050047hokypoky">an icecream car</Annotation> round
         which a group of presumably Italians in heated altercation were getting
         rid of voluble expressions in their vivacious language in a particularly
         animated way, there being some little differences between the parties.
@@ -440,7 +440,7 @@ const Eumaeus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         <i>—{" "}Farabutto! Mortacci sui!</i>
       </p>
       <p>
-        Mr Bloom and Stephen entered <Annotation annotationId="050051shelter" visited={visitedNotes.has("050051shelter")} annotationSelect={() => {openNote("050051shelter"); addToVisited("050051shelter")}} activeAnnotationId={currentNoteId}>the cabman's shelter, an unpretentious
+        Mr Bloom and Stephen entered <Annotation annotationId="050051shelter">the cabman's shelter, an unpretentious
         wooden structure</Annotation>, where, prior to then, he had rarely if ever been
         before, the former having previously whispered to the latter a few
         hints anent the keeper of it said to be the once famous Skin-the-Goat
@@ -454,7 +454,7 @@ const Eumaeus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <p>
         —{" "}Now touching a cup of coffee, Mr Bloom ventured to plausibly suggest
-        <Annotation annotationId="160006icebergs" visited={visitedNotes.has("160006icebergs")} annotationSelect={() => {openNote("160006icebergs"); addToVisited("160006icebergs")}} activeAnnotationId={currentNoteId}>to break the ice</Annotation>, it occurs to me you ought to sample something in the
+        <Annotation annotationId="160006icebergs">to break the ice</Annotation>, it occurs to me you ought to sample something in the
         shape of solid food, say, a roll of some description.
       </p>
       <p>
@@ -613,7 +613,7 @@ const Eumaeus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       <p>
         —{" "}Why, the sailor replied, relaxing to a certain extent under the magic
         influence of diamond cut diamond, it might be a matter of ten years. He
-        toured the wide world with <Annotation annotationId="040066bonethemyoung" visited={visitedNotes.has("040066bonethemyoung")} annotationSelect={() => {openNote("040066bonethemyoung"); addToVisited("040066bonethemyoung")}} activeAnnotationId={currentNoteId}>Hengler's Royal Circus</Annotation>. I seen him do that in
+        toured the wide world with <Annotation annotationId="040066bonethemyoung">Hengler's Royal Circus</Annotation>. I seen him do that in
         Stockholm.
       </p>
       <p>
@@ -629,7 +629,7 @@ const Eumaeus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <span data-edition="ed1932" data-page="533"> </span>
       <p>
-        —{" "}That's right, the sailor said. <Annotation annotationId="170019localities" visited={visitedNotes.has("170019localities")} annotationSelect={() => {openNote("170019localities"); addToVisited("170019localities")}} activeAnnotationId={currentNoteId}>Fort Camden and Fort Carlisle.</Annotation> That's
+        —{" "}That's right, the sailor said. <Annotation annotationId="170019localities">Fort Camden and Fort Carlisle.</Annotation> That's
         where I hails from. I belongs there. That's where I hails from. My
         little woman's down there. She's waiting for me, I know. <i>For England,
         home and beauty</i>. She's my own true wife I haven't seen for seven years
@@ -640,9 +640,9 @@ const Eumaeus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         to the mariner's roadside shieling after having diddled Davy Jones,
         a rainy night with a blind moon. Across the world for a wife. Quite a
         number of stories there were on that particular Alice Ben Bolt topic,
-        Enoch Arden and Rip van Winkle and <Annotation annotationId="160012caocoleary" visited={visitedNotes.has("160012caocoleary")} annotationSelect={() => {openNote("160012caocoleary"); addToVisited("160012caocoleary")}} activeAnnotationId={currentNoteId}>does anybody hereabouts remember Caoc
+        Enoch Arden and Rip van Winkle and <Annotation annotationId="160012caocoleary">does anybody hereabouts remember Caoc
         O'Leary, a favourite and most trying declamation piece</Annotation> by the way of
-        <Annotation annotationId="160011johncasey" visited={visitedNotes.has("160011johncasey")} annotationSelect={() => {openNote("160011johncasey"); addToVisited("160011johncasey")}} activeAnnotationId={currentNoteId}>poor John Casey</Annotation> and a bit of perfect poetry in its own small way.
+        <Annotation annotationId="160011johncasey">poor John Casey</Annotation> and a bit of perfect poetry in its own small way.
         Never about the runaway wife coming back, however much devoted to the
         absentee. The face at the window! Judge of his astonishment when he
         finally did breast the tape and the awful truth dawned upon him anent
@@ -676,7 +676,7 @@ const Eumaeus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         stammers, proceeded:
       </p>
       <p>
-        —{" "}We come up this morning eleven o'clock. <Annotation annotationId="030071threemaster" visited={visitedNotes.has("030071threemaster")} annotationSelect={() => {openNote("030071threemaster"); addToVisited("030071threemaster")}} activeAnnotationId={currentNoteId}>The threemaster <i>Rosevean</i>
+        —{" "}We come up this morning eleven o'clock. <Annotation annotationId="030071threemaster">The threemaster <i>Rosevean</i>
         from Bridgwater with bricks.</Annotation> I shipped to get over. Paid off this
         afternoon. There's my discharge. See? W. B. Murphy, A. B. S.
       </p>
@@ -693,7 +693,7 @@ const Eumaeus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         —{" "}Why, the sailor answered, upon reflection upon it, I've circumnavigated
         a bit since I first joined on. I was in the Red Sea. I was in China and
         North America and South America. We was chased by pirates one voyage.
-        I seen icebergs plenty, <Annotation annotationId="160006icebergs" visited={visitedNotes.has("160006icebergs")} annotationSelect={() => {openNote("160006icebergs"); addToVisited("160006icebergs")}} activeAnnotationId={currentNoteId}>growlers</Annotation>. I was in Stockholm and the Black 
+        I seen icebergs plenty, <Annotation annotationId="160006icebergs">growlers</Annotation>. I was in Stockholm and the Black 
         <span data-edition="ed1939" data-page="439"> </span>
         Sea, the Dardanelles under Captain Dalton, the best bloody man that ever
         scuttled a ship. I seen Russia. <i>Gospodi pomilyou</i>. That's how the
@@ -768,12 +768,12 @@ const Eumaeus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         ever travelled extensively to any great extent but he was at heart a
         born adventurer though by a trick of fate he had consistently remained
         a landlubber except you call going to Holyhead which was his longest.
-        <Annotation annotationId="060034martincunningham" visited={visitedNotes.has("060034martincunningham")} annotationSelect={() => {openNote("060034martincunningham"); addToVisited("060034martincunningham")}} activeAnnotationId={currentNoteId}>Martin Cunningham</Annotation> frequently said he would work a pass through Egan but
+        <Annotation annotationId="060034martincunningham">Martin Cunningham</Annotation> frequently said he would work a pass through Egan but
         some deuced hitch or other eternally cropped up with the net result that
         the scheme fell through. But even suppose it did come to planking
         down the needful and breaking Boyd's heart it was not so dear, purse
         permitting, a few guineas at the outside considering the fare to
-        <Annotation annotationId="010126mullingar" visited={visitedNotes.has("010126mullingar")} annotationSelect={() => {openNote("010126mullingar"); addToVisited("010126mullingar")}} activeAnnotationId={currentNoteId}>Mullingar</Annotation> where he figured on going was five and six there and back.
+        <Annotation annotationId="010126mullingar">Mullingar</Annotation> where he figured on going was five and six there and back.
         The trip would benefit health on account of the bracing ozone and be in
         every way thoroughly pleasurable, especially for
         <span data-edition="ed1939" data-page="440"> </span>
@@ -786,7 +786,7 @@ const Eumaeus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         struck him as a by no means bad notion was he might have a gaze around
         on the spot to see about trying to make arrangements about a concert
         tour of summer music embracing the most prominent pleasure resorts,
-        <Annotation annotationId="180002margate" visited={visitedNotes.has("180002margate")} annotationSelect={() => {openNote("180002margate"); addToVisited("180002margate")}} activeAnnotationId={currentNoteId}>Margate with mixed bathing</Annotation> and firstrate hydros and spas, Eastbourne,
+        <Annotation annotationId="180002margate">Margate with mixed bathing</Annotation> and firstrate hydros and spas, Eastbourne,
         Scarborough, Margate and so on, beautiful Bournemouth, the Channel
         islands and similar bijou spots, which might prove highly remunerative.
         Not, of course, with a hole and corner scratch company or local ladies
@@ -825,21 +825,21 @@ const Eumaeus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         island, delightful sylvan spots for <span data-edition="ed1961" data-page="627"> </span>rejuvenation, offering a plethora
         of attractions as well as a bracing tonic for the system in and around
         Dublin and its picturesque environs even, Poulaphouca to which there was
-        a steam tram, but also <Annotation annotationId="060005churchyard" visited={visitedNotes.has("060005churchyard")} annotationSelect={() => {openNote("060005churchyard"); addToVisited("060005churchyard")}} activeAnnotationId={currentNoteId}>farther away from the madding crowd</Annotation> in <Annotation annotationId="050025botanicgardens" visited={visitedNotes.has("050025botanicgardens")} annotationSelect={() => {openNote("050025botanicgardens"); addToVisited("050025botanicgardens")}} activeAnnotationId={currentNoteId}>Wicklow,
+        a steam tram, but also <Annotation annotationId="060005churchyard">farther away from the madding crowd</Annotation> in <Annotation annotationId="050025botanicgardens">Wicklow,
         rightly termed the garden of Ireland</Annotation>, an ideal neighbourhood for elderly
         wheelmen so long as it didn't come down, and in the wilds of Donegal
         where, if report spoke true, the <i>coup d'œil</i> was exceedingly grand,
         though the lastnamed locality was not easily getatable so that the
         influx of visitors was not as yet all that it might be considering the
         signal benefits to be derived from it, while Howth with its historic
-        associations and otherwise, <Annotation annotationId="030058pretenders" visited={visitedNotes.has("030058pretenders")} annotationSelect={() => {openNote("030058pretenders"); addToVisited("030058pretenders")}} activeAnnotationId={currentNoteId}>Silken Thomas</Annotation>, Grace O'Malley, George IV,
+        associations and otherwise, <Annotation annotationId="030058pretenders">Silken Thomas</Annotation>, Grace O'Malley, George IV,
         rhododendrons several hundred feet above sealevel was a favourite haunt
         with all sorts and conditions of men, especially in the spring when young
         men's fancy, though it had its own toll of deaths by falling off the
         cliffs by design or accidentally, usually, by the way, on their left
         leg, it being only about three quarters 
         <span data-edition="ed1939" data-page="441"> </span>
-        of an hour's <Annotation annotationId="070006nelsonspillar" visited={visitedNotes.has("070006nelsonspillar")} annotationSelect={() => {openNote("070006nelsonspillar"); addToVisited("070006nelsonspillar")}} activeAnnotationId={currentNoteId}>run from the
+        of an hour's <Annotation annotationId="070006nelsonspillar">run from the
         pillar</Annotation>. Because of course uptodate tourist travelling was as yet merely
         in its infancy, so to speak, and the accommodation left much to be
         desired. Interesting to fathom, it seemed to him, from a motive of
@@ -850,8 +850,8 @@ const Eumaeus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       <span data-edition="ed1922" data-page="583"> </span>
       <p>
         —{" "}I seen a Chinese one time, related the doughty narrator, that had
-        <span data-edition="ed1932" data-page="537"> </span><Annotation annotationId="160008littlepills" visited={visitedNotes.has("160008littlepills")} annotationSelect={() => {openNote("160008littlepills"); addToVisited("160008littlepills")}} activeAnnotationId={currentNoteId}>little pills like putty and he put them in the water and they opened and
-        every pill</Annotation> <span data-edition="ed1986" data-page="513"> </span><Annotation annotationId="160008littlepills" visited={visitedNotes.has("160008littlepills")} annotationSelect={() => {openNote("160008littlepills"); addToVisited("160008littlepills")}} activeAnnotationId={currentNoteId}>was something different. One was a ship, another was a house,
+        <span data-edition="ed1932" data-page="537"> </span><Annotation annotationId="160008littlepills">little pills like putty and he put them in the water and they opened and
+        every pill</Annotation> <span data-edition="ed1986" data-page="513"> </span><Annotation annotationId="160008littlepills">was something different. One was a ship, another was a house,
         another was a flower.</Annotation> Cooks rats in your soup, he appetisingly added,
         the chinks does.
       </p>
@@ -930,7 +930,7 @@ const Eumaeus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       <p>
         —{" "}Ah, you've touched there too, Mr Bloom said, Europa point, thinking he
         had, in the hope that the rover might possibly by some reminiscences but
-        he <span data-edition="ed1986" data-page="514"> </span>failed to do so, <Annotation annotationId="080022sawdust" visited={visitedNotes.has("080022sawdust")} annotationSelect={() => {openNote("080022sawdust"); addToVisited("080022sawdust")}} activeAnnotationId={currentNoteId}>simply letting spurt a jet of spew into the sawdust</Annotation>,
+        he <span data-edition="ed1986" data-page="514"> </span>failed to do so, <Annotation annotationId="080022sawdust">simply letting spurt a jet of spew into the sawdust</Annotation>,
         and shook his head with a sort of lazy scorn.
       </p>
       <p>
@@ -943,7 +943,7 @@ const Eumaeus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         answering:
       </p>
       <p>
-        —{" "}I'm tired of <Annotation annotationId="160006icebergs" visited={visitedNotes.has("160006icebergs")} annotationSelect={() => {openNote("160006icebergs"); addToVisited("160006icebergs")}} activeAnnotationId={currentNoteId}>all them rocks in the sea</Annotation>, he said, and boats and ships.
+        —{" "}I'm tired of <Annotation annotationId="160006icebergs">all them rocks in the sea</Annotation>, he said, and boats and ships.
         Salt junk all the time.
       </p>
       <p>
@@ -952,11 +952,11 @@ const Eumaeus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         fell to woolgathering on the enormous dimensions of the water about the
         globe. Suffice it to say that, as a casual glance at the map revealed,
         it covered fully three fourths of it and he fully realised accordingly
-        what it meant, to <Annotation annotationId="010107seasruler" visited={visitedNotes.has("010107seasruler")} annotationSelect={() => {openNote("010107seasruler"); addToVisited("010107seasruler")}} activeAnnotationId={currentNoteId}>rule the waves</Annotation>. On more than one occasion—a dozen
+        what it meant, to <Annotation annotationId="010107seasruler">rule the waves</Annotation>. On more than one occasion—a dozen
         at the lowest—near the North Bull at Dollymount he had remarked a
         superannuated old salt, evidently derelict, seated habitually near the
         not particularly redolent sea on the wall, staring quite obliviously at
-        it and it at him, dreaming of <Annotation annotationId="020010lycidas" visited={visitedNotes.has("020010lycidas")} annotationSelect={() => {openNote("020010lycidas"); addToVisited("020010lycidas")}} activeAnnotationId={currentNoteId}>fresh woods and pastures new as someone
+        it and it at him, dreaming of <Annotation annotationId="020010lycidas">fresh woods and pastures new as someone
         somewhere sings</Annotation>. And it left him wondering why. Possibly he had tried to
         find out the secret for himself, floundering up and down the antipodes
         and all that sort of thing and over and under—well, not exactly under—tempting the fates. And the odds were twenty to nil there was really no
@@ -974,7 +974,7 @@ const Eumaeus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         gratitude also to the harbourmasters and coastguard service who had
         to man the <span data-edition="ed1932" data-page="539"> </span>rigging and push off and out amid the elements, whatever the
         season, when duty called <i>Ireland expects that every man</i> and so on, and
-        sometimes had a terrible time of it in the wintertime not forgetting <Annotation annotationId="030013kishlightship" visited={visitedNotes.has("030013kishlightship")} annotationSelect={() => {openNote("030013kishlightship"); addToVisited("030013kishlightship")}} activeAnnotationId={currentNoteId}>the
+        sometimes had a terrible time of it in the wintertime not forgetting <Annotation annotationId="030013kishlightship">the
         Irish lights, Kish and others</Annotation>, liable to capsize at any moment, rounding
         which he once with his daughter had experienced some remarkably choppy,
         not to say stormy, weather.
@@ -1041,7 +1041,7 @@ const Eumaeus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         time stretched over.
       </p>
       <p>
-        —{" "}Ay, <Annotation annotationId="160006icebergs" visited={visitedNotes.has("160006icebergs")} annotationSelect={() => {openNote("160006icebergs"); addToVisited("160006icebergs")}} activeAnnotationId={currentNoteId}> ay, sighed</Annotation> the sailor, looking down on his manly chest. He's gone
+        —{" "}Ay, <Annotation annotationId="160006icebergs"> ay, sighed</Annotation> the sailor, looking down on his manly chest. He's gone
         too. Ate by sharks after. Ay, ay.
       </p>
       <p>
@@ -1099,7 +1099,7 @@ const Eumaeus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         company so it came as a genuine relief when the keeper made her a rude
         sign to take herself off. Round the side of the 
         <span data-edition="ed1922" data-page="587"> </span>
-        <Annotation annotationId="020064telegraph" visited={visitedNotes.has("020064telegraph")} annotationSelect={() => {openNote("020064telegraph"); addToVisited("020064telegraph")}} activeAnnotationId={currentNoteId}><i>Evening Telegraph</i></Annotation> he
+        <Annotation annotationId="020064telegraph"><i>Evening Telegraph</i></Annotation> he
         just caught a fleeting glimpse of her face round the side of the door
         with a kind of <span data-edition="ed1932" data-page="541"> </span>demented glassy grin showing that she was not exactly all
         there, viewing with evident amusement the group of gazers round skipper
@@ -1143,7 +1143,7 @@ const Eumaeus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         in the soul. Or do you mean the intelligence, the brainpower as such,
         as distinct from any outside object, the table, let us say, that cup. I
         believe in that myself because it has been explained by competent men as
-        the convolutions of the grey matter. Otherwise we would never have <Annotation annotationId="080011xrays" visited={visitedNotes.has("080011xrays")} annotationSelect={() => {openNote("080011xrays"); addToVisited("080011xrays")}} activeAnnotationId={currentNoteId}>such
+        the convolutions of the grey matter. Otherwise we would never have <Annotation annotationId="080011xrays">such
         inventions as X rays</Annotation>, for instance. Do you?
       </p>
       <p>
@@ -1245,7 +1245,7 @@ const Eumaeus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       <span data-edition="ed1939" data-page="446"> </span>
       <p>
         —{" "}Liquids I can eat, Stephen said. But oblige me by taking away that
-        knife. I can't look at the point of it. <Annotation annotationId="020007juliuscaesar" visited={visitedNotes.has("020007juliuscaesar")} annotationSelect={() => {openNote("020007juliuscaesar"); addToVisited("020007juliuscaesar")}} activeAnnotationId={currentNoteId}>It reminds me of Roman history.</Annotation>
+        knife. I can't look at the point of it. <Annotation annotationId="020007juliuscaesar">It reminds me of Roman history.</Annotation>
       </p>
       <p>
         Mr Bloom promptly did as suggested and removed the incriminated article,
@@ -1303,9 +1303,9 @@ const Eumaeus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <p>
         However, reverting to friend Sinbad and his horrifying adventures (who
-        reminded him a bit of <Annotation annotationId="060040gaietytheatre" visited={visitedNotes.has("060040gaietytheatre")} annotationSelect={() => {openNote("060040gaietytheatre"); addToVisited("060040gaietytheatre")}} activeAnnotationId={currentNoteId}>Ludwig, <i>alias</i> Ledwidge, when he occupied
+        reminded him a bit of <Annotation annotationId="060040gaietytheatre">Ludwig, <i>alias</i> Ledwidge, when he occupied
         the boards of the Gaiety when Michael Gunn was identified with the
-        management</Annotation> in <Annotation annotationId="160009flyingdutchmen" visited={visitedNotes.has("160009flyingdutchmen")} annotationSelect={() => {openNote("160009flyingdutchmen"); addToVisited("160009flyingdutchmen")}} activeAnnotationId={currentNoteId}>the <i>Flying Dutchman</i>, a stupendous success, and his host
+        management</Annotation> in <Annotation annotationId="160009flyingdutchmen">the <i>Flying Dutchman</i>, a stupendous success, and his host
         of admirers came in large numbers, everyone simply flocking to hear him
         though ships of any sort, phantom or the reverse, on the stage usually
         fell a bit flat as also did trains</Annotation>), there was nothing intrinsically
@@ -1315,7 +1315,7 @@ const Eumaeus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         <span data-edition="ed1939" data-page="447"> </span>
         free to admit those ice <span data-edition="ed1961" data-page="636"> </span>creamers and friers in the fish
         way, not to mention the chip potato variety and so forth, over in little
-        Italy there near <Annotation annotationId="050014thecoombe" visited={visitedNotes.has("050014thecoombe")} annotationSelect={() => {openNote("050014thecoombe"); addToVisited("050014thecoombe")}} activeAnnotationId={currentNoteId}>the Coombe</Annotation>, were sober thrifty hardworking fellows
+        Italy there near <Annotation annotationId="050014thecoombe">the Coombe</Annotation>, were sober thrifty hardworking fellows
         except perhaps a bit too given to pothunting the harmless necessary
         animal of the feline persuasion of others at night so as to have a good
         old succulent tuckin with garlic <i>de rigueur</i> off him or her next day on
@@ -1344,7 +1344,7 @@ const Eumaeus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <p>
         —{" "}Then, Stephen said, staring and rambling on to himself or some unknown
-        listener somewhere, we have the impetuosity of <Annotation annotationId="160003isoscelestriangle" visited={visitedNotes.has("160003isoscelestriangle")} annotationSelect={() => {openNote("160003isoscelestriangle"); addToVisited("160003isoscelestriangle")}} activeAnnotationId={currentNoteId}>Dante and the isosceles
+        listener somewhere, we have the impetuosity of <Annotation annotationId="160003isoscelestriangle">Dante and the isosceles
         triangle, Miss Portinari, he fell in love with and Leonardo and san
         Tommaso Mastino.</Annotation>
       </p>
@@ -1363,7 +1363,7 @@ const Eumaeus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       <p>
         Interest, however, was starting to flag somewhat all round and the
         others got on to talking about accidents at sea, ships lost in a fog,
-        <Annotation annotationId="160006icebergs" visited={visitedNotes.has("160006icebergs")} annotationSelect={() => {openNote("160006icebergs"); addToVisited("160006icebergs")}} activeAnnotationId={currentNoteId}> collisions with icebergs</Annotation>, all that sort of thing. Shipahoy, of course,
+        <Annotation annotationId="160006icebergs"> collisions with icebergs</Annotation>, all that sort of thing. Shipahoy, of course,
         had his own say to say. He had doubled the Cape a few odd times and
         weathered a monsoon, a kind of <span data-edition="ed1961" data-page="637"> </span>wind, in the China seas and through all
         those perils of the deep there was one thing, he declared, stood to him,
@@ -1408,7 +1408,7 @@ const Eumaeus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         counterattraction in the shape of a female, who, however, had disappeared
         to all intents and purposes, could, by straining, just perceive him, when
         duly refreshed by his rum puncheon exploit, gaping up at the piers and
-        girders of <Annotation annotationId="050006looplinebridge" visited={visitedNotes.has("050006looplinebridge")} annotationSelect={() => {openNote("050006looplinebridge"); addToVisited("050006looplinebridge")}} activeAnnotationId={currentNoteId}>the Loop line</Annotation>, rather out of his depth, as of course it was all
+        girders of <Annotation annotationId="050006looplinebridge">the Loop line</Annotation>, rather out of his depth, as of course it was all
         radically altered since his last visit and greatly improved. Some person
         or persons invisible directed him to the male urinal erected by the
         cleansing committee all over the place for the purpose but, after a brief
@@ -1496,7 +1496,7 @@ const Eumaeus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         nose always, and gobbling up the best meat in the market, and a lot more
         surplus steam in the same vein. Their conversation accordingly became
         general and all agreed that that was a fact. You could grow any mortal
-        thing in Irish soil, he stated, and there was <Annotation annotationId="100002tobacco" visited={visitedNotes.has("100002tobacco")} annotationSelect={() => {openNote("100002tobacco"); addToVisited("100002tobacco")}} activeAnnotationId={currentNoteId}>colonel Everard down
+        thing in Irish soil, he stated, and there was <Annotation annotationId="100002tobacco">colonel Everard down
         there in Navan growing tobacco</Annotation>. Where would you find anywhere the like
         of Irish bacon? But a day of reckoning, he stated <i>crescendo</i> with no
         uncertain voice—thoroughly monopolising all the conversation—was in store for mighty England, despite her power of pelf on 
@@ -1538,7 +1538,7 @@ const Eumaeus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       <span data-edition="ed1922" data-page="595"> </span>
       <p>
         —{" "}That's right, the old tarpaulin corroborated. The Irish catholic
-        peasant. He's <Annotation annotationId="010058bloodyswindle" visited={visitedNotes.has("010058bloodyswindle")} annotationSelect={() => {openNote("010058bloodyswindle"); addToVisited("010058bloodyswindle")}} activeAnnotationId={currentNoteId}>the backbone of our empire</Annotation>. You know Jem Mullins?
+        peasant. He's <Annotation annotationId="010058bloodyswindle">the backbone of our empire</Annotation>. You know Jem Mullins?
       </p>
       <p>
         While allowing him his individual opinions, as every man, the keeper added
@@ -1563,7 +1563,7 @@ const Eumaeus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         equally relevant to the issue, might occur ere then it was highly
         advisable in the interim to try to make the most of both countries, even
         though poles apart. Another little interesting point, the amours of
-        whores and chummies, to put it in common parlance, reminded him <Annotation annotationId="010058bloodyswindle" visited={visitedNotes.has("010058bloodyswindle")} annotationSelect={() => {openNote("010058bloodyswindle"); addToVisited("010058bloodyswindle")}} activeAnnotationId={currentNoteId}>Irish
+        whores and chummies, to put it in common parlance, reminded him <Annotation annotationId="010058bloodyswindle">Irish
         soldiers had as often fought for England as against her, more so, in
         fact</Annotation>. And now, why? So the scene between the pair of them, the licensee
         of the place, rumoured to be or have been Fitzharris, the famous
@@ -1576,7 +1576,7 @@ const Eumaeus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         goby unless you were a blithering idiot altogether and refuse to have
         anything to do with them as a golden rule in private life and their
         felonsetting, there always being the offchance of a Dannyman coming
-        forward and <Annotation annotationId="040089denzille" visited={visitedNotes.has("040089denzille")} annotationSelect={() => {openNote("040089denzille"); addToVisited("040089denzille")}} activeAnnotationId={currentNoteId}>turning queen's evidence—or king's now—like Denis or Peter
+        forward and <Annotation annotationId="040089denzille">turning queen's evidence—or king's now—like Denis or Peter
         Carey, an idea he utterly repudiated.</Annotation> Quite apart from that, he disliked
         those careers of wrongdoing and crime on principle. Yet, though such
         criminal propensities had never been an inmate of his bosom in any
@@ -1594,7 +1594,7 @@ const Eumaeus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         by plunging his knife into her until it just <span data-edition="ed1932" data-page="550"> </span>struck him that
         Fitz, nicknamed Skin-the-Goat, merely drove
         <span data-edition="ed1939" data-page="451"> </span>
-        <Annotation annotationId="050013jauntingcar" visited={visitedNotes.has("050013jauntingcar")} annotationSelect={() => {openNote("050013jauntingcar"); addToVisited("050013jauntingcar")}} activeAnnotationId={currentNoteId}>the car</Annotation> for the actual
+        <Annotation annotationId="050013jauntingcar">the car</Annotation> for the actual
         perpetrators of the outrage and so was not, if he was reliably informed,
         actually party to the ambush which, in point of fact, was the plea some
         legal luminary saved his skin on. In any case that was very ancient
@@ -1614,7 +1614,7 @@ const Eumaeus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         whole eventempered person declared, I let <span data-edition="ed1961" data-page="642"> </span>slip. He called me a jew, and
         in a heated fashion, offensively. So I, without deviating from plain facts
         in the least, told him his God, I mean Christ, was a jew too, and all his
-        family, like me, though <Annotation annotationId="040083hewasajew" visited={visitedNotes.has("040083hewasajew")} annotationSelect={() => {openNote("040083hewasajew"); addToVisited("040083hewasajew")}} activeAnnotationId={currentNoteId}>in reality I'm not</Annotation>. That was one for him. A soft
+        family, like me, though <Annotation annotationId="040083hewasajew">in reality I'm not</Annotation>. That was one for him. A soft
         answer turns away wrath. He hadn't a word to say for himself as everyone
         saw. Am I not right?
       </p>
@@ -1674,7 +1674,7 @@ const Eumaeus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         you be surprised to learn?—proves up to the hilt Spain decayed when the
         inquisition hounded the jews out and England prospered when Cromwell,
         an uncommonly able ruffian who, in other respects, has much to answer for,
-        imported them. Why? Because they are imbued with <Annotation annotationId="160001priestpoverty" visited={visitedNotes.has("160001priestpoverty")} annotationSelect={() => {openNote("160001priestpoverty"); addToVisited("160001priestpoverty")}} activeAnnotationId={currentNoteId}>the proper spirit. They
+        imported them. Why? Because they are imbued with <Annotation annotationId="160001priestpoverty">the proper spirit. They
         are practical and are proved to be so. I don't want to indulge in any...
         because you know the standard works on the subject, and then, orthodox as
         you are... But in the economic, not touching religion, domain, the priest
@@ -1697,7 +1697,7 @@ const Eumaeus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         Over his untasteable apology for a cup of coffee, listening to this
         synopsis of things in general, Stephen stared at nothing in particular.
         <span data-edition="ed1932" data-page="552"> </span>He could hear, of course, all kinds of words changing colour like those
-        crabs about  <Annotation annotationId="030099ringsend" visited={visitedNotes.has("030099ringsend")} annotationSelect={() => {openNote("030099ringsend"); addToVisited("030099ringsend")}} activeAnnotationId={currentNoteId}> Ringsend</Annotation> in the morning, burrowing quickly into all colours
+        crabs about  <Annotation annotationId="030099ringsend"> Ringsend</Annotation> in the morning, burrowing quickly into all colours
         of different sorts of the same sand where they had a home somewhere
         beneath or seemed to. Then he looked up and saw the eyes that said or
         didn't say the words the voice he heard said—if you work.
@@ -1714,7 +1714,7 @@ const Eumaeus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       <p>
         —{" "}I mean, of course, the other hastened to affirm, work in the widest
         possible sense. Also literary labour, not merely for the kudos of
-        the thing. <Annotation annotationId="160004newspapers" visited={visitedNotes.has("160004newspapers")} annotationSelect={() => {openNote("160004newspapers"); addToVisited("160004newspapers")}} activeAnnotationId={currentNoteId}>Writing for the newspapers</Annotation> which is the readiest channel
+        the thing. <Annotation annotationId="160004newspapers">Writing for the newspapers</Annotation> which is the readiest channel
         nowadays. That's work too. Important work. After all, from the little
         I know of you, after all the money expended on your education, you are
         entitled to <span data-edition="ed1961" data-page="644"> </span>recoup yourself and command your price. You have every bit
@@ -1810,30 +1810,30 @@ const Eumaeus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         as such, was, he felt, from time to time a firstrate tonic for the mind.
         Added to which was the coincidence of meeting, discussion, dance, row,
         old salt, of the here today and gone tomorrow type, night loafers, the
-        whole galaxy of events, <Annotation annotationId="070021putusall" visited={visitedNotes.has("070021putusall")} annotationSelect={() => {openNote("070021putusall"); addToVisited("070021putusall")}} activeAnnotationId={currentNoteId}>all went to make up a miniature cameo of the
+        whole galaxy of events, <Annotation annotationId="070021putusall">all went to make up a miniature cameo of the
         world we live in</Annotation>, especially as the lives of the submerged tenth, viz.,
         coalminers, divers, <span data-edition="ed1961" data-page="646"> </span>scavengers, etc., were very much under the microscope
         lately. To improve the shining hour he wondered whether he might meet
-        with anything approaching <Annotation annotationId="040019titbits" visited={visitedNotes.has("040019titbits")} annotationSelect={() => {openNote("040019titbits"); addToVisited("040019titbits")}} activeAnnotationId={currentNoteId}>the same luck as Mr Philip Beaufoy</Annotation> if taken
-        down in writing. <Annotation annotationId="040030leopoldbloom" visited={visitedNotes.has("040030leopoldbloom")} annotationSelect={() => {openNote("040030leopoldbloom"); addToVisited("040030leopoldbloom")}} activeAnnotationId={currentNoteId}>Suppose he were to pen something out of the common
+        with anything approaching <Annotation annotationId="040019titbits">the same luck as Mr Philip Beaufoy</Annotation> if taken
+        down in writing. <Annotation annotationId="040030leopoldbloom">Suppose he were to pen something out of the common
         groove</Annotation> (as he fully intended doing) at the rate of one guinea per
         column, <i>My Experiences</i>, let us say, <i>in a Cabman's Shelter</i>.
       </p>
       <p>
-        <Annotation annotationId="020064telegraph" visited={visitedNotes.has("020064telegraph")} annotationSelect={() => {openNote("020064telegraph"); addToVisited("020064telegraph")}} activeAnnotationId={currentNoteId}>The pink edition, extra sporting, of the <i>Telegraph</i>, tell a graphic lie</Annotation>,
+        <Annotation annotationId="020064telegraph">The pink edition, extra sporting, of the <i>Telegraph</i>, tell a graphic lie</Annotation>,
         lay, as luck would have it, beside his elbow and as he was just puzzling
         again, far from satisfied, over a country belonging to him and the
         preceding rebus the vessel came from Bridgwater and the postcard was
         addressed to A. Boudin, find the captain's age, his eyes went aimlessly
         over the respective captions which came under his special province, the
-        allembracing <Annotation annotationId="040077ourfather" visited={visitedNotes.has("040077ourfather")} annotationSelect={() => {openNote("040077ourfather"); addToVisited("040077ourfather")}} activeAnnotationId={currentNoteId}>give us this day our daily press</Annotation>. First he got a bit of a
+        allembracing <Annotation annotationId="040077ourfather">give us this day our daily press</Annotation>. First he got a bit of a
         start but it turned out to be only something about somebody named H.
         du Boyes, agent for typewriters or something like that. Great battle
         Tokio. Lovemaking in Irish £200 damages. Gordon Bennett.
         Emigration Swindle. Letter from His Grace <span data-edition="ed1986" data-page="528"> </span>William <b>✠</b>. Ascot 
         <i>Throwaway</i> recalls Derby of '92 when
         Captain Marshall's dark horse, <i>Sir Hugo</i>, captured the blue ribband at long
-        odds. <Annotation annotationId="100008generalslocum" visited={visitedNotes.has("100008generalslocum")} annotationSelect={() => {openNote("100008generalslocum"); addToVisited("100008generalslocum")}} activeAnnotationId={currentNoteId}>New York disaster, thousand lives lost.</Annotation> <Annotation annotationId="020054footandmouth" visited={visitedNotes.has("020054footandmouth")} annotationSelect={() => {openNote("020054footandmouth"); addToVisited("020054footandmouth")}} activeAnnotationId={currentNoteId}>Foot and Mouth.</Annotation> Funeral of
+        odds. <Annotation annotationId="100008generalslocum">New York disaster, thousand lives lost.</Annotation> <Annotation annotationId="020054footandmouth">Foot and Mouth.</Annotation> Funeral of
         the late Mr Patrick Dignam.
       </p>
       <span data-edition="ed1922" data-page="601"> </span>
@@ -1843,7 +1843,7 @@ const Eumaeus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <p>
         —{" "}<i>This morning</i> (Hynes put in, of course) <i>the remains of the late Mr
-        Patrick Dignam were removed from his residence, <Annotation annotationId="060019theavenue" visited={visitedNotes.has("060019theavenue")} annotationSelect={() => {openNote("060019theavenue"); addToVisited("060019theavenue")}} activeAnnotationId={currentNoteId}>n° 9 Newbridge Avenue,
+        Patrick Dignam were removed from his residence, <Annotation annotationId="060019theavenue">n° 9 Newbridge Avenue,
         Sandymount</Annotation>, for interment in Glasnevin. The deceased gentleman was a
         most popular and genial personality in city life and his demise, after a
         brief illness, came as a great shock to citizens of all classes by whom
@@ -1853,7 +1853,7 @@ const Eumaeus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         road. The mourners included: Patk. Dignam (son), Bernard Corrigan
         (brother-in-law), John Henry Menton, solr., Martin Cunningham, John
         Power eatondph 1/8 ador dorador douradora</i> <span data-edition="ed1932" data-page="555"> </span>(must be where he called
-        Monks the dayfather about Keyes's ad), <i><Annotation annotationId="050037tomkernan" visited={visitedNotes.has("050037tomkernan")} annotationSelect={() => {openNote("050037tomkernan"); addToVisited("050037tomkernan")}} activeAnnotationId={currentNoteId}>Thomas Kernan</Annotation>, Simon Dedalus,
+        Monks the dayfather about Keyes's ad), <i><Annotation annotationId="050037tomkernan">Thomas Kernan</Annotation>, Simon Dedalus,
         Stephen Dedalus, B. A., Edward J. Lambert, Cornelius Kelleher, Joseph
         M'C. Hynes, L. Boom, C.P. M'Coy,—M'lntosh, and several others</i>.
       </p>
@@ -1861,7 +1861,7 @@ const Eumaeus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         Nettled not a little by <i>L. Boom</i> (as it incorrectly stated) and <span data-edition="ed1961" data-page="647"> </span>the
         line of bitched type, but tickled to death simultaneously by C. P. M'Coy
         and Stephen Dedalus, B. A., who were conspicuous, needless to say, by
-        their total absence (to say nothing of M'Intosh), <Annotation annotationId="040082highgradeha" visited={visitedNotes.has("040082highgradeha")} annotationSelect={() => {openNote("040082highgradeha"); addToVisited("040082highgradeha")}} activeAnnotationId={currentNoteId}> L. Boom pointed it
+        their total absence (to say nothing of M'Intosh), <Annotation annotationId="040082highgradeha"> L. Boom pointed it
         out to his companion B. A.</Annotation>, engaged in stifling another yawn, half
         nervousness, not forgetting the usual crop of nonsensical howlers of
         misprints.
@@ -1911,7 +1911,7 @@ const Eumaeus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <p>
         —{" "}One morning you would open the paper, the cabman affirmed, and read:
-        <i>Return of Parnell</i>. He bet them what they <span data-edition="ed1961" data-page="648"> </span>liked. A <Annotation annotationId="030118royaldublins" visited={visitedNotes.has("030118royaldublins")} annotationSelect={() => {openNote("030118royaldublins"); addToVisited("030118royaldublins")}} activeAnnotationId={currentNoteId}>Dublin fusilier</Annotation> was
+        <i>Return of Parnell</i>. He bet them what they <span data-edition="ed1961" data-page="648"> </span>liked. A <Annotation annotationId="030118royaldublins">Dublin fusilier</Annotation> was
         in that shelter one night and said he saw him in South Africa. Pride it
         was killed him. He ought to have done away with himself or lain low for
         a time after Committee Room No. 15 until he was his old self again with
@@ -2037,10 +2037,10 @@ const Eumaeus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         <span data-edition="ed1922" data-page="605"> </span>
         coals of
         fire on his head, much in the same way as the fabled ass's kick. Looking
-        back now in <Annotation annotationId="060030retrospective" visited={visitedNotes.has("060030retrospective")} annotationSelect={() => {openNote("060030retrospective"); addToVisited("060030retrospective")}} activeAnnotationId={currentNoteId}>a retrospective kind of arrangement</Annotation>, all seemed a kind of
+        back now in <Annotation annotationId="060030retrospective">a retrospective kind of arrangement</Annotation>, all seemed a kind of
         dream. And the coming back was the worst thing you ever did because it
         went without saying you would feel out of place as things always moved
-        with the times. Why, as he reflected, <Annotation annotationId="030015irishtown" visited={visitedNotes.has("030015irishtown")} annotationSelect={() => {openNote("030015irishtown"); addToVisited("030015irishtown")}} activeAnnotationId={currentNoteId}>Irishtown strand</Annotation>, a locality he
+        with the times. Why, as he reflected, <Annotation annotationId="030015irishtown">Irishtown strand</Annotation>, a locality he
         had not been <span data-edition="ed1961" data-page="651"> </span>in for quite a number of years, looked different somehow
         since, as it happened, he went to reside on the north side. North or
         south, however, it was just the wellknown case of hot passion, pure and
@@ -2068,7 +2068,7 @@ const Eumaeus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       <span data-edition="ed1986" data-page="532"> </span>
       <p>
         Carefully avoiding a book in his pocket <i>Sweets of</i>, which reminded him
-        by the by of that <Annotation annotationId="040043capelstreet" visited={visitedNotes.has("040043capelstreet")} annotationSelect={() => {openNote("040043capelstreet"); addToVisited("040043capelstreet")}} activeAnnotationId={currentNoteId}>Capel street library</Annotation> book out of date, he took out his
+        by the by of that <Annotation annotationId="040043capelstreet">Capel street library</Annotation> book out of date, he took out his
         pocketbook and, turning over the various contents it contained rapidly,
         finally he...
       </p>
@@ -2134,7 +2134,7 @@ const Eumaeus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         with the starch out. Suppose she was gone when he?... I looked for the lamp
         which she told me came into his mind but merely as a passing fancy of
         his because he then recollected the morning littered bed etcetera and
-        <Annotation annotationId="040021ruby" visited={visitedNotes.has("040021ruby")} annotationSelect={() => {openNote("040021ruby"); addToVisited("040021ruby")}} activeAnnotationId={currentNoteId}>the book about Ruby</Annotation> with <Annotation annotationId="030087pastlife" visited={visitedNotes.has("030087pastlife")} annotationSelect={() => {openNote("030087pastlife"); addToVisited("030087pastlife")}} activeAnnotationId={currentNoteId}>met him pike hoses</Annotation> (<i>sic</i>) in it which must
+        <Annotation annotationId="040021ruby">the book about Ruby</Annotation> with <Annotation annotationId="030087pastlife">met him pike hoses</Annotation> (<i>sic</i>) in it which must
         have fell down sufficiently appropriately beside the domestic chamberpot
         with apologies to Lindley Murray.
       </p>
@@ -2239,7 +2239,7 @@ const Eumaeus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         ladies' society was a <i>conditio sine qua non</i> though he had the gravest
         possible doubts, not that he wanted in the smallest to pump Stephen
         about Miss Ferguson (who was very possibly the particular lodestar who
-        brought him down to <Annotation annotationId="030015irishtown" visited={visitedNotes.has("030015irishtown")} annotationSelect={() => {openNote("030015irishtown"); addToVisited("030015irishtown")}} activeAnnotationId={currentNoteId}>Irishtown</Annotation> so early in the morning), as to whether he
+        brought him down to <Annotation annotationId="030015irishtown">Irishtown</Annotation> so early in the morning), as to whether he
         would find much satisfaction basking in the boy and girl courtship idea
         and the company of smirking misses without 
         a penny to their names bi- or
@@ -2264,7 +2264,7 @@ const Eumaeus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         Friday. Ah, you mean it's after twelve!
       </p>
       <p>
-        —{" "}<Annotation annotationId="010138eatenall" visited={visitedNotes.has("010138eatenall")} annotationSelect={() => {openNote("010138eatenall"); addToVisited("010138eatenall")}} activeAnnotationId={currentNoteId}>The day before yesterday</Annotation>, Stephen said, improving on himself.
+        —{" "}<Annotation annotationId="010138eatenall">The day before yesterday</Annotation>, Stephen said, improving on himself.
       </p>
       <p>
         Literally astounded at this piece of intelligence, Bloom reflected.
@@ -2318,7 +2318,7 @@ const Eumaeus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         did entertain the proposal, as it would afford him very great personal
         pleasure if he would allow him to help to put coin in his way or some
         wardrobe, if found suitable. At all events he wound up by concluding,
-        eschewing for the nonce hidebound precedent, a cup of <Annotation annotationId="170006eppscocoa" visited={visitedNotes.has("170006eppscocoa")} annotationSelect={() => {openNote("170006eppscocoa"); addToVisited("170006eppscocoa")}} activeAnnotationId={currentNoteId}>Epps's cocoa</Annotation> and
+        eschewing for the nonce hidebound precedent, a cup of <Annotation annotationId="170006eppscocoa">Epps's cocoa</Annotation> and
         a shakedown for the night plus the <span data-edition="ed1961" data-page="657"> </span>use of a rug or two and overcoat
         doubled into a pillow. At least he would be in safe hands and as warm as
         a toast on a trivet. He failed to perceive any very vast amount of harm
@@ -2343,7 +2343,7 @@ const Eumaeus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         put up with being bitten by a wolf but what properly riled
         them was a bite from a sheep. The most vulnerable point too of tender
         Achilles, your God was <span data-edition="ed1932" data-page="565"> </span>a jew, because mostly they appeared to imagine he
-        came from <Annotation annotationId="040046countyleitrim" visited={visitedNotes.has("040046countyleitrim")} annotationSelect={() => {openNote("040046countyleitrim"); addToVisited("040046countyleitrim")}} activeAnnotationId={currentNoteId}>Carrick-on-Shannon</Annotation> or somewhere about in the county Sligo.
+        came from <Annotation annotationId="040046countyleitrim">Carrick-on-Shannon</Annotation> or somewhere about in the county Sligo.
       </p>
       <p>
         —{" "}I propose, our hero eventually suggested, after mature reflection, while
@@ -2410,7 +2410,7 @@ const Eumaeus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <p>
         Thereupon he pawed the journal open and pored upon Lord only knows what,
-        <Annotation annotationId="030069founddrowned" visited={visitedNotes.has("030069founddrowned")} annotationSelect={() => {openNote("030069founddrowned"); addToVisited("030069founddrowned")}} activeAnnotationId={currentNoteId}>found drowned</Annotation> or <Annotation annotationId="050041cricket" visited={visitedNotes.has("050041cricket")} annotationSelect={() => {openNote("050041cricket"); addToVisited("050041cricket")}} activeAnnotationId={currentNoteId}>the exploits of King Willow, Iremonger having made a
+        <Annotation annotationId="030069founddrowned">found drowned</Annotation> or <Annotation annotationId="050041cricket">the exploits of King Willow, Iremonger having made a
         hundred and something second wicket not out for Notts</Annotation>, during which
         time (completely regardless of Ire) the keeper was intensely occupied
         loosening an apparently new or secondhand boot which manifestly pinched
@@ -2473,7 +2473,7 @@ const Eumaeus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         accordingly.
       </p>
       <p>
-        —{" "}Yes, Stephen said uncertainly, because he thought he <Annotation annotationId="010152linkedarm" visited={visitedNotes.has("010152linkedarm")} annotationSelect={() => {openNote("010152linkedarm"); addToVisited("010152linkedarm")}} activeAnnotationId={currentNoteId}>felt a strange
+        —{" "}Yes, Stephen said uncertainly, because he thought he <Annotation annotationId="010152linkedarm">felt a strange
         kind of flesh of a different man approach him</Annotation>, sinewless and wobbly and
         all that.
       </p>
@@ -2481,7 +2481,7 @@ const Eumaeus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         Anyhow, they passed the sentrybox with stones, brazier, etc. where
         the municipal supernumerary, ex-Gumley, was still to all intents and
         purposes wrapped in the arms of Murphy, as the adage has it, dreaming
-        of  <Annotation annotationId="020010lycidas" visited={visitedNotes.has("020010lycidas")} annotationSelect={() => {openNote("020010lycidas"); addToVisited("020010lycidas")}} activeAnnotationId={currentNoteId}>fresh fields and pastures new</Annotation>. And <i>apropos</i> of coffin of stones, the
+        of  <Annotation annotationId="020010lycidas">fresh fields and pastures new</Annotation>. And <i>apropos</i> of coffin of stones, the
         analogy was not at all bad, as it was in fact a stoning to death on the
         part of seventytwo out of eighty odd constituencies that ratted at the
         time of the <span data-edition="ed1961" data-page="660"> </span>split and chiefly the belauded peasant class, probably the
@@ -2490,8 +2490,8 @@ const Eumaeus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       <p>
         So they turned on to chatting about music, a form of art for which
         Bloom, as a pure amateur, possessed the greatest love, as they made
-        tracks arm in arm across <Annotation annotationId="160007shipofthestreet" visited={visitedNotes.has("160007shipofthestreet")} annotationSelect={() => {openNote("160007shipofthestreet"); addToVisited("160007shipofthestreet")}} activeAnnotationId={currentNoteId}>Beresford place</Annotation>. <Annotation annotationId="160009flyingdutchmen" visited={visitedNotes.has("160009flyingdutchmen")} annotationSelect={() => {openNote("160009flyingdutchmen"); addToVisited("160009flyingdutchmen")}} activeAnnotationId={currentNoteId}>Wagnerian music, though
-        confessedly</Annotation> <span data-edition="ed1986" data-page="539"> </span><Annotation annotationId="160009flyingdutchmen" visited={visitedNotes.has("160009flyingdutchmen")} annotationSelect={() => {openNote("160009flyingdutchmen"); addToVisited("160009flyingdutchmen")}} activeAnnotationId={currentNoteId}>grand in its way, was a bit too heavy for Bloom and hard to
+        tracks arm in arm across <Annotation annotationId="160007shipofthestreet">Beresford place</Annotation>. <Annotation annotationId="160009flyingdutchmen">Wagnerian music, though
+        confessedly</Annotation> <span data-edition="ed1986" data-page="539"> </span><Annotation annotationId="160009flyingdutchmen">grand in its way, was a bit too heavy for Bloom and hard to
         follow at the first go-off</Annotation> but the music of Mercadante's <i>Huguenots</i>,
         Meyerbeer's <i>Seven Last Words on the Cross</i>, and Mozart's <i>Twelfth Mass</i>,
         he simply revelled in, the <i>Gloria</i> in that being to his mind the acme
@@ -2506,7 +2506,7 @@ const Eumaeus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         sensation, he might safely say, greatly adding to her other laurels and
         putting the others totally in the 
         <span data-edition="ed1922" data-page="614"> </span>
-        shade, in the <Annotation annotationId="010008jesuit" visited={visitedNotes.has("010008jesuit")} annotationSelect={() => {openNote("010008jesuit"); addToVisited("010008jesuit")}} activeAnnotationId={currentNoteId}>jesuit</Annotation> fathers' <Annotation annotationId="100010xavier" visited={visitedNotes.has("100010xavier")} annotationSelect={() => {openNote("100010xavier"); addToVisited("100010xavier")}} activeAnnotationId={currentNoteId}>church
+        shade, in the <Annotation annotationId="010008jesuit">jesuit</Annotation> fathers' <Annotation annotationId="100010xavier">church
         in upper Gardiner street</Annotation>, the sacred edifice being thronged to the
         doors to hear her with virtuosos, or <i>virtuosi</i> rather. There was the
         unanimous opinion that there was none to come up to her and suffice it
@@ -2542,28 +2542,28 @@ const Eumaeus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         striking coincidence.
       </p>
       <p>
-        By the chains, the horse <Annotation annotationId="160007shipofthestreet" visited={visitedNotes.has("160007shipofthestreet")} annotationSelect={() => {openNote("160007shipofthestreet"); addToVisited("160007shipofthestreet")}} activeAnnotationId={currentNoteId}>slowly swerved</Annotation> to turn, which perceiving, Bloom,
-        who was <Annotation annotationId="160006icebergs" visited={visitedNotes.has("160006icebergs")} annotationSelect={() => {openNote("160006icebergs"); addToVisited("160006icebergs")}} activeAnnotationId={currentNoteId}> keeping a sharp lookout</Annotation> as usual, plucked the other's sleeve
+        By the chains, the horse <Annotation annotationId="160007shipofthestreet">slowly swerved</Annotation> to turn, which perceiving, Bloom,
+        who was <Annotation annotationId="160006icebergs"> keeping a sharp lookout</Annotation> as usual, plucked the other's sleeve
         gently, jocosely remarking:
       </p>
       <p>
-        —{" "}Our lives are in peril tonight. Beware of <Annotation annotationId="160007shipofthestreet" visited={visitedNotes.has("160007shipofthestreet")} annotationSelect={() => {openNote("160007shipofthestreet"); addToVisited("160007shipofthestreet")}} activeAnnotationId={currentNoteId}>the steamroller</Annotation>.
+        —{" "}Our lives are in peril tonight. Beware of <Annotation annotationId="160007shipofthestreet">the steamroller</Annotation>.
       </p>
       <span data-edition="ed1986" data-page="540"> </span>
       <p>
         They thereupon stopped. Bloom looked at the head of a horse not worth
         anything like sixtyfive guineas, suddenly in evidence in the dark quite
-        near, so that <Annotation annotationId="160007shipofthestreet" visited={visitedNotes.has("160007shipofthestreet")} annotationSelect={() => {openNote("160007shipofthestreet"); addToVisited("160007shipofthestreet")}} activeAnnotationId={currentNoteId}>it seemed new</Annotation>, a different grouping of bones and even flesh,
+        near, so that <Annotation annotationId="160007shipofthestreet">it seemed new</Annotation>, a different grouping of bones and even flesh,
         because palpably it was a fourwalker, a hipshaker, a blackbuttocker, a
         taildangler, a headhanger, putting his hind foot foremost the while the
         lord of his creation 
         <span data-edition="ed1922" data-page="615"> </span>
         sat on the perch, busy with his thoughts. But such
         a good poor brute, he was sorry he hadn't a lump of sugar but, as he
-        wisely reflected, you could scarcely be prepared for <Annotation annotationId="160006icebergs" visited={visitedNotes.has("160006icebergs")} annotationSelect={() => {openNote("160006icebergs"); addToVisited("160006icebergs")}} activeAnnotationId={currentNoteId}>every emergency
+        wisely reflected, you could scarcely be prepared for <Annotation annotationId="160006icebergs">every emergency
         that might crop up</Annotation>. He was just a big nervous foolish noodly kind of a
         horse, without a second care in the world. But even a dog, he reflected,
-        take that mongrel in Barney Kiernan's, of the same size, would be <Annotation annotationId="160007shipofthestreet" visited={visitedNotes.has("160007shipofthestreet")} annotationSelect={() => {openNote("160007shipofthestreet"); addToVisited("160007shipofthestreet")}} activeAnnotationId={currentNoteId}>a holy
+        take that mongrel in Barney Kiernan's, of the same size, would be <Annotation annotationId="160007shipofthestreet">a holy
         horror</Annotation> to face. But it was no animal's fault in particular if he was
         built that way like the camel, ship of the desert, distilling grapes
         into potheen in his hump. Nine tenths of them all could be caged or
@@ -2573,7 +2573,7 @@ const Eumaeus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         <span data-edition="ed1939" data-page="465"> </span>
         chalk a circle for a rooster; tiger, my eagle eye. These timely
         reflections anent the brutes of the field occupied his mind, somewhat
-        distracted from Stephen's words, while <Annotation annotationId="160007shipofthestreet" visited={visitedNotes.has("160007shipofthestreet")} annotationSelect={() => {openNote("160007shipofthestreet"); addToVisited("160007shipofthestreet")}} activeAnnotationId={currentNoteId}>the ship of the street was
+        distracted from Stephen's words, while <Annotation annotationId="160007shipofthestreet">the ship of the street was
         manoeuvring</Annotation> and Stephen went on about the highly interesting old...
       </p>
       <p>

--- a/src/content/chapters/Hades.js
+++ b/src/content/chapters/Hades.js
@@ -1,13 +1,13 @@
 import Annotation from "../../components/Annotation";
 
 
-const Hades = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
+const Hades = () => {
   return (
     <div>
       <p></p>
-      <center><Annotation annotationId="060000hades" visited={visitedNotes.has("060000hades")} annotationSelect={() => {openNote("060000hades"); addToVisited("060000hades")}} activeAnnotationId={currentNoteId}><font size="+2">[6]</font></Annotation></center>
+      <center><Annotation annotationId="060000hades"><font size="+2">[6]</font></Annotation></center>
       <br/>
-      <Annotation annotationId="060034martincunningham" visited={visitedNotes.has("060034martincunningham")} annotationSelect={() => {openNote("060034martincunningham"); addToVisited("060034martincunningham")}} activeAnnotationId={currentNoteId}>Martin Cunningham, first, poked his silkhatted head</Annotation> into the creaking
+      <Annotation annotationId="060034martincunningham">Martin Cunningham, first, poked his silkhatted head</Annotation> into the creaking
       carriage and, entering deftly, seated himself. Mr Power stepped in after
       him, curving his height with care.
       <p></p>
@@ -24,17 +24,17 @@ const Hades = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         Yes, yes.
       </p>
       <p>
-        —{" "}<Annotation annotationId="060026allofus" visited={visitedNotes.has("060026allofus")} annotationSelect={() => {openNote("060026allofus"); addToVisited("060026allofus")}} activeAnnotationId={currentNoteId}>Are we all here now?</Annotation> Martin Cunningham asked. Come along, Bloom.
+        —{" "}<Annotation annotationId="060026allofus">Are we all here now?</Annotation> Martin Cunningham asked. Come along, Bloom.
       </p>
       <p>
         Mr Bloom entered and sat in the vacant place. He pulled the door to
-        after him and <Annotation annotationId="040011rightright" visited={visitedNotes.has("040011rightright")} annotationSelect={() => {openNote("040011rightright"); addToVisited("040011rightright")}} activeAnnotationId={currentNoteId}>slammed it tight till it shut tight.</Annotation> He passed an arm
+        after him and <Annotation annotationId="040011rightright">slammed it tight till it shut tight.</Annotation> He passed an arm
         through the armstrap and looked seriously from the open carriagewindow
-        at <Annotation annotationId="060019theavenue" visited={visitedNotes.has("060019theavenue")} annotationSelect={() => {openNote("060019theavenue"); addToVisited("060019theavenue")}} activeAnnotationId={currentNoteId}>the lowered blinds of the avenue</Annotation>. One dragged aside: an old woman
+        at <Annotation annotationId="060019theavenue">the lowered blinds of the avenue</Annotation>. One dragged aside: an old woman
         peeping. Nose whiteflattened against the pane. Thanking her stars she
-        was <Annotation annotationId="060043passover" visited={visitedNotes.has("060043passover")} annotationSelect={() => {openNote("060043passover"); addToVisited("060043passover")}} activeAnnotationId={currentNoteId}>passed over</Annotation>. Extraordinary the interest they take in a corpse. Glad
+        was <Annotation annotationId="060043passover">passed over</Annotation>. Extraordinary the interest they take in a corpse. Glad
         to see us go we give them such trouble coming. Job seems to suit them.
-        <Annotation annotationId="060029huggermugger" visited={visitedNotes.has("060029huggermugger")} annotationSelect={() => {openNote("060029huggermugger"); addToVisited("060029huggermugger")}} activeAnnotationId={currentNoteId}>Huggermugger in corners.</Annotation>  <Annotation annotationId="060045slipperslapper" visited={visitedNotes.has("060045slipperslapper")} annotationSelect={() => {openNote("060045slipperslapper"); addToVisited("060045slipperslapper")}} activeAnnotationId={currentNoteId}>Slop about in slipperslappers for fear he'd
+        <Annotation annotationId="060029huggermugger">Huggermugger in corners.</Annotation>  <Annotation annotationId="060045slipperslapper">Slop about in slipperslappers for fear he'd
         wake.</Annotation> Then getting it ready. Laying it out. Molly and Mrs Fleming making
         the bed. Pull it more to your side. Our windingsheet. Never know who
         will touch you dead. Wash and shampoo. I believe<span data-edition="ed1932" data-page="77"></span> they clip the nails and
@@ -52,12 +52,12 @@ const Hades = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         swaying.  
         <span data-edition="ed1922" data-page="84"></span>
         Other hoofs and creaking wheels started behind. The blinds of
-        the avenue passed and <Annotation annotationId="060019theavenue" visited={visitedNotes.has("060019theavenue")} annotationSelect={() => {openNote("060019theavenue"); addToVisited("060019theavenue")}} activeAnnotationId={currentNoteId}>number nine</Annotation> with its craped knocker, door ajar. At
+        the avenue passed and <Annotation annotationId="060019theavenue">number nine</Annotation> with its craped knocker, door ajar. At
         walking pace.
       </p>
       <p>
         They waited still, their knees jogging, till they had turned and were
-        passing along the tramtracks. <Annotation annotationId="060025whatway" visited={visitedNotes.has("060025whatway")} annotationSelect={() => {openNote("060025whatway"); addToVisited("060025whatway")}} activeAnnotationId={currentNoteId}>Tritonville road.</Annotation> Quicker. The wheels
+        passing along the tramtracks. <Annotation annotationId="060025whatway">Tritonville road.</Annotation> Quicker. The wheels
         rattled rolling over the cobbled causeway and the crazy glasses shook
         rattling in the doorframes.
       </p>
@@ -65,7 +65,7 @@ const Hades = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         —{" "}What way is he taking us? Mr Power asked through both windows.
       </p>
       <p>
-        —{" "}<Annotation annotationId="060025whatway" visited={visitedNotes.has("060025whatway")} annotationSelect={() => {openNote("060025whatway"); addToVisited("060025whatway")}} activeAnnotationId={currentNoteId}>Irishtown, Martin Cunningham said. Ringsend. Brunswick street.</Annotation>
+        —{" "}<Annotation annotationId="060025whatway">Irishtown, Martin Cunningham said. Ringsend. Brunswick street.</Annotation>
       </p>
       <p>
         Mr Dedalus nodded, looking out.
@@ -73,14 +73,14 @@ const Hades = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       <span data-edition="ed1961" data-page="87"></span>
       <span data-edition="ed1986" data-page="72"></span>
       <p>
-        —{" "}<Annotation annotationId="060039fineoldcustom" visited={visitedNotes.has("060039fineoldcustom")} annotationSelect={() => {openNote("060039fineoldcustom"); addToVisited("060039fineoldcustom")}} activeAnnotationId={currentNoteId}>That's a fine old custom, he said. I am glad to see it has not died
+        —{" "}<Annotation annotationId="060039fineoldcustom">That's a fine old custom, he said. I am glad to see it has not died
         out.</Annotation>
       </p>
       <p>
         All watched awhile through their windows caps and hats lifted by
         passers. Respect. The carriage swerved from the tramtrack to the
-        smoother road past <Annotation annotationId="030015irishtown" visited={visitedNotes.has("030015irishtown")} annotationSelect={() => {openNote("030015irishtown"); addToVisited("030015irishtown")}} activeAnnotationId={currentNoteId}>Watery lane</Annotation>. Mr Bloom at gaze saw a lithe young man,
-        clad in mourning, a <Annotation annotationId="010097latinquarterhat" visited={visitedNotes.has("010097latinquarterhat")} annotationSelect={() => {openNote("010097latinquarterhat"); addToVisited("010097latinquarterhat")}} activeAnnotationId={currentNoteId}>wide hat</Annotation>.
+        smoother road past <Annotation annotationId="030015irishtown">Watery lane</Annotation>. Mr Bloom at gaze saw a lithe young man,
+        clad in mourning, a <Annotation annotationId="010097latinquarterhat">wide hat</Annotation>.
       </p>
       <span data-edition="ed1939" data-page="67"> </span>
       <p>
@@ -102,7 +102,7 @@ const Hades = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         fell back, saying:
       </p>
       <p>
-        —{" "}Was that Mulligan cad with him? His <Annotation annotationId="060000hades" visited={visitedNotes.has("060000hades")} annotationSelect={() => {openNote("060000hades"); addToVisited("060000hades")}} activeAnnotationId={currentNoteId}><i>fidus Achates</i></Annotation>!
+        —{" "}Was that Mulligan cad with him? His <Annotation annotationId="060000hades"><i>fidus Achates</i></Annotation>!
       </p>
       <p>
         —{" "}No, Mr Bloom said. He was alone.
@@ -113,15 +113,15 @@ const Hades = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         of dung, the wise child that knows her own father.
       </p>
       <p>
-        Mr Bloom smiled joylessly on <Annotation annotationId="060025whatway" visited={visitedNotes.has("060025whatway")} annotationSelect={() => {openNote("060025whatway"); addToVisited("060025whatway")}} activeAnnotationId={currentNoteId}>Ringsend road. Wallace Bros the
+        Mr Bloom smiled joylessly on <Annotation annotationId="060025whatway">Ringsend road. Wallace Bros the
         bottleworks. Dodder bridge.</Annotation>
       </p>
       <p>
-        Richie Goulding and the legal bag. <Annotation annotationId="030113richiegoulding" visited={visitedNotes.has("030113richiegoulding")} annotationSelect={() => {openNote("030113richiegoulding"); addToVisited("030113richiegoulding")}} activeAnnotationId={currentNoteId}>Goulding, Collis and Ward he calls
+        Richie Goulding and the legal bag. <Annotation annotationId="030113richiegoulding">Goulding, Collis and Ward he calls
         the firm.</Annotation> His jokes are getting a bit damp. Great card he was.<span data-edition="ed1932" data-page="78"></span> Waltzing
         in Stamer street with Ignatius Gallaher on a Sunday morning, the
         landlady's two hats pinned on his head. Out on the rampage all night.
-        <Annotation annotationId="030076backachepills" visited={visitedNotes.has("030076backachepills")} annotationSelect={() => {openNote("030076backachepills"); addToVisited("030076backachepills")}} activeAnnotationId={currentNoteId}>Beginning to tell on him now: that backache of his, I fear. Wife ironing
+        <Annotation annotationId="030076backachepills">Beginning to tell on him now: that backache of his, I fear. Wife ironing
         his back. Thinks he'll cure it with pills.</Annotation> All breadcrumbs they are.
         About six hundred per cent profit.
       </p>
@@ -145,12 +145,12 @@ const Hades = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       <p>
         He ceased. Mr Bloom glanced from his angry moustache to<span data-edition="ed1961" data-page="88"></span> Mr Power's mild
         face and Martin Cunningham's eyes and beard, gravely shaking. Noisy
-        selfwilled man. <Annotation annotationId="060000hades" visited={visitedNotes.has("060000hades")} annotationSelect={() => {openNote("060000hades"); addToVisited("060000hades")}} activeAnnotationId={currentNoteId}>Full of his son.</Annotation> <Annotation annotationId="080008parallax" visited={visitedNotes.has("080008parallax")} annotationSelect={() => {openNote("080008parallax"); addToVisited("080008parallax")}} activeAnnotationId={currentNoteId}>He is right. Something to hand on.</Annotation> If
+        selfwilled man. <Annotation annotationId="060000hades">Full of his son.</Annotation> <Annotation annotationId="080008parallax">He is right. Something to hand on.</Annotation> If
         little Rudy had lived. See him grow up. Hear his voice in the house.
         Walking beside Molly in an Eton suit. My son. Me in his eyes. Strange
         feeling it would be. From me. Just a chance. Must have been that morning
-        in <Annotation annotationId="040049pleasantoldtimes" visited={visitedNotes.has("040049pleasantoldtimes")} annotationSelect={() => {openNote("040049pleasantoldtimes"); addToVisited("040049pleasantoldtimes")}} activeAnnotationId={currentNoteId}>Raymond terrace</Annotation> she was at the window watching the two dogs at it by
-        the wall of <Annotation annotationId="010013barracks" visited={visitedNotes.has("010013barracks")} annotationSelect={() => {openNote("010013barracks"); addToVisited("010013barracks")}} activeAnnotationId={currentNoteId}>the cease to do evil</Annotation>. And the sergeant grinning up. She<span data-edition="ed1986" data-page="73"></span> had
+        in <Annotation annotationId="040049pleasantoldtimes">Raymond terrace</Annotation> she was at the window watching the two dogs at it by
+        the wall of <Annotation annotationId="010013barracks">the cease to do evil</Annotation>. And the sergeant grinning up. She<span data-edition="ed1986" data-page="73"></span> had
         that cream gown on with the rip she never stitched. Give us a touch,
         Poldy. God, I'm dying for it. How life begins.
       </p>
@@ -218,7 +218,7 @@ const Hades = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <span data-edition="ed1961" data-page="89"></span>
       <p>
-        —{" "}Did <Annotation annotationId="050037tomkernan" visited={visitedNotes.has("050037tomkernan")} annotationSelect={() => {openNote("050037tomkernan"); addToVisited("050037tomkernan")}} activeAnnotationId={currentNoteId}>Tom Kernan</Annotation> turn up? Martin Cunningham asked, twirling the peak of
+        —{" "}Did <Annotation annotationId="050037tomkernan">Tom Kernan</Annotation> turn up? Martin Cunningham asked, twirling the peak of
         his beard gently.
       </p>
       <p>
@@ -228,7 +228,7 @@ const Hades = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         —{" "}And Corny Kelleher himself? Mr Power asked.
       </p>
       <p>
-        —{" "}At <Annotation annotationId="060035prospect" visited={visitedNotes.has("060035prospect")} annotationSelect={() => {openNote("060035prospect"); addToVisited("060035prospect")}} activeAnnotationId={currentNoteId}>the cemetery</Annotation>, Martin Cunningham said.
+        —{" "}At <Annotation annotationId="060035prospect">the cemetery</Annotation>, Martin Cunningham said.
       </p>
       <p>
         —{" "}I met M'Coy this morning, Mr Bloom said. He said he'd try to come.
@@ -249,15 +249,15 @@ const Hades = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         Mr Bloom put his head out of the window.
       </p>
       <p>
-        —{" "}<Annotation annotationId="060016canals" visited={visitedNotes.has("060016canals")} annotationSelect={() => {openNote("060016canals"); addToVisited("060016canals")}} activeAnnotationId={currentNoteId}>The grand canal</Annotation>, he said.
+        —{" "}<Annotation annotationId="060016canals">The grand canal</Annotation>, he said.
       </p>
       <p>
         Gasworks. Whooping cough they say it cures. Good job Milly never got
         it. Poor children! Doubles them up black and blue in convulsions. Shame
         really. Got off lightly with illnesses compared. Only measles. Flaxseed
         tea. Scarlatina, influenza epidemics. Canvassing for death. Don't<span data-edition="ed1986" data-page="74"></span> miss
-        this chance. Dogs' home over there. <Annotation annotationId="060004athos" visited={visitedNotes.has("060004athos")} annotationSelect={() => {openNote("060004athos"); addToVisited("060004athos")}} activeAnnotationId={currentNoteId}>Poor old Athos! Be good to Athos,
-        Leopold, is my last wish.</Annotation> <Annotation annotationId="040077ourfather" visited={visitedNotes.has("040077ourfather")} annotationSelect={() => {openNote("040077ourfather"); addToVisited("040077ourfather")}} activeAnnotationId={currentNoteId}>Thy will be done.</Annotation> We obey them in the grave.
+        this chance. Dogs' home over there. <Annotation annotationId="060004athos">Poor old Athos! Be good to Athos,
+        Leopold, is my last wish.</Annotation> <Annotation annotationId="040077ourfather">Thy will be done.</Annotation> We obey them in the grave.
         A dying scrawl. He took it to heart, pined away. Quiet brute. Old men's
         dogs usually are.
       </p>
@@ -299,7 +299,7 @@ const Hades = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       <span data-edition="ed1939" data-page="69"> </span>
       <p>
         —{" "}O, draw him out, Martin, Mr Power said eagerly. Wait till<span data-edition="ed1961" data-page="90"></span> you hear
-        him, Simon, on <Annotation annotationId="110007croppyboy" visited={visitedNotes.has("110007croppyboy")} annotationSelect={() => {openNote("110007croppyboy"); addToVisited("110007croppyboy")}} activeAnnotationId={currentNoteId}>Ben Dollard's singing of <i>The Croppy Boy</i></Annotation>.
+        him, Simon, on <Annotation annotationId="110007croppyboy">Ben Dollard's singing of <i>The Croppy Boy</i></Annotation>.
       </p>
       <p>
         —{" "}Immense, Martin Cunningham said pompously. <i>His singing of that simple
@@ -308,10 +308,10 @@ const Hades = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <p>
         —{" "}Trenchant, Mr Power said laughing. He's dead nuts on that. And the
-        <Annotation annotationId="060030retrospective" visited={visitedNotes.has("060030retrospective")} annotationSelect={() => {openNote("060030retrospective"); addToVisited("060030retrospective")}} activeAnnotationId={currentNoteId}>retrospective arrangement</Annotation>.
+        <Annotation annotationId="060030retrospective">retrospective arrangement</Annotation>.
       </p>
       <p>
-        —{" "}Did you read <Annotation annotationId="060037dandawson" visited={visitedNotes.has("060037dandawson")} annotationSelect={() => {openNote("060037dandawson"); addToVisited("060037dandawson")}} activeAnnotationId={currentNoteId}>Dan Dawson's speech</Annotation>? Martin Cunningham asked.
+        —{" "}Did you read <Annotation annotationId="060037dandawson">Dan Dawson's speech</Annotation>? Martin Cunningham asked.
       </p>
       <p>
         —{" "}I did not then, Mr Dedalus said. Where is it?
@@ -348,7 +348,7 @@ const Hades = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         fled. Before my patience are exhausted.
       </p>
       <p>
-        <Annotation annotationId="040002nationalschool" visited={visitedNotes.has("040002nationalschool")} annotationSelect={() => {openNote("040002nationalschool"); addToVisited("040002nationalschool")}} activeAnnotationId={currentNoteId}>National school.</Annotation> <Annotation annotationId="050050meades" visited={visitedNotes.has("050050meades")} annotationSelect={() => {openNote("050050meades"); addToVisited("050050meades")}} activeAnnotationId={currentNoteId}>Meade's yard.</Annotation> <Annotation annotationId="050012cabstands" visited={visitedNotes.has("050012cabstands")} annotationSelect={() => {openNote("050012cabstands"); addToVisited("050012cabstands")}} activeAnnotationId={currentNoteId}>The hazard.</Annotation> Only two there now. Nodding.
+        <Annotation annotationId="040002nationalschool">National school.</Annotation> <Annotation annotationId="050050meades">Meade's yard.</Annotation> <Annotation annotationId="050012cabstands">The hazard.</Annotation> Only two there now. Nodding.
         Full as a tick. Too much bone in their skulls. The other trotting round
         with a fare. An hour ago I was passing there. The jarvies raised their
         hats.
@@ -364,24 +364,24 @@ const Hades = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         making the new invention?
       </p>
       <p>
-        <Annotation annotationId="060021concertrooms" visited={visitedNotes.has("060021concertrooms")} annotationSelect={() => {openNote("060021concertrooms"); addToVisited("060021concertrooms")}} activeAnnotationId={currentNoteId}>Antient concert rooms.</Annotation> Nothing on there. A man in a buff<span data-edition="ed1961" data-page="91"></span> suit with a
+        <Annotation annotationId="060021concertrooms">Antient concert rooms.</Annotation> Nothing on there. A man in a buff<span data-edition="ed1961" data-page="91"></span> suit with a
         crape armlet. Not much grief there. Quarter mourning. People in law
         perhaps.
       </p>
       <p>
-        They went past <Annotation annotationId="060023saintmarks" visited={visitedNotes.has("060023saintmarks")} annotationSelect={() => {openNote("060023saintmarks"); addToVisited("060023saintmarks")}} activeAnnotationId={currentNoteId}>the bleak pulpit of saint Mark's</Annotation>, under <Annotation annotationId="050006looplinebridge" visited={visitedNotes.has("050006looplinebridge")} annotationSelect={() => {openNote("050006looplinebridge"); addToVisited("050006looplinebridge")}} activeAnnotationId={currentNoteId}>the railway
-        bridge</Annotation>, past the <Annotation annotationId="060032queenstheatre" visited={visitedNotes.has("060032queenstheatre")} annotationSelect={() => {openNote("060032queenstheatre"); addToVisited("060032queenstheatre")}} activeAnnotationId={currentNoteId}>Queen's theatre</Annotation>: in silence. Hoardings: <Annotation annotationId="060003eugenestratton" visited={visitedNotes.has("060003eugenestratton")} annotationSelect={() => {openNote("060003eugenestratton"); addToVisited("060003eugenestratton")}} activeAnnotationId={currentNoteId}>Eugene
-        Stratton</Annotation>, Mrs Bandmann Palmer. <Annotation annotationId="050032leah" visited={visitedNotes.has("050032leah")} annotationSelect={() => {openNote("050032leah"); addToVisited("050032leah")}} activeAnnotationId={currentNoteId}>Could I go to see <em>Leah</em> tonight, I wonder.</Annotation>
+        They went past <Annotation annotationId="060023saintmarks">the bleak pulpit of saint Mark's</Annotation>, under <Annotation annotationId="050006looplinebridge">the railway
+        bridge</Annotation>, past the <Annotation annotationId="060032queenstheatre">Queen's theatre</Annotation>: in silence. Hoardings: <Annotation annotationId="060003eugenestratton">Eugene
+        Stratton</Annotation>, Mrs Bandmann Palmer. <Annotation annotationId="050032leah">Could I go to see <em>Leah</em> tonight, I wonder.</Annotation>
         I said I. Or the <i>Lily of Killarney</i>? Elster Grimes Opera Company. Big
         powerful change. Wet bright bills for next week. <i>Fun on the Bristol</i>.
-        <Annotation annotationId="060040gaietytheatre" visited={visitedNotes.has("060040gaietytheatre")} annotationSelect={() => {openNote("060040gaietytheatre"); addToVisited("060040gaietytheatre")}} activeAnnotationId={currentNoteId}>Martin Cunningham could work a pass for the Gaiety.</Annotation> Have to stand a
+        <Annotation annotationId="060040gaietytheatre">Martin Cunningham could work a pass for the Gaiety.</Annotation> Have to stand a
         drink or two. As broad as it's long.
       </p>
       <p>
         He's coming in the afternoon. Her songs.
       </p>
       <p>
-        <Annotation annotationId="040062bolandsbread" visited={visitedNotes.has("040062bolandsbread")} annotationSelect={() => {openNote("040062bolandsbread"); addToVisited("040062bolandsbread")}} activeAnnotationId={currentNoteId}>Plasto's.</Annotation> Sir Philip <Annotation annotationId="060022sirphilip" visited={visitedNotes.has("060022sirphilip")} annotationSelect={() => {openNote("060022sirphilip"); addToVisited("060022sirphilip")}} activeAnnotationId={currentNoteId}>Crampton's memorial fountain bust.</Annotation> Who was he?
+        <Annotation annotationId="040062bolandsbread">Plasto's.</Annotation> Sir Philip <Annotation annotationId="060022sirphilip">Crampton's memorial fountain bust.</Annotation> Who was he?
       </p>
       <p>
         —{" "}How do you do? Martin Cunningham said, raising his palm to his brow in
@@ -401,7 +401,7 @@ const Hades = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         Just that moment I was thinking.
       </p>
       <p>
-        Mr Dedalus bent across to salute. From the door of <Annotation annotationId="060020redbank" visited={visitedNotes.has("060020redbank")} annotationSelect={() => {openNote("060020redbank"); addToVisited("060020redbank")}} activeAnnotationId={currentNoteId}>the Red Bank</Annotation> the
+        Mr Dedalus bent across to salute. From the door of <Annotation annotationId="060020redbank">the Red Bank</Annotation> the
         white disc of a straw hat flashed reply: passed.
       </p>
       <p>
@@ -449,7 +449,7 @@ const Hades = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <p>
         —{" "}Louis Werner is touring her, Mr Bloom said. O yes, we'll have all
-        topnobbers. <Annotation annotationId="040094jcdoyle" visited={visitedNotes.has("040094jcdoyle")} annotationSelect={() => {openNote("040094jcdoyle"); addToVisited("040094jcdoyle")}} activeAnnotationId={currentNoteId}>J. C. Doyle and John MacCormack I hope</Annotation> and. The best, in
+        topnobbers. <Annotation annotationId="040094jcdoyle">J. C. Doyle and John MacCormack I hope</Annotation> and. The best, in
         fact.
       </p>
       <p>
@@ -457,12 +457,12 @@ const Hades = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <p>
         Mr Bloom unclasped his hands in a gesture of soft politeness and clasped
-        them. <Annotation annotationId="040031smithobrien" visited={visitedNotes.has("040031smithobrien")} annotationSelect={() => {openNote("040031smithobrien"); addToVisited("040031smithobrien")}} activeAnnotationId={currentNoteId}>Smith O'Brien. Someone has laid a bunch of flowers there. Woman.
+        them. <Annotation annotationId="040031smithobrien">Smith O'Brien. Someone has laid a bunch of flowers there. Woman.
         Must be his deathday. For many happy returns. The carriage wheeling by
         Farrell's statue</Annotation> united noiselessly their unresisting knees.
       </p>
       <p>
-        <Annotation annotationId="040082highgradeha" visited={visitedNotes.has("040082highgradeha")} annotationSelect={() => {openNote("040082highgradeha"); addToVisited("040082highgradeha")}} activeAnnotationId={currentNoteId}> Oot: a dullgarbed old man from the curbstone tendered his wares, his
+        <Annotation annotationId="040082highgradeha"> Oot: a dullgarbed old man from the curbstone tendered his wares, his
         mouth opening: oot.</Annotation>
       </p>
       <p>
@@ -477,8 +477,8 @@ const Hades = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <p>
         And <i>Madame</i>. Twenty past eleven. Up. Mrs Fleming is in to clean. Doing
-        her hair, humming: <Annotation annotationId="040025lacidarem" visited={visitedNotes.has("040025lacidarem")} annotationSelect={() => {openNote("040025lacidarem"); addToVisited("040025lacidarem")}} activeAnnotationId={currentNoteId}><i>voglio e non vorrei</i>. No: <i>vorrei e non</i>.</Annotation> Looking at
-        the tips of her hairs to see if they are split. <Annotation annotationId="040025lacidarem" visited={visitedNotes.has("040025lacidarem")} annotationSelect={() => {openNote("040025lacidarem"); addToVisited("040025lacidarem")}} activeAnnotationId={currentNoteId}><i>Mi trema un poco
+        her hair, humming: <Annotation annotationId="040025lacidarem"><i>voglio e non vorrei</i>. No: <i>vorrei e non</i>.</Annotation> Looking at
+        the tips of her hairs to see if they are split. <Annotation annotationId="040025lacidarem"><i>Mi trema un poco
         il</i>.</Annotation> Beautiful on that <i>tre</i> her voice is: weeping tone. A thrush. A
         throstle. There is a word throstle that expresses that.
       </p>
@@ -495,7 +495,7 @@ const Hades = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         Moira, was it?
       </p>
       <p>
-        They passed under <Annotation annotationId="060012liberatorsform" visited={visitedNotes.has("060012liberatorsform")} annotationSelect={() => {openNote("060012liberatorsform"); addToVisited("060012liberatorsform")}} activeAnnotationId={currentNoteId}>the hugecloaked Liberator's form</Annotation>.
+        They passed under <Annotation annotationId="060012liberatorsform">the hugecloaked Liberator's form</Annotation>.
       </p>
       <p>
         Martin Cunningham nudged Mr Power.
@@ -506,7 +506,7 @@ const Hades = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <p>
         A tall blackbearded figure, bent on a stick, stumping round<span data-edition="ed1961" data-page="93"></span> the corner
-        of <Annotation annotationId="060009elveryselephant" visited={visitedNotes.has("060009elveryselephant")} annotationSelect={() => {openNote("060009elveryselephant"); addToVisited("060009elveryselephant")}} activeAnnotationId={currentNoteId}>Elvery's Elephant house</Annotation>, showed them a curved hand open on his spine.
+        of <Annotation annotationId="060009elveryselephant">Elvery's Elephant house</Annotation>, showed them a curved hand open on his spine.
       </p>
       <span data-edition="ed1922" data-page="90"></span>
       <p>
@@ -521,10 +521,10 @@ const Hades = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       <span data-edition="ed1986" data-page="77"></span>
       <p>
         Mr Power, collapsing in laughter, shaded his face from the window as the
-        carriage passed <Annotation annotationId="060008sirjohngray" visited={visitedNotes.has("060008sirjohngray")} annotationSelect={() => {openNote("060008sirjohngray"); addToVisited("060008sirjohngray")}} activeAnnotationId={currentNoteId}>Gray's statue</Annotation>.
+        carriage passed <Annotation annotationId="060008sirjohngray">Gray's statue</Annotation>.
       </p>
       <p>
-        —{" "}<Annotation annotationId="060026allofus" visited={visitedNotes.has("060026allofus")} annotationSelect={() => {openNote("060026allofus"); addToVisited("060026allofus")}} activeAnnotationId={currentNoteId}>We have all been there</Annotation>, Martin Cunningham said broadly.
+        —{" "}<Annotation annotationId="060026allofus">We have all been there</Annotation>, Martin Cunningham said broadly.
       </p>
       <p>
         His eyes met Mr Bloom's eyes. He caressed his beard, adding:
@@ -611,11 +611,11 @@ const Hades = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         Mr Power's choked laugh burst quietly in the carriage.
       </p>
       <p>
-        <Annotation annotationId="070006nelsonspillar" visited={visitedNotes.has("070006nelsonspillar")} annotationSelect={() => {openNote("070006nelsonspillar"); addToVisited("070006nelsonspillar")}} activeAnnotationId={currentNoteId}>Nelson's pillar.</Annotation>
+        <Annotation annotationId="070006nelsonspillar">Nelson's pillar.</Annotation>
       </p>
       <span data-edition="ed1939" data-page="72"> </span>
       <p>
-        <Annotation annotationId="070006nelsonspillar" visited={visitedNotes.has("070006nelsonspillar")} annotationSelect={() => {openNote("070006nelsonspillar"); addToVisited("070006nelsonspillar")}} activeAnnotationId={currentNoteId}>—{" "}Eight plums a penny! Eight for a penny!</Annotation>
+        <Annotation annotationId="070006nelsonspillar">—{" "}Eight plums a penny! Eight for a penny!</Annotation>
       </p>
       <p>
         —{" "}We had better look a little serious, Martin Cunningham said.
@@ -644,7 +644,7 @@ const Hades = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         He tapped his chest sadly.
       </p>
       <p>
-        <Annotation annotationId="060000hades" visited={visitedNotes.has("060000hades")} annotationSelect={() => {openNote("060000hades"); addToVisited("060000hades")}} activeAnnotationId={currentNoteId}>Blazing face: redhot. Too much John Barleycorn.</Annotation> Cure for a red nose.
+        <Annotation annotationId="060000hades">Blazing face: redhot. Too much John Barleycorn.</Annotation> Cure for a red nose.
         Drink like the devil till it turns adelite. A lot of money he spent
         colouring it.
       </p>
@@ -667,14 +667,14 @@ const Hades = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         No-one spoke.
       </p>
       <p>
-        <Annotation annotationId="060012liberatorsform" visited={visitedNotes.has("060012liberatorsform")} annotationSelect={() => {openNote("060012liberatorsform"); addToVisited("060012liberatorsform")}} activeAnnotationId={currentNoteId}>Dead side of the street this.</Annotation> Dull business by day, <Annotation annotationId="060013catholicclub" visited={visitedNotes.has("060013catholicclub")} annotationSelect={() => {openNote("060013catholicclub"); addToVisited("060013catholicclub")}} activeAnnotationId={currentNoteId}>land agents,
+        <Annotation annotationId="060012liberatorsform">Dead side of the street this.</Annotation> Dull business by day, <Annotation annotationId="060013catholicclub">land agents,
         temperance hotel, Falconer's railway guide, civil service college,
         Gill's, catholic club, the industrious blind.</Annotation> Why? Some reason. Sun or
         wind. At night too. Chummies and slaveys. Under the patronage of the
-        late <Annotation annotationId="060010fathermathew" visited={visitedNotes.has("060010fathermathew")} annotationSelect={() => {openNote("060010fathermathew"); addToVisited("060010fathermathew")}} activeAnnotationId={currentNoteId}>Father Mathew</Annotation>. Foundation <Annotation annotationId="060018foundationstone" visited={visitedNotes.has("060018foundationstone")} annotationSelect={() => {openNote("060018foundationstone"); addToVisited("060018foundationstone")}} activeAnnotationId={currentNoteId}>stone for Parnell. Breakdown. Heart.</Annotation>
+        late <Annotation annotationId="060010fathermathew">Father Mathew</Annotation>. Foundation <Annotation annotationId="060018foundationstone">stone for Parnell. Breakdown. Heart.</Annotation>
       </p>
       <p>
-        White horses with white frontlet plumes came round the <Annotation annotationId="060011therotunda" visited={visitedNotes.has("060011therotunda")} annotationSelect={() => {openNote("060011therotunda"); addToVisited("060011therotunda")}} activeAnnotationId={currentNoteId}>Rotunda</Annotation> corner,
+        White horses with white frontlet plumes came round the <Annotation annotationId="060011therotunda">Rotunda</Annotation> corner,
         galloping. A tiny coffin flashed by. In a hurry<span data-edition="ed1961" data-page="95"></span> to bury. A mourning
         coach. Unmarried. Black for the married. Piebald for bachelors. Dun for
         a nun.
@@ -683,10 +683,10 @@ const Hades = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         —{" "}Sad, Martin Cunningham said. A child.
       </p>
       <p>
-        A dwarf's face, <Annotation annotationId="040096sheknew" visited={visitedNotes.has("040096sheknew")} annotationSelect={() => {openNote("040096sheknew"); addToVisited("040096sheknew")}} activeAnnotationId={currentNoteId}>mauve and wrinkled like little Rudy's was</Annotation>. Dwarf's body,
+        A dwarf's face, <Annotation annotationId="040096sheknew">mauve and wrinkled like little Rudy's was</Annotation>. Dwarf's body,
         weak as putty, in a whitelined deal box. Burial friendly society
         pays. Penny a week for a sod of turf. Our. Little. Beggar. Baby. Meant<span data-edition="ed1932" data-page="85"></span>
-        nothing. Mistake of nature. <Annotation annotationId="040087poorlittlerudy" visited={visitedNotes.has("040087poorlittlerudy")} annotationSelect={() => {openNote("040087poorlittlerudy"); addToVisited("040087poorlittlerudy")}} activeAnnotationId={currentNoteId}>If it's healthy it's from the mother. If not
+        nothing. Mistake of nature. <Annotation annotationId="040087poorlittlerudy">If it's healthy it's from the mother. If not
         from the man.</Annotation> Better luck next time.
       </p>
       <span data-edition="ed1922" data-page="92"></span>
@@ -729,9 +729,9 @@ const Hades = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         Refuse christian burial. They used to drive
         a stake of wood through his heart in the grave. As if it wasn't broken
         already. Yet sometimes they repent too late. Found in the riverbed
-        clutching rushes. He looked at me. And <Annotation annotationId="050049comehometoma" visited={visitedNotes.has("050049comehometoma")} annotationSelect={() => {openNote("050049comehometoma"); addToVisited("050049comehometoma")}} activeAnnotationId={currentNoteId}>that awful drunkard of a wife
+        clutching rushes. He looked at me. And <Annotation annotationId="050049comehometoma">that awful drunkard of a wife
         of his</Annotation>. Setting up house for her time after time and then pawning the
-        furniture on him every Saturday almost. <Annotation annotationId="060000hades" visited={visitedNotes.has("060000hades")} annotationSelect={() => {openNote("060000hades"); addToVisited("060000hades")}} activeAnnotationId={currentNoteId}>Leading him the life of the
+        furniture on him every Saturday almost. <Annotation annotationId="060000hades">Leading him the life of the
         damned. Wear the heart out of a stone, that. Monday morning. Start
         afresh. Shoulder to the wheel.</Annotation> Lord, she must have looked a sight
         that night Dedalus told me he was in there. Drunk about the place and
@@ -776,16 +776,16 @@ const Hades = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         —{" "}Yes, by Jove, Mr Dedalus said. That will be worth seeing, faith.
       </p>
       <p>
-        As they turned into <Annotation annotationId="060002berkeleystreet" visited={visitedNotes.has("060002berkeleystreet")} annotationSelect={() => {openNote("060002berkeleystreet"); addToVisited("060002berkeleystreet")}} activeAnnotationId={currentNoteId}>Berkeley street</Annotation> a streetorgan near the Basin sent
-        over and after them <Annotation annotationId="040076musichall" visited={visitedNotes.has("040076musichall")} annotationSelect={() => {openNote("040076musichall"); addToVisited("040076musichall")}} activeAnnotationId={currentNoteId}>a rollicking rattling song of the halls</Annotation>. Has anybody
+        As they turned into <Annotation annotationId="060002berkeleystreet">Berkeley street</Annotation> a streetorgan near the Basin sent
+        over and after them <Annotation annotationId="040076musichall">a rollicking rattling song of the halls</Annotation>. Has anybody
         here seen Kelly? Kay ee double ell wy. Dead March from <i>Saul.</i> He's
-        as bad as old Antonio. He left me on my ownio. Pirouette! <Annotation annotationId="010068themater" visited={visitedNotes.has("010068themater")} annotationSelect={() => {openNote("010068themater"); addToVisited("010068themater")}} activeAnnotationId={currentNoteId}>The <i>Mater
+        as bad as old Antonio. He left me on my ownio. Pirouette! <Annotation annotationId="010068themater">The <i>Mater
         Misericordiae</i>. Eccles street. My house down there.</Annotation> Big place. Ward for
         incurables there. Very encouraging. Our Lady's Hospice for the dying.
-        Deadhouse handy underneath. Where <Annotation annotationId="060015riordan" visited={visitedNotes.has("060015riordan")} annotationSelect={() => {openNote("060015riordan"); addToVisited("060015riordan")}} activeAnnotationId={currentNoteId}>old Mrs Riordan</Annotation> died. They look
+        Deadhouse handy underneath. Where <Annotation annotationId="060015riordan">old Mrs Riordan</Annotation> died. They look
         terrible the women. Her feeding cup and rubbing her mouth with the
         spoon. Then the screen round her bed for her to die. Nice young student
-        that was dressed that bite the bee gave me. He's gone over to <Annotation annotationId="040086mrsthornton" visited={visitedNotes.has("040086mrsthornton")} annotationSelect={() => {openNote("040086mrsthornton"); addToVisited("040086mrsthornton")}} activeAnnotationId={currentNoteId}>the
+        that was dressed that bite the bee gave me. He's gone over to <Annotation annotationId="040086mrsthornton">the
         lying-in hospital</Annotation> they told me. From one extreme to the other. The
         carriage galloped round a corner: stopped.
       </p>
@@ -808,7 +808,7 @@ const Hades = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         Huuuh! out of that!
       </p>
       <p>
-        Thursday, of course. <Annotation annotationId="040037cattlemarket" visited={visitedNotes.has("040037cattlemarket")} annotationSelect={() => {openNote("040037cattlemarket"); addToVisited("040037cattlemarket")}} activeAnnotationId={currentNoteId}>Tomorrow is killing day.</Annotation> Springers. Cuffe sold them
+        Thursday, of course. <Annotation annotationId="040037cattlemarket">Tomorrow is killing day.</Annotation> Springers. Cuffe sold them
         about twentyseven quid each. For Liverpool probably. Roastbeef for old
         England. They 
         <span data-edition="ed1939" data-page="74"> </span>
@@ -822,7 +822,7 @@ const Hades = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         The carriage moved on through the drove.
       </p>
       <p>
-        —{" "}I can't make out why <Annotation annotationId="060033corporation" visited={visitedNotes.has("060033corporation")} annotationSelect={() => {openNote("060033corporation"); addToVisited("060033corporation")}} activeAnnotationId={currentNoteId}>the corporation</Annotation> doesn't run a tramline from the
+        —{" "}I can't make out why <Annotation annotationId="060033corporation">the corporation</Annotation> doesn't run a tramline from the
         parkgate to the quays, Mr Bloom said. All those animals could be taken
         in trucks down to the boats.
       </p>
@@ -835,7 +835,7 @@ const Hades = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         —{" "}Yes, Mr Bloom said, and another thing I often thought, is to have 
         <span data-edition="ed1922" data-page="94"></span>
         
-        <Annotation annotationId="060039fineoldcustom" visited={visitedNotes.has("060039fineoldcustom")} annotationSelect={() => {openNote("060039fineoldcustom"); addToVisited("060039fineoldcustom")}} activeAnnotationId={currentNoteId}>municipal funeral trams like they have in Milan, you know. Run the line
+        <Annotation annotationId="060039fineoldcustom">municipal funeral trams like they have in Milan, you know. Run the line
         out to the cemetery gates and have special trams, hearse and carriage
         and all.</Annotation> Don't you see what I mean?
       </p>
@@ -855,7 +855,7 @@ const Hades = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <p>
         —{" "}And, Martin Cunningham said, we wouldn't have scenes like that when
-        the hearse capsized <Annotation annotationId="060014dunphyscorner" visited={visitedNotes.has("060014dunphyscorner")} annotationSelect={() => {openNote("060014dunphyscorner"); addToVisited("060014dunphyscorner")}} activeAnnotationId={currentNoteId}>round Dunphy's</Annotation> and upset the coffin on to the road.
+        the hearse capsized <Annotation annotationId="060014dunphyscorner">round Dunphy's</Annotation> and upset the coffin on to the road.
       </p>
       <p>
         —{" "}That was terrible, Mr Power's shocked face said, and the corpse fell
@@ -896,10 +896,10 @@ const Hades = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         by, coming from the cemetery: looks relieved.
       </p>
       <p>
-        <Annotation annotationId="060016canals" visited={visitedNotes.has("060016canals")} annotationSelect={() => {openNote("060016canals"); addToVisited("060016canals")}} activeAnnotationId={currentNoteId}>Crossguns bridge: the royal canal.</Annotation>
+        <Annotation annotationId="060016canals">Crossguns bridge: the royal canal.</Annotation>
       </p>
       <p>
-        <Annotation annotationId="060016canals" visited={visitedNotes.has("060016canals")} annotationSelect={() => {openNote("060016canals"); addToVisited("060016canals")}} activeAnnotationId={currentNoteId}>Water rushed roaring through the sluices. A man stood on his
+        <Annotation annotationId="060016canals">Water rushed roaring through the sluices. A man stood on his
         dropping barge</Annotation>, between clamps of turf. On the towpath by the lock a<span data-edition="ed1932" data-page="88"></span>
         slacktethered horse. Aboard of the <i>Bugabu.</i>
       </p>
@@ -907,23 +907,23 @@ const Hades = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         Their eyes watched him. On the slow weedy waterway he had floated on his
         raft coastward over Ireland drawn by a haulage rope past beds of reeds, 
         <span data-edition="ed1922" data-page="95"></span>
-        over slime, mudchoked bottles, carrion dogs. Athlone, <Annotation annotationId="010126mullingar" visited={visitedNotes.has("010126mullingar")} annotationSelect={() => {openNote("010126mullingar"); addToVisited("010126mullingar")}} activeAnnotationId={currentNoteId}>Mullingar</Annotation>,
+        over slime, mudchoked bottles, carrion dogs. Athlone, <Annotation annotationId="010126mullingar">Mullingar</Annotation>,
         Moyvalley, I could make a walking tour to see Milly by the canal. Or
         cycle down. Hire some old crock, safety. 
         <span data-edition="ed1939" data-page="75"> </span>
         Wren had one the other day at
-        the auction but a lady's. Developing waterways. <Annotation annotationId="060031ferry" visited={visitedNotes.has("060031ferry")} annotationSelect={() => {openNote("060031ferry"); addToVisited("060031ferry")}} activeAnnotationId={currentNoteId}>James M'Cann's hobby
+        the auction but a lady's. Developing waterways. <Annotation annotationId="060031ferry">James M'Cann's hobby
         to row me o'er the ferry.</Annotation> Cheaper transit. By easy stages. Houseboats.
         Camping out. Also hearses. To heaven by water. Perhaps I will without
-        writing. Come as a surprise, Leixlip, Clonsilla. <Annotation annotationId="060036bogs" visited={visitedNotes.has("060036bogs")} annotationSelect={() => {openNote("060036bogs"); addToVisited("060036bogs")}} activeAnnotationId={currentNoteId}>Dropping down lock by
+        writing. Come as a surprise, Leixlip, Clonsilla. <Annotation annotationId="060036bogs">Dropping down lock by
         lock to Dublin. With turf from the midland bogs.</Annotation> Salute. He lifted his
         brown straw hat, saluting Paddy Dignam.
       </p>
       <p>
-        They drove on past <Annotation annotationId="060017brianboroimhehouse" visited={visitedNotes.has("060017brianboroimhehouse")} annotationSelect={() => {openNote("060017brianboroimhehouse"); addToVisited("060017brianboroimhehouse")}} activeAnnotationId={currentNoteId}>Brian Boroimhe house</Annotation>. Near it now.
+        They drove on past <Annotation annotationId="060017brianboroimhehouse">Brian Boroimhe house</Annotation>. Near it now.
       </p>
       <p>
-        —{" "}I wonder <Annotation annotationId="050037tomkernan" visited={visitedNotes.has("050037tomkernan")} annotationSelect={() => {openNote("050037tomkernan"); addToVisited("050037tomkernan")}} activeAnnotationId={currentNoteId}>how is our friend Fogarty getting on</Annotation>, Mr Power said.
+        —{" "}I wonder <Annotation annotationId="050037tomkernan">how is our friend Fogarty getting on</Annotation>, Mr Power said.
       </p>
       <p>
         —{" "}Better ask Tom Kernan, Mr Dedalus said.
@@ -935,13 +935,13 @@ const Hades = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         —{" "}Though lost to sight, Mr Dedalus said, to memory dear.
       </p>
       <p>
-        The carriage steered left for <Annotation annotationId="060035prospect" visited={visitedNotes.has("060035prospect")} annotationSelect={() => {openNote("060035prospect"); addToVisited("060035prospect")}} activeAnnotationId={currentNoteId}>Finglas road</Annotation>.
+        The carriage steered left for <Annotation annotationId="060035prospect">Finglas road</Annotation>.
       </p>
       <p>
-        <Annotation annotationId="060046monumental" visited={visitedNotes.has("060046monumental")} annotationSelect={() => {openNote("060046monumental"); addToVisited("060046monumental")}} activeAnnotationId={currentNoteId}>The stonecutter's yard on the right. Last lap.</Annotation> <Annotation annotationId="060000hades" visited={visitedNotes.has("060000hades")} annotationSelect={() => {openNote("060000hades"); addToVisited("060000hades")}} activeAnnotationId={currentNoteId}>Crowded on the spit of
+        <Annotation annotationId="060046monumental">The stonecutter's yard on the right. Last lap.</Annotation> <Annotation annotationId="060000hades">Crowded on the spit of
         land silent shapes appeared, white, sorrowful, holding out calm hands,
         knelt in grief, pointing. Fragments of shapes, hewn. In white silence:
-        appealing.</Annotation> <Annotation annotationId="060046monumental" visited={visitedNotes.has("060046monumental")} annotationSelect={() => {openNote("060046monumental"); addToVisited("060046monumental")}} activeAnnotationId={currentNoteId}>The best obtainable. Thos. H. Dennany, monumental builder and
+        appealing.</Annotation> <Annotation annotationId="060046monumental">The best obtainable. Thos. H. Dennany, monumental builder and
         sculptor.</Annotation>
       </p>
       <p>
@@ -989,9 +989,9 @@ const Hades = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         their pants down. Never forgive you after. Fifteen.
       </p>
       <p>
-        <Annotation annotationId="060035prospect" visited={visitedNotes.has("060035prospect")} annotationSelect={() => {openNote("060035prospect"); addToVisited("060035prospect")}} activeAnnotationId={currentNoteId}>The high railings of Prospect</Annotation> rippled past their gaze. Dark poplars,
+        <Annotation annotationId="060035prospect">The high railings of Prospect</Annotation> rippled past their gaze. Dark poplars,
         rare white forms. Forms more frequent, white shapes thronged amid the
-        trees, white forms and fragments streaming by <Annotation annotationId="010070mutes" visited={visitedNotes.has("010070mutes")} annotationSelect={() => {openNote("010070mutes"); addToVisited("010070mutes")}} activeAnnotationId={currentNoteId}>mutely, sustaining vain
+        trees, white forms and fragments streaming by <Annotation annotationId="010070mutes">mutely, sustaining vain
         gestures</Annotation> on the air.
       </p>
       <p>
@@ -1002,7 +1002,7 @@ const Hades = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       <p>
         Change that soap now. Mr Bloom's hand unbuttoned his hip pocket swiftly
         and transferred the paperstuck soap to his inner handkerchief pocket.
-        He stepped out of the carriage, replacing <Annotation annotationId="050021freeman" visited={visitedNotes.has("050021freeman")} annotationSelect={() => {openNote("050021freeman"); addToVisited("050021freeman")}} activeAnnotationId={currentNoteId}>the newspaper his other hand
+        He stepped out of the carriage, replacing <Annotation annotationId="050021freeman">the newspaper his other hand
         still held</Annotation>.
       </p>
       <span data-edition="ed1939" data-page="76"> </span>
@@ -1030,7 +1030,7 @@ const Hades = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         Coffin now. Got here before us, dead as he is. Horse looking round at it
         with his plume skeowways. Dull eye: collar tight on his neck, pressing
         on a bloodvessel or something. Do they know what they cart out here
-        every day? Must be twenty or thirty funerals every day. Then <Annotation annotationId="050025botanicgardens" visited={visitedNotes.has("050025botanicgardens")} annotationSelect={() => {openNote("050025botanicgardens"); addToVisited("050025botanicgardens")}} activeAnnotationId={currentNoteId}>Mount
+        every day? Must be twenty or thirty funerals every day. Then <Annotation annotationId="050025botanicgardens">Mount
         Jerome</Annotation> for the protestants. Funerals all over the world everywhere every
         minute. Shovelling them under by the cartload doublequick. Thousands
         every hour. Too many in the world.
@@ -1043,7 +1043,7 @@ const Hades = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <span data-edition="ed1932" data-page="90"></span>
       <p>
-        <Annotation annotationId="010070mutes" visited={visitedNotes.has("010070mutes")} annotationSelect={() => {openNote("010070mutes"); addToVisited("010070mutes")}} activeAnnotationId={currentNoteId}>The mutes</Annotation> shouldered the coffin and bore it in through the gates. So much 
+        <Annotation annotationId="010070mutes">The mutes</Annotation> shouldered the coffin and bore it in through the gates. So much 
         <span data-edition="ed1922" data-page="97"></span>
         
         dead weight. Felt heavier myself stepping out of that bath. First
@@ -1073,7 +1073,7 @@ const Hades = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <p>
         He glanced behind him to where a face with dark thinking eyes followed
-        towards <Annotation annotationId="060035prospect" visited={visitedNotes.has("060035prospect")} annotationSelect={() => {openNote("060035prospect"); addToVisited("060035prospect")}} activeAnnotationId={currentNoteId}>the cardinal's mausoleum</Annotation>. Speaking.
+        towards <Annotation annotationId="060035prospect">the cardinal's mausoleum</Annotation>. Speaking.
       </p>
       <p>
         —{" "}Was he insured? Mr Bloom asked.
@@ -1109,7 +1109,7 @@ const Hades = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         him. For Hindu widows only. She would marry another. Him? No. Yet who
         knows after. Widowhood not the thing 
         <span data-edition="ed1939" data-page="77"> </span>
-        since the old queen died. <Annotation annotationId="060028frogmore" visited={visitedNotes.has("060028frogmore")} annotationSelect={() => {openNote("060028frogmore"); addToVisited("060028frogmore")}} activeAnnotationId={currentNoteId}>Drawn on
+        since the old queen died. <Annotation annotationId="060028frogmore">Drawn on
         a guncarriage. Victoria and Albert. Frogmore memorial mourning.</Annotation> But
         in the end she put a few violets in her bonnet. Vain in her heart of
         hearts. All for a shadow. Consort not even a king. Her son was the
@@ -1134,14 +1134,14 @@ const Hades = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         —{" "}And how is Dick, the solid man?
       </p>
       <p>
-        —{" "}<Annotation annotationId="010098metbutterly" visited={visitedNotes.has("010098metbutterly")} annotationSelect={() => {openNote("010098metbutterly"); addToVisited("010098metbutterly")}} activeAnnotationId={currentNoteId}>Nothing between himself and heaven</Annotation>, Ned Lambert answered.
+        —{" "}<Annotation annotationId="010098metbutterly">Nothing between himself and heaven</Annotation>, Ned Lambert answered.
       </p>
       <p>
         —{" "}By the holy Paul! Mr Dedalus said in subdued wonder. Dick Tivy bald?
       </p>
       <p>
         —{" "}Martin is going to get up a whip for the youngsters, Ned Lambert said,
-        pointing ahead. A few bob a skull. Just to keep them going <Annotation annotationId="130007scottishwidows" visited={visitedNotes.has("130007scottishwidows")} annotationSelect={() => {openNote("130007scottishwidows"); addToVisited("130007scottishwidows")}} activeAnnotationId={currentNoteId}>till the
+        pointing ahead. A few bob a skull. Just to keep them going <Annotation annotationId="130007scottishwidows">till the
         insurance is cleared up</Annotation>.
       </p>
       <span data-edition="ed1986" data-page="84"></span>
@@ -1164,7 +1164,7 @@ const Hades = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         —{" "}Many a good man's fault, Mr Dedalus said with a sigh.
       </p>
       <p>
-        They halted about the door of the <Annotation annotationId="060035prospect" visited={visitedNotes.has("060035prospect")} annotationSelect={() => {openNote("060035prospect"); addToVisited("060035prospect")}} activeAnnotationId={currentNoteId}>mortuary chapel</Annotation>. Mr Bloom stood behind
+        They halted about the door of the <Annotation annotationId="060035prospect">mortuary chapel</Annotation>. Mr Bloom stood behind
         the boy with the wreath looking down at his sleekcombed hair and at the
         slender furrowed neck inside his brandnew collar. Poor boy! Was he there
         when the father? Both unconscious. Lighten up at the last moment
@@ -1177,16 +1177,16 @@ const Hades = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         light. The coffin lay on its bier before the chancel, four tall yellow
         candles at its corners. Always in front of us. Corny Kelleher, laying a
         wreath at each fore corner, beckoned to the boy to kneel. The mourners
-        knelt here and there in prayingdesks. Mr Bloom stood behind near <Annotation annotationId="050023holywater" visited={visitedNotes.has("050023holywater")} annotationSelect={() => {openNote("050023holywater"); addToVisited("050023holywater")}} activeAnnotationId={currentNoteId}>the
+        knelt here and there in prayingdesks. Mr Bloom stood behind near <Annotation annotationId="050023holywater">the
         font</Annotation> and, when all had knelt, dropped carefully his unfolded newspaper
         from his pocket and knelt his right knee upon it. He fitted his black
         hat gently on his left knee and, holding its brim, bent over piously.
       </p>
       <p>
-        <Annotation annotationId="010084server" visited={visitedNotes.has("010084server")} annotationSelect={() => {openNote("010084server"); addToVisited("010084server")}} activeAnnotationId={currentNoteId}>A server</Annotation> bearing a brass bucket with something in it came out through a
-        door. The whitesmocked priest came after him, <Annotation annotationId="010104stole" visited={visitedNotes.has("010104stole")} annotationSelect={() => {openNote("010104stole"); addToVisited("010104stole")}} activeAnnotationId={currentNoteId}>tidying his stole</Annotation> with one
+        <Annotation annotationId="010084server">A server</Annotation> bearing a brass bucket with something in it came out through a
+        door. The whitesmocked priest came after him, <Annotation annotationId="010104stole">tidying his stole</Annotation> with one
         hand, balancing with the other a little book against his toad's belly.
-        <Annotation annotationId="060006toadeyes" visited={visitedNotes.has("060006toadeyes")} annotationSelect={() => {openNote("060006toadeyes"); addToVisited("060006toadeyes")}} activeAnnotationId={currentNoteId}>Who'll read the book? I, said the rook.</Annotation>
+        <Annotation annotationId="060006toadeyes">Who'll read the book? I, said the rook.</Annotation>
       </p>
       <p>
         They halted by the bier and the priest began to read out of his book
@@ -1194,7 +1194,7 @@ const Hades = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <span data-edition="ed1922" data-page="99"></span>
       <p>
-        Father Coffey. I knew his name was like a coffin. <i>Domine-namine.</i> <Annotation annotationId="060000hades" visited={visitedNotes.has("060000hades")} annotationSelect={() => {openNote("060000hades"); addToVisited("060000hades")}} activeAnnotationId={currentNoteId}>Bully
+        Father Coffey. I knew his name was like a coffin. <i>Domine-namine.</i> <Annotation annotationId="060000hades">Bully
         about the muzzle he looks.</Annotation> Bosses the show. Muscular christian. Woe
         betide anyone that looks crooked at him: priest. Thou art Peter. Burst
         sideways like a sheep in clover Dedalus says he will. With a belly<span data-edition="ed1932" data-page="92"></span> on
@@ -1209,7 +1209,7 @@ const Hades = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         Makes them feel more important to be prayed over in Latin. Requiem mass.
         Crape weepers. Blackedged notepaper. Your name on the altarlist. Chilly
         place this. Want to feed well, sitting in there all the morning in the
-        gloom kicking his heels waiting for the next please. <Annotation annotationId="060006toadeyes" visited={visitedNotes.has("060006toadeyes")} annotationSelect={() => {openNote("060006toadeyes"); addToVisited("060006toadeyes")}} activeAnnotationId={currentNoteId}>Eyes of a toad too.</Annotation>
+        gloom kicking his heels waiting for the next please. <Annotation annotationId="060006toadeyes">Eyes of a toad too.</Annotation>
         What swells him up that way? Molly gets swelled after cabbage. Air of
         the place maybe. Looks full up of bad gas. Must be an infernal lot
         of bad gas round the place. Butchers, for instance: they get like<span data-edition="ed1961" data-page="103"></span> raw
@@ -1222,7 +1222,7 @@ const Hades = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         My kneecap is hurting me. Ow. That's better.
       </p>
       <p>
-        <Annotation annotationId="050023holywater" visited={visitedNotes.has("050023holywater")} annotationSelect={() => {openNote("050023holywater"); addToVisited("050023holywater")}} activeAnnotationId={currentNoteId}>The priest took a stick with a knob at the end of it out of the boy's
+        <Annotation annotationId="050023holywater">The priest took a stick with a knob at the end of it out of the boy's
         bucket and shook it over the coffin.</Annotation> Then he walked to the other end and
         shook it again. Then he came back and put it back in the bucket. As you
         were before you rested. It's all written down: he has to do it.
@@ -1271,11 +1271,11 @@ const Hades = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         —{" "}The O'Connell circle, Mr Dedalus said about him.
       </p>
       <p>
-        Mr Power's soft eyes went up to the apex of <Annotation annotationId="060027loftycone" visited={visitedNotes.has("060027loftycone")} annotationSelect={() => {openNote("060027loftycone"); addToVisited("060027loftycone")}} activeAnnotationId={currentNoteId}>the lofty cone</Annotation>.
+        Mr Power's soft eyes went up to the apex of <Annotation annotationId="060027loftycone">the lofty cone</Annotation>.
       </p>
       <span data-edition="ed1961" data-page="104"></span>
       <p>
-        —{" "}He's at rest, he said, in the middle of his people, old Dan O'. <Annotation annotationId="020038oconnell" visited={visitedNotes.has("020038oconnell")} annotationSelect={() => {openNote("020038oconnell"); addToVisited("020038oconnell")}} activeAnnotationId={currentNoteId}>But
+        —{" "}He's at rest, he said, in the middle of his people, old Dan O'. <Annotation annotationId="020038oconnell">But
         his heart is buried in Rome.</Annotation> How many broken hearts are buried here,
         Simon!
       </p>
@@ -1350,7 +1350,7 @@ const Hades = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         every day. One fine day it gets bunged up: and there you are. Lots of
         them lying around here: lungs, hearts, livers. Old rusty pumps: damn
         the thing else.<span data-edition="ed1932" data-page="94"></span> The resurrection and the life. Once you are dead you are
-        dead. That last day idea. Knocking them all up out of their graves. <Annotation annotationId="010098metbutterly" visited={visitedNotes.has("010098metbutterly")} annotationSelect={() => {openNote("010098metbutterly"); addToVisited("010098metbutterly")}} activeAnnotationId={currentNoteId}>Come
+        dead. That last day idea. Knocking them all up out of their graves. <Annotation annotationId="010098metbutterly">Come
         forth, Lazarus! And he came fifth and lost the job.</Annotation> Get<span data-edition="ed1961" data-page="105"></span> up! Last day!
         Then every fellow mousing around for his liver and his lights and the
         rest of his traps. Find damn all of himself that morning. Pennyweight of
@@ -1388,7 +1388,7 @@ const Hades = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <p>
         —{" "}O, to be sure, John Henry Menton said. I haven't seen her for some
-        time. She was a finelooking woman. <Annotation annotationId="170008precedingseries" visited={visitedNotes.has("170008precedingseries")} annotationSelect={() => {openNote("170008precedingseries"); addToVisited("170008precedingseries")}} activeAnnotationId={currentNoteId}>I danced with her, wait, fifteen
+        time. She was a finelooking woman. <Annotation annotationId="170008precedingseries">I danced with her, wait, fifteen
         seventeen golden years ago, at Mat Dillon's in Roundtown. And a good
         armful she was.</Annotation>
       </p>
@@ -1442,7 +1442,7 @@ const Hades = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         Cunningham's side puzzling two long keys at his back.
       </p>
       <p>
-        —{" "}Did you hear that one, he asked them, about Mulcahy from <Annotation annotationId="050014thecoombe" visited={visitedNotes.has("050014thecoombe")} annotationSelect={() => {openNote("050014thecoombe"); addToVisited("050014thecoombe")}} activeAnnotationId={currentNoteId}>the Coombe</Annotation>?
+        —{" "}Did you hear that one, he asked them, about Mulcahy from <Annotation annotationId="050014thecoombe">the Coombe</Annotation>?
       </p>
       <p>
         —{" "}I did not, Martin Cunningham said.
@@ -1466,7 +1466,7 @@ const Hades = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <p>
         —{" "}And, after blinking up at the sacred figure, <i>Not a bloody bit like
-        the man</i>, says he. <Annotation annotationId="010098metbutterly" visited={visitedNotes.has("010098metbutterly")} annotationSelect={() => {openNote("010098metbutterly"); addToVisited("010098metbutterly")}} activeAnnotationId={currentNoteId}><i>That's not Mulcahy</i></Annotation>, says he, <i>whoever done it</i>.
+        the man</i>, says he. <Annotation annotationId="010098metbutterly"><i>That's not Mulcahy</i></Annotation>, says he, <i>whoever done it</i>.
       </p>
       <p>
         Rewarded by smiles he fell back and spoke with Corny Kelleher, accepting
@@ -1494,15 +1494,15 @@ const Hades = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         in the dead letter office. Be
         the better of a shave. Grey sprouting beard. That's the first sign when
         the hairs come out grey. And temper getting cross. Silver threads among
-        the grey. <Annotation annotationId="060000hades" visited={visitedNotes.has("060000hades")} annotationSelect={() => {openNote("060000hades"); addToVisited("060000hades")}} activeAnnotationId={currentNoteId}>Fancy being his wife. Wonder</Annotation><span data-edition="ed1961" data-page="107"></span> <Annotation annotationId="060000hades" visited={visitedNotes.has("060000hades")} annotationSelect={() => {openNote("060000hades"); addToVisited("060000hades")}} activeAnnotationId={currentNoteId}>how he had the gumption to propose to
+        the grey. <Annotation annotationId="060000hades">Fancy being his wife. Wonder</Annotation><span data-edition="ed1961" data-page="107"></span> <Annotation annotationId="060000hades">how he had the gumption to propose to
         any girl. Come out and live in the graveyard. Dangle that before her.</Annotation> It
         might thrill her first. Courting death... Shades of night hovering
         here with all the dead stretched about. 
         <span data-edition="ed1939" data-page="81"> </span>
         The shadows of the tombs when
-        churchyards yawn and <Annotation annotationId="020038oconnell" visited={visitedNotes.has("020038oconnell")} annotationSelect={() => {openNote("020038oconnell"); addToVisited("020038oconnell")}} activeAnnotationId={currentNoteId}>Daniel O'Connell must be a descendant I suppose
+        churchyards yawn and <Annotation annotationId="020038oconnell">Daniel O'Connell must be a descendant I suppose
         who is this used to say he was a queer breedy man</Annotation><span data-edition="ed1932" data-page="96"></span> great catholic all the
-        same like a big giant in the dark. <Annotation annotationId="150004willowisp" visited={visitedNotes.has("150004willowisp")} annotationSelect={() => {openNote("150004willowisp"); addToVisited("150004willowisp")}} activeAnnotationId={currentNoteId}>Will o' the wisp.</Annotation> Gas of graves.
+        same like a big giant in the dark. <Annotation annotationId="150004willowisp">Will o' the wisp.</Annotation> Gas of graves.
         Want to keep her mind off it to conceive at all. Women especially are so
         touchy. Tell her a ghost story in bed to make her sleep. Have you ever
         seen a ghost? Well, I have. It was a pitchdark night. The clock was on
@@ -1510,7 +1510,7 @@ const Hades = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         Whores in Turkish graveyards. Learn anything if taken young. You might
         pick up a young widow here. Men like that. Love among the tombstones.
         Romeo. Spice of pleasure. In the midst of death we are in life. Both
-        ends meet. <Annotation annotationId="060000hades" visited={visitedNotes.has("060000hades")} annotationSelect={() => {openNote("060000hades"); addToVisited("060000hades")}} activeAnnotationId={currentNoteId}>Tantalising for the poor dead. Smell of grilled beefsteaks to
+        ends meet. <Annotation annotationId="060000hades">Tantalising for the poor dead. Smell of grilled beefsteaks to
         the starving. Gnawing their vitals.</Annotation> Desire to grig people. Molly wanting
         to do it at the window. Eight children he has anyway.
       </p>
@@ -1522,7 +1522,7 @@ const Hades = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         the ground must be: oblong cells. And very neat he keeps it too: trim
         grass and edgings. His garden Major Gamble calls Mount Jerome. Well,
         so it is. Ought to be flowers of sleep. Chinese cemeteries with giant
-        poppies growing produce the best opium Mastiansky told me. <Annotation annotationId="050025botanicgardens" visited={visitedNotes.has("050025botanicgardens")} annotationSelect={() => {openNote("050025botanicgardens"); addToVisited("050025botanicgardens")}} activeAnnotationId={currentNoteId}>The Botanic
+        poppies growing produce the best opium Mastiansky told me. <Annotation annotationId="050025botanicgardens">The Botanic
         Gardens are just over there.</Annotation> It's the blood sinking in the earth gives
         new life. Same idea those jews they said killed the christian boy. Every
         man his price. Well preserved fat corpse, gentleman, epicure, invaluable
@@ -1542,10 +1542,10 @@ const Hades = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       <span data-edition="ed1922" data-page="104"></span>
       <p>
         But they must breed a devil of a lot of maggots. Soil must be simply
-        swirling with them. <Annotation annotationId="040069seasidegirls" visited={visitedNotes.has("040069seasidegirls")} annotationSelect={() => {openNote("040069seasidegirls"); addToVisited("040069seasidegirls")}} activeAnnotationId={currentNoteId}>Your head it simply swurls. Those pretty little
+        swirling with them. <Annotation annotationId="040069seasidegirls">Your head it simply swurls. Those pretty little
         seaside gurls.</Annotation> He looks cheerful enough over it. Gives him a sense of
         power seeing all the others go under first. Wonder how he looks at life.
-        Cracking his jokes too: <Annotation annotationId="030080cockles" visited={visitedNotes.has("030080cockles")} annotationSelect={() => {openNote("030080cockles"); addToVisited("030080cockles")}} activeAnnotationId={currentNoteId}>warms the cockles of his heart</Annotation>. The one about
+        Cracking his jokes too: <Annotation annotationId="030080cockles">warms the cockles of his heart</Annotation>. The one about
         the bulletin. Spurgeon went to heaven 4 a.m. this morning. 11 p.m.
         (closing time). Not<span data-edition="ed1986" data-page="89"></span> arrived yet. Peter. The dead themselves the men<span data-edition="ed1932" data-page="97"></span>
         anyhow would like to hear an odd joke or the women to know what's in
@@ -1606,8 +1606,8 @@ const Hades = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <span data-edition="ed1932" data-page="98"></span>
       <p>
-        Nice soft tweed Ned Lambert has in that suit.  <Annotation annotationId="020080mauve" visited={visitedNotes.has("020080mauve")} annotationSelect={() => {openNote("020080mauve"); addToVisited("020080mauve")}} activeAnnotationId={currentNoteId}>Tinge of purple.</Annotation> I had
-        one like that <Annotation annotationId="040049pleasantoldtimes" visited={visitedNotes.has("040049pleasantoldtimes")} annotationSelect={() => {openNote("040049pleasantoldtimes"); addToVisited("040049pleasantoldtimes")}} activeAnnotationId={currentNoteId}>when we lived in Lombard street west</Annotation>. Dressy fellow he was
+        Nice soft tweed Ned Lambert has in that suit.  <Annotation annotationId="020080mauve">Tinge of purple.</Annotation> I had
+        one like that <Annotation annotationId="040049pleasantoldtimes">when we lived in Lombard street west</Annotation>. Dressy fellow he was
         once. Used to change three suits in the day. Must get that grey suit
         of mine turned by Mesias. Hello. It's dyed. His wife I forgot he's not
         married or his landlady ought to have picked out those threads for him.
@@ -1621,10 +1621,10 @@ const Hades = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         Pause.
       </p>
       <p>
-        <Annotation annotationId="030087pastlife" visited={visitedNotes.has("030087pastlife")} annotationSelect={() => {openNote("030087pastlife"); addToVisited("030087pastlife")}} activeAnnotationId={currentNoteId}>If we were all suddenly somebody else.</Annotation>
+        <Annotation annotationId="030087pastlife">If we were all suddenly somebody else.</Annotation>
       </p>
       <p>
-        <Annotation annotationId="060044donkey" visited={visitedNotes.has("060044donkey")} annotationSelect={() => {openNote("060044donkey"); addToVisited("060044donkey")}} activeAnnotationId={currentNoteId}>Far away a donkey brayed.</Annotation> <Annotation annotationId="060044donkey" visited={visitedNotes.has("060044donkey")} annotationSelect={() => {openNote("060044donkey"); addToVisited("060044donkey")}} activeAnnotationId={currentNoteId}>Rain. No such ass. Never see a dead one, they
+        <Annotation annotationId="060044donkey">Far away a donkey brayed.</Annotation> <Annotation annotationId="060044donkey">Rain. No such ass. Never see a dead one, they
         say.</Annotation> Shame of death. They hide. Also poor papa went away.
       </p>
       <p>
@@ -1658,7 +1658,7 @@ const Hades = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       <p>
         Does he ever think of the hole waiting for himself? They say you do when
         you shiver in the sun. Someone walking over it. Callboy's warning. Near
-        you. Mine over there <Annotation annotationId="060035prospect" visited={visitedNotes.has("060035prospect")} annotationSelect={() => {openNote("060035prospect"); addToVisited("060035prospect")}} activeAnnotationId={currentNoteId}>towards Finglas</Annotation>, the plot I bought. Mamma, poor
+        you. Mine over there <Annotation annotationId="060035prospect">towards Finglas</Annotation>, the plot I bought. Mamma, poor
         mamma, and little Rudy.
       </p>
       <p>
@@ -1679,7 +1679,7 @@ const Hades = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         it. The mourners took heart of grace, one by one, covering themselves
         without show. Mr Bloom put on his hat and saw the portly figure make its
         way deftly through the maze of graves. Quietly, sure of his ground, he
-        traversed the <Annotation annotationId="060000hades" visited={visitedNotes.has("060000hades")} annotationSelect={() => {openNote("060000hades"); addToVisited("060000hades")}} activeAnnotationId={currentNoteId}>dismal fields</Annotation>.
+        traversed the <Annotation annotationId="060000hades">dismal fields</Annotation>.
       </p>
       <span data-edition="ed1986" data-page="91"></span>
       <p>
@@ -1687,7 +1687,7 @@ const Hades = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         knows them all. No: coming to me.
       </p>
       <p>
-        —{" "}I am just taking the names, Hynes said below his breath. <Annotation annotationId="060026allofus" visited={visitedNotes.has("060026allofus")} annotationSelect={() => {openNote("060026allofus"); addToVisited("060026allofus")}} activeAnnotationId={currentNoteId}> What is your
+        —{" "}I am just taking the names, Hynes said below his breath. <Annotation annotationId="060026allofus"> What is your
         christian name?</Annotation> I'm not sure.
       </p>
       <p>
@@ -1695,12 +1695,12 @@ const Hades = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         asked me to.
       </p>
       <p>
-        —{" "}<Annotation annotationId="040079mcoy" visited={visitedNotes.has("040079mcoy")} annotationSelect={() => {openNote("040079mcoy"); addToVisited("040079mcoy")}} activeAnnotationId={currentNoteId}>Charley</Annotation>, Hynes said writing. I know. He was on <Annotation annotationId="050021freeman" visited={visitedNotes.has("050021freeman")} annotationSelect={() => {openNote("050021freeman"); addToVisited("050021freeman")}} activeAnnotationId={currentNoteId}>the <i>Freeman</i></Annotation> once.
+        —{" "}<Annotation annotationId="040079mcoy">Charley</Annotation>, Hynes said writing. I know. He was on <Annotation annotationId="050021freeman">the <i>Freeman</i></Annotation> once.
       </p>
       <p>
         So he was before he got the job in the morgue under Louis Byrne. Good
         idea a postmortem for doctors. Find out what they imagine they know.
-        He died of a Tuesday. <Annotation annotationId="060041charley" visited={visitedNotes.has("060041charley")} annotationSelect={() => {openNote("060041charley"); addToVisited("060041charley")}} activeAnnotationId={currentNoteId}>Got the run. Levanted with the cash of a few ads.
+        He died of a Tuesday. <Annotation annotationId="060041charley">Got the run. Levanted with the cash of a few ads.
         Charley, you're my darling.</Annotation><span data-edition="ed1961" data-page="111"></span> That was why he asked me to. O well, does
         no harm. I saw to that, M'Coy. Thanks, old chap: much obliged. Leave him
         under an obligation: costs nothing.
@@ -1728,7 +1728,7 @@ const Hades = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <p>
         Didn't hear. What? Where has he disappeared to? Not a sign. Well of all
-        the. Has anybody here seen? Kay ee double ell. <Annotation annotationId="010078invisibility" visited={visitedNotes.has("010078invisibility")} annotationSelect={() => {openNote("010078invisibility"); addToVisited("010078invisibility")}} activeAnnotationId={currentNoteId}>Become invisible.</Annotation> Good
+        the. Has anybody here seen? Kay ee double ell. <Annotation annotationId="010078invisibility">Become invisible.</Annotation> Good
         Lord, what became of him?
       </p>
       <p>
@@ -1759,7 +1759,7 @@ const Hades = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         The mourners moved away slowly without aim, by devious paths, staying awhile to read a name on a tomb.
       </p>
       <p>
-        —{" "}Let us go round by <Annotation annotationId="060035prospect" visited={visitedNotes.has("060035prospect")} annotationSelect={() => {openNote("060035prospect"); addToVisited("060035prospect")}} activeAnnotationId={currentNoteId}>the chief's grave</Annotation>, Hynes said. We have time.
+        —{" "}Let us go round by <Annotation annotationId="060035prospect">the chief's grave</Annotation>, Hynes said. We have time.
       </p>
       <p>
         —{" "}Let us, Mr Power said.
@@ -1796,11 +1796,11 @@ const Hades = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         bucket. More interesting if they told you what they were. So and So,
         wheelwright. I travelled for cork lino. I paid five shillings in the
         pound. Or a woman's with her saucepan. I cooked good Irish stew.
-        <Annotation annotationId="060005churchyard" visited={visitedNotes.has("060005churchyard")} annotationSelect={() => {openNote("060005churchyard"); addToVisited("060005churchyard")}} activeAnnotationId={currentNoteId}>Eulogy in a country churchyard it ought to be that poem of whose is it
+        <Annotation annotationId="060005churchyard">Eulogy in a country churchyard it ought to be that poem of whose is it
         Wordsworth or Thomas Campbell.</Annotation> Entered into rest the protestants put it.
         Old Dr Murren's. The great physician called him home. Well it's God's
         acre for them. Nice country residence. Newly plastered and painted.
-        Ideal spot to have a quiet smoke and read <Annotation annotationId="160004newspapers" visited={visitedNotes.has("160004newspapers")} annotationSelect={() => {openNote("160004newspapers"); addToVisited("160004newspapers")}} activeAnnotationId={currentNoteId}>the <i>Church Times</i></Annotation>. Marriage
+        Ideal spot to have a quiet smoke and read <Annotation annotationId="160004newspapers">the <i>Church Times</i></Annotation>. Marriage
         ads they never try to beautify. Rusty wreaths<span data-edition="ed1932" data-page="101"></span> hung on knobs, garlands of
         bronzefoil. Better value that for the money. Still, the flowers are more
         poetical. The other gets rather tiresome, never withering. Expresses
@@ -1808,7 +1808,7 @@ const Hades = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <p>
         A bird sat tamely perched on a poplar branch. Like stuffed. Like the
-        wedding present <Annotation annotationId="060033corporation" visited={visitedNotes.has("060033corporation")} annotationSelect={() => {openNote("060033corporation"); addToVisited("060033corporation")}} activeAnnotationId={currentNoteId}>alderman Hooper</Annotation> gave us. Hu! Not a budge out of him.
+        wedding present <Annotation annotationId="060033corporation">alderman Hooper</Annotation> gave us. Hu! Not a budge out of him.
         Knows there are no catapults to let fly at him. Dead animal even sadder.
         Silly-Milly burying the little dead bird in the kitchen matchbox, a
         daisychain and bits of broken chainies on the grave.
@@ -1823,7 +1823,7 @@ const Hades = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         boy. Apollo that was.
       </p>
       <p>
-        <Annotation annotationId="060000hades" visited={visitedNotes.has("060000hades")} annotationSelect={() => {openNote("060000hades"); addToVisited("060000hades")}} activeAnnotationId={currentNoteId}>How many! All these here once walked round Dublin.</Annotation> Faithful departed. As
+        <Annotation annotationId="060000hades">How many! All these here once walked round Dublin.</Annotation> Faithful departed. As
         you are now so once were we.
       </p>
       <span data-edition="ed1961" data-page="113"></span>
@@ -1838,7 +1838,7 @@ const Hades = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         when I was in Wisdom Hely's.
       </p>
       <p>
-        Rtststr! <Annotation annotationId="030038pebbles" visited={visitedNotes.has("030038pebbles")} annotationSelect={() => {openNote("030038pebbles"); addToVisited("030038pebbles")}} activeAnnotationId={currentNoteId}>A rattle of pebbles.</Annotation> Wait. Stop!
+        Rtststr! <Annotation annotationId="030038pebbles">A rattle of pebbles.</Annotation> Wait. Stop!
       </p>
       <p>
         He looked down intently into a stone crypt. Some animal. Wait. There he
@@ -1846,7 +1846,7 @@ const Hades = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <span data-edition="ed1922" data-page="109"></span>
       <p>
-        <Annotation annotationId="010062ghoul" visited={visitedNotes.has("010062ghoul")} annotationSelect={() => {openNote("010062ghoul"); addToVisited("010062ghoul")}} activeAnnotationId={currentNoteId}>An obese grey rat</Annotation> toddled along the side of the crypt, moving the
+        <Annotation annotationId="010062ghoul">An obese grey rat</Annotation> toddled along the side of the crypt, moving the
         pebbles. An old stager: greatgrandfather: he knows the ropes. The grey
         alive crushed itself in under the plinth, wriggled itself in under it.
         Good hidingplace for treasure.
@@ -1877,17 +1877,17 @@ const Hades = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         like raw white turnips.
       </p>
       <p>
-        <Annotation annotationId="060000hades" visited={visitedNotes.has("060000hades")} annotationSelect={() => {openNote("060000hades"); addToVisited("060000hades")}} activeAnnotationId={currentNoteId}>The gates glimmered in front: still open. Back to the world again.</Annotation>
-        Enough of this place. Brings you a bit nearer every time. <Annotation annotationId="060038emilysinico" visited={visitedNotes.has("060038emilysinico")} annotationSelect={() => {openNote("060038emilysinico"); addToVisited("060038emilysinico")}} activeAnnotationId={currentNoteId}>Last time I
+        <Annotation annotationId="060000hades">The gates glimmered in front: still open. Back to the world again.</Annotation>
+        Enough of this place. Brings you a bit nearer every time. <Annotation annotationId="060038emilysinico">Last time I
         was here was Mrs Sinico's funeral.</Annotation> Poor papa too. The love that kills.
         And even scraping up the earth at<span data-edition="ed1961" data-page="114"></span> night with a lantern like that case
         I read of to get at fresh buried females or even putrefied with running
         gravesores. Give you the creeps after a bit. I will appear to you after
         death. You will see my ghost after death. My ghost will haunt you after
-        death. There is another world after death named hell. <Annotation annotationId="050003otherworld" visited={visitedNotes.has("050003otherworld")} annotationSelect={() => {openNote("050003otherworld"); addToVisited("050003otherworld")}} activeAnnotationId={currentNoteId}>I do not like that
+        death. There is another world after death named hell. <Annotation annotationId="050003otherworld">I do not like that
         other world she wrote.</Annotation> No more do I. Plenty to see and hear and feel
         yet. Feel live warm beings near you. Let them sleep in their maggoty
-        beds. They are not going to get me this innings. Warm beds: <Annotation annotationId="040063happywarmth" visited={visitedNotes.has("040063happywarmth")} annotationSelect={() => {openNote("040063happywarmth"); addToVisited("040063happywarmth")}} activeAnnotationId={currentNoteId}>warm
+        beds. They are not going to get me this innings. Warm beds: <Annotation annotationId="040063happywarmth">warm
         fullblooded life</Annotation>.
       </p>
       <p>
@@ -1904,7 +1904,7 @@ const Hades = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         
         the bowling green because I sailed inside him. Pure fluke
         of mine: the bias. Why he took such a rooted dislike to me. Hate
-        at first sight.<span data-edition="ed1986" data-page="94"></span> <Annotation annotationId="170008precedingseries" visited={visitedNotes.has("170008precedingseries")} annotationSelect={() => {openNote("170008precedingseries"); addToVisited("170008precedingseries")}} activeAnnotationId={currentNoteId}>Molly and Floey Dillon linked under the lilactree,
+        at first sight.<span data-edition="ed1986" data-page="94"></span> <Annotation annotationId="170008precedingseries">Molly and Floey Dillon linked under the lilactree,
         laughing. Fellow always like that, mortified if women are by.</Annotation>
       </p>
       <p>

--- a/src/content/chapters/Ithaca.js
+++ b/src/content/chapters/Ithaca.js
@@ -1,13 +1,13 @@
 import Annotation from "../../components/Annotation";
 
 
-const Ithaca = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
+const Ithaca = () => {
   return (
     <div>
       <p></p>
       <center><font size="+2">[17]</font></center>
       <br/>
-      <Annotation annotationId="170003parallelcourses" visited={visitedNotes.has("170003parallelcourses")} annotationSelect={() => {openNote("170003parallelcourses"); addToVisited("170003parallelcourses")}} activeAnnotationId={currentNoteId}>What parallel courses</Annotation> did Bloom and Stephen follow <Annotation annotationId="170007returning" visited={visitedNotes.has("170007returning")} annotationSelect={() => {openNote("170007returning"); addToVisited("170007returning")}} activeAnnotationId={currentNoteId}>returning</Annotation>?
+      <Annotation annotationId="170003parallelcourses">What parallel courses</Annotation> did Bloom and Stephen follow <Annotation annotationId="170007returning">returning</Annotation>?
       <p></p>
       <p>
         Starting united both at normal walking pace from Beresford place they
@@ -17,19 +17,19 @@ const Ithaca = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         Temple street, north: then, at reduced pace with interruptions of halt, bearing
         right, Temple street, north, as far as Hardwicke place. Approaching,
         disparate, at relaxed walking pace they crossed both the circus before
-        <Annotation annotationId="040008georgeschurch" visited={visitedNotes.has("040008georgeschurch")} annotationSelect={() => {openNote("040008georgeschurch"); addToVisited("040008georgeschurch")}} activeAnnotationId={currentNoteId}>George's church</Annotation> <Annotation annotationId="170003parallelcourses" visited={visitedNotes.has("170003parallelcourses")} annotationSelect={() => {openNote("170003parallelcourses"); addToVisited("170003parallelcourses")}} activeAnnotationId={currentNoteId}>diametrically, the chord in any circle being less than
+        <Annotation annotationId="040008georgeschurch">George's church</Annotation> <Annotation annotationId="170003parallelcourses">diametrically, the chord in any circle being less than
         the arc which it subtends</Annotation>.
       </p>
       <p>
-        Of what <Annotation annotationId="170004duumvirate" visited={visitedNotes.has("170004duumvirate")} annotationSelect={() => {openNote("170004duumvirate"); addToVisited("170004duumvirate")}} activeAnnotationId={currentNoteId}>did the duumvirate deliberate during their itinerary</Annotation>?
+        Of what <Annotation annotationId="170004duumvirate">did the duumvirate deliberate during their itinerary</Annotation>?
       </p>
       <span data-edition="ed1932" data-page="572"></span>
       <p>
         Music, literature, Ireland, Dublin, Paris, friendship, woman,
         prostitution, diet, the influence of gaslight or the light of arc and
-        glowlamps on the growth of adjoining paraheliotropic trees, <Annotation annotationId="060033corporation" visited={visitedNotes.has("060033corporation")} annotationSelect={() => {openNote("060033corporation"); addToVisited("060033corporation")}} activeAnnotationId={currentNoteId}>corporation</Annotation> exposed <Annotation annotationId="170005dustbuckets" visited={visitedNotes.has("170005dustbuckets")} annotationSelect={() => {openNote("170005dustbuckets"); addToVisited("170005dustbuckets")}} activeAnnotationId={currentNoteId}>
+        glowlamps on the growth of adjoining paraheliotropic trees, <Annotation annotationId="060033corporation">corporation</Annotation> exposed <Annotation annotationId="170005dustbuckets">
         emergency dustbuckets</Annotation>, the Roman catholic church,
-        ecclesiastical celibacy, the Irish nation, <Annotation annotationId="010008jesuit" visited={visitedNotes.has("010008jesuit")} annotationSelect={() => {openNote("010008jesuit"); addToVisited("010008jesuit")}} activeAnnotationId={currentNoteId}>jesuit education</Annotation>, careers,
+        ecclesiastical celibacy, the Irish nation, <Annotation annotationId="010008jesuit">jesuit education</Annotation>, careers,
         the study of medicine, the past day, the maleficent influence of the
         presabbath, Stephen's collapse.
       </p>
@@ -54,11 +54,11 @@ const Ithaca = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       <p>
         Stephen dissented openly from Bloom's views on the importance of dietary
         and civic selfhelp while Bloom dissented tacitly from Stephen's views
-        on <Annotation annotationId="170010spiritofman" visited={visitedNotes.has("170010spiritofman")} annotationSelect={() => {openNote("170010spiritofman"); addToVisited("170010spiritofman")}} activeAnnotationId={currentNoteId}>the eternal affirmation of the spirit of man in literature</Annotation>. Bloom
-        assented <span data-edition="ed1986" data-page="544"></span>covertly to <Annotation annotationId="050036saintpatrick" visited={visitedNotes.has("050036saintpatrick")} annotationSelect={() => {openNote("050036saintpatrick"); addToVisited("050036saintpatrick")}} activeAnnotationId={currentNoteId}>Stephen's rectification of the anachronism
+        on <Annotation annotationId="170010spiritofman">the eternal affirmation of the spirit of man in literature</Annotation>. Bloom
+        assented <span data-edition="ed1986" data-page="544"></span>covertly to <Annotation annotationId="050036saintpatrick">Stephen's rectification of the anachronism
         involved in assigning the date of the conversion of the Irish nation to
         christianity from druidism by Patrick son of Calpornus, son of Potitus,
-        son of Odyssus, sent by pope Celestine I in the year 432 in the</Annotation> <span data-edition="ed1961" data-page="666"></span><Annotation annotationId="050036saintpatrick" visited={visitedNotes.has("050036saintpatrick")} annotationSelect={() => {openNote("050036saintpatrick"); addToVisited("050036saintpatrick")}} activeAnnotationId={currentNoteId}>reign of
+        son of Odyssus, sent by pope Celestine I in the year 432 in the</Annotation> <span data-edition="ed1961" data-page="666"></span><Annotation annotationId="050036saintpatrick">reign of
         Leary to the year 260 or thereabouts in the reign of Cormac MacArt</Annotation> (†
         266 A.D.), suffocated by imperfect deglutition of aliment at Sletty
         and 
@@ -68,7 +68,7 @@ const Ithaca = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         adulteration and alcoholic strength, accelerated by mental exertion and
         the velocity of rapid circular motion in a relaxing atmosphere, Stephen
         attributed to the reapparition of a matutinal cloud (perceived by both
-        from two different points of observation, Sandycove and Dublin) <Annotation annotationId="170001womanshand" visited={visitedNotes.has("170001womanshand")} annotationSelect={() => {openNote("170001womanshand"); addToVisited("170001womanshand")}} activeAnnotationId={currentNoteId}>at first
+        from two different points of observation, Sandycove and Dublin) <Annotation annotationId="170001womanshand">at first
         no bigger than a woman's hand</Annotation>.
       </p>
       <p>
@@ -91,11 +91,11 @@ const Ithaca = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         between Gibraltar villa and Bloomfield house in Crumlin, barony
         of Uppercross. In 1886 occasionally with casual acquaintances and
         prospective purchasers on doorsteps, in front parlours, in third class
-        railway carriages of suburban lines. In 1888 frequently with <Annotation annotationId="040018oldtweedy" visited={visitedNotes.has("040018oldtweedy")} annotationSelect={() => {openNote("040018oldtweedy"); addToVisited("040018oldtweedy")}} activeAnnotationId={currentNoteId}>major Brian
+        railway carriages of suburban lines. In 1888 frequently with <Annotation annotationId="040018oldtweedy">major Brian
         Tweedy</Annotation> and his daughter Miss Marion Tweedy, together and separately on
         the lounge in Matthew Dillon's house in Roundtown. Once in 1892 and once
         in 1893 with Julius Mastiansky, on both occasions in the parlour
-        of his (Bloom's) house <Annotation annotationId="040049pleasantoldtimes" visited={visitedNotes.has("040049pleasantoldtimes")} annotationSelect={() => {openNote("040049pleasantoldtimes"); addToVisited("040049pleasantoldtimes")}} activeAnnotationId={currentNoteId}>in Lombard street, west</Annotation>.
+        of his (Bloom's) house <Annotation annotationId="040049pleasantoldtimes">in Lombard street, west</Annotation>.
       </p>
       <p>
         What reflection concerning the irregular sequence of dates 1884, 1885,
@@ -121,7 +121,7 @@ const Ithaca = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         What action did Bloom make on their arrival at their destination?
       </p>
       <p>
-        At the housesteps of the 4th of the equidifferent uneven numbers, <Annotation annotationId="040005seveneccles" visited={visitedNotes.has("040005seveneccles")} annotationSelect={() => {openNote("040005seveneccles"); addToVisited("040005seveneccles")}} activeAnnotationId={currentNoteId}>number
+        At the housesteps of the 4th of the equidifferent uneven numbers, <Annotation annotationId="040005seveneccles">number
         7 Eccles street</Annotation>, he inserted his hand mechanically into the back pocket
         of his trousers to obtain his latchkey.
       </p>
@@ -213,7 +213,7 @@ const Ithaca = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <p>
         Yes, entering softly, he helped to close and chain the door and followed
-        softly along the hallway the man's back and <Annotation annotationId="170020listedfeet" visited={visitedNotes.has("170020listedfeet")} annotationSelect={() => {openNote("170020listedfeet"); addToVisited("170020listedfeet")}} activeAnnotationId={currentNoteId}>listed feet</Annotation> and lighted
+        softly along the hallway the man's back and <Annotation annotationId="170020listedfeet">listed feet</Annotation> and lighted
         candle past a lighted crevice of doorway on the left and carefully down
         a turning staircase of more than five steps into the kitchen of Bloom's
         house.
@@ -231,7 +231,7 @@ const Ithaca = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         of best Abram coal <span data-edition="ed1961" data-page="669"></span>at twentyone shillings a ton from the yard of Messrs
         Flower and M'Donald of 14 D'Olier 
         <span data-edition="ed1922" data-page="622"></span>
-        street, <Annotation annotationId="150013matches" visited={visitedNotes.has("150013matches")} annotationSelect={() => {openNote("150013matches"); addToVisited("150013matches")}} activeAnnotationId={currentNoteId}>kindled it at three projecting
+        street, <Annotation annotationId="150013matches">kindled it at three projecting
         points of paper with one ignited lucifer match</Annotation>, thereby releasing
         the potential energy contained in the fuel by allowing its carbon and
         hydrogen elements to enter into free union with the oxygen of the air.
@@ -242,10 +242,10 @@ const Ithaca = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       <p>
         Of others elsewhere in other times who, kneeling on one knee or on two,
         had kindled fires for him, of Brother Michael in the infirmary of the
-        college of the <Annotation annotationId="010008jesuit" visited={visitedNotes.has("010008jesuit")} annotationSelect={() => {openNote("010008jesuit"); addToVisited("010008jesuit")}} activeAnnotationId={currentNoteId}>Society of Jesus</Annotation> at <Annotation annotationId="010157clongowes" visited={visitedNotes.has("010157clongowes")} annotationSelect={() => {openNote("010157clongowes"); addToVisited("010157clongowes")}} activeAnnotationId={currentNoteId}>Clongowes Wood, Sallins, in the
+        college of the <Annotation annotationId="010008jesuit">Society of Jesus</Annotation> at <Annotation annotationId="010157clongowes">Clongowes Wood, Sallins, in the
         county of Kildare</Annotation>: of his father, Simon Dedalus, in an unfurnished room
         of his first residence in Dublin, number thirteen Fitzgibbon street:
-        of <Annotation annotationId="040027conroy" visited={visitedNotes.has("040027conroy")} annotationSelect={() => {openNote("040027conroy"); addToVisited("040027conroy")}} activeAnnotationId={currentNoteId}>his godmother Miss Kate Morkan in the house of her dying sister Miss
+        of <Annotation annotationId="040027conroy">his godmother Miss Kate Morkan in the house of her dying sister Miss
         Julia Morkan at 15 Usher's Island</Annotation>: of his mother Mary, wife of Simon Dedalus, in the kitchen of
         number twelve North Richmond street <span data-edition="ed1986" data-page="547"></span>on the morning of the feast of
         Saint Francis Xavier 1898: of the dean of studies, Father Butt, in the
@@ -302,11 +302,11 @@ const Ithaca = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         waterworks engineer, Mr Spencer Harty, C. E., on the instructions of
         the waterworks committee had prohibited the use of municipal water for
         purposes other than those of consumption (envisaging the possibility of
-        recourse being had to <Annotation annotationId="060016canals" visited={visitedNotes.has("060016canals")} annotationSelect={() => {openNote("060016canals"); addToVisited("060016canals")}} activeAnnotationId={currentNoteId}>the impotable water of the Grand and Royal canals</Annotation>
+        recourse being had to <Annotation annotationId="060016canals">the impotable water of the Grand and Royal canals</Annotation>
         as in 1893) particularly as the South Dublin Guardians, notwithstanding
         their ration of 15 gallons per day per pauper supplied through a 6 inch
         meter, had been convicted of a wastage of 20,000 gallons per night by
-        a reading of their meter on the affirmation of <Annotation annotationId="060033corporation" visited={visitedNotes.has("060033corporation")} annotationSelect={() => {openNote("060033corporation"); addToVisited("060033corporation")}} activeAnnotationId={currentNoteId}>the law agent of
+        a reading of their meter on the affirmation of <Annotation annotationId="060033corporation">the law agent of
         the corporation</Annotation>, Mr Ignatius Rice, solicitor, thereby acting to the
         detriment of another section of the public, selfsupporting taxpayers,
         solvent, sound.
@@ -340,7 +340,7 @@ const Ithaca = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         <span data-edition="ed1922" data-page="624"></span>
         lakecontained streams and
         confluent oceanflowing rivers with their tributaries and transoceanic
-        currents, <Annotation annotationId="010116gulfstream" visited={visitedNotes.has("010116gulfstream")} annotationSelect={() => {openNote("010116gulfstream"); addToVisited("010116gulfstream")}} activeAnnotationId={currentNoteId}>gulfstream</Annotation>, north and south equatorial courses: its violence
+        currents, <Annotation annotationId="010116gulfstream">gulfstream</Annotation>, north and south equatorial courses: its violence
         in seaquakes, waterspouts, Artesian wells, eruptions, torrents, eddies,
         freshets, spates, groundswells, watersheds, waterpartings, geysers,
         cataracts, whirlpools, maelstroms, inundations, deluges, cloudbursts:
@@ -366,7 +366,7 @@ const Ithaca = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         derivable from harnessed tides or watercourses falling from level
         to level: its submarine fauna and flora (anacoustic, photophobe),
         numerically, if not literally, the inhabitants of the globe: its
-        ubiquity as constituting 90% of the human <span data-edition="ed1986" data-page="549"></span>body: <Annotation annotationId="060036bogs" visited={visitedNotes.has("060036bogs")} annotationSelect={() => {openNote("060036bogs"); addToVisited("060036bogs")}} activeAnnotationId={currentNoteId}>the noxiousness
+        ubiquity as constituting 90% of the human <span data-edition="ed1986" data-page="549"></span>body: <Annotation annotationId="060036bogs">the noxiousness
         of its effluvia in lacustrine marshes, pestilential fens</Annotation>, faded
         flowerwater, stagnant pools in the waning moon.
       </p>
@@ -500,23 +500,23 @@ const Ithaca = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         goldrimmed eggcups, <span data-edition="ed1986" data-page="551"></span>an open shammy purse displaying coins, mostly
         copper, and a phial of aromatic violet comfits. On the middle shelf
         a chipped eggcup containing pepper, a drum of table salt, four
-        conglomerated black olives in oleaginous paper, <Annotation annotationId="050016pottedmeat" visited={visitedNotes.has("050016pottedmeat")} annotationSelect={() => {openNote("050016pottedmeat"); addToVisited("050016pottedmeat")}} activeAnnotationId={currentNoteId}>an empty pot of</Annotation>
+        conglomerated black olives in oleaginous paper, <Annotation annotationId="050016pottedmeat">an empty pot of</Annotation>
         <span data-edition="ed1922" data-page="627"></span>
-        <Annotation annotationId="050016pottedmeat" visited={visitedNotes.has("050016pottedmeat")} annotationSelect={() => {openNote("050016pottedmeat"); addToVisited("050016pottedmeat")}} activeAnnotationId={currentNoteId}>Plumtree's potted meat</Annotation>, an oval wicker basket bedded with fibre and
+        <Annotation annotationId="050016pottedmeat">Plumtree's potted meat</Annotation>, an oval wicker basket bedded with fibre and
         containing one Jersey pear, a halfempty bottle of William Gilbey and
         Co's white invalid port, half disrobed of its swathe of coralpink tissue
-        paper, a packet of <Annotation annotationId="170006eppscocoa" visited={visitedNotes.has("170006eppscocoa")} annotationSelect={() => {openNote("170006eppscocoa"); addToVisited("170006eppscocoa")}} activeAnnotationId={currentNoteId}>Epps's soluble cocoa</Annotation>, five ounces of Anne Lynch's
+        paper, a packet of <Annotation annotationId="170006eppscocoa">Epps's soluble cocoa</Annotation>, five ounces of Anne Lynch's
         choice tea at 2/- per lb. in a crinkled leadpaper bag, a cylindrical
         canister containing the best crystallised lump sugar, two onions, one,
         the larger, Spanish, 
         <span data-edition="ed1939" data-page="474"> </span>
         entire, the other, smaller, Irish, bisected with
         augmented surface and more redolent, a jar of Irish Model Dairy's cream,
-        a jug of brown crockery containing <Annotation annotationId="040090naggin" visited={visitedNotes.has("040090naggin")} annotationSelect={() => {openNote("040090naggin"); addToVisited("040090naggin")}} activeAnnotationId={currentNoteId}>a naggin and a quarter</Annotation> of soured
+        a jug of brown crockery containing <Annotation annotationId="040090naggin">a naggin and a quarter</Annotation> of soured
         adulterated milk, converted by heat into water, acidulous serum and
         semisolidified curds, which added to the quantity subtracted for Mr
         Bloom's and Mrs Fleming's breakfasts, made one imperial pint, the total
-        quantity originally delivered, two cloves, <Annotation annotationId="010019money" visited={visitedNotes.has("010019money")} annotationSelect={() => {openNote("010019money"); addToVisited("010019money")}} activeAnnotationId={currentNoteId}>a halfpenny</Annotation> and a small dish
+        quantity originally delivered, two cloves, <Annotation annotationId="010019money">a halfpenny</Annotation> and a small dish
         containing a slice of fresh ribsteak. On the upper shelf a battery of
         jamjars of various sizes and proveniences.
       </p>
@@ -533,8 +533,8 @@ const Ithaca = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       <p>
         Reminiscences of coincidences, truth stranger than fiction,
         preindicative of the result of the Gold Cup flat handicap, the official
-        and definitive result of which he had read in <Annotation annotationId="020064telegraph" visited={visitedNotes.has("020064telegraph")} annotationSelect={() => {openNote("020064telegraph"); addToVisited("020064telegraph")}} activeAnnotationId={currentNoteId}>the <i>Evening Telegraph</i>,
-        late pink edition</Annotation>, in the <Annotation annotationId="050012cabstands" visited={visitedNotes.has("050012cabstands")} annotationSelect={() => {openNote("050012cabstands"); addToVisited("050012cabstands")}} activeAnnotationId={currentNoteId}>cabman's shelter</Annotation>, at <Annotation annotationId="070015buttbridge" visited={visitedNotes.has("070015buttbridge")} annotationSelect={() => {openNote("070015buttbridge"); addToVisited("070015buttbridge")}} activeAnnotationId={currentNoteId}>Butt bridge</Annotation>.
+        and definitive result of which he had read in <Annotation annotationId="020064telegraph">the <i>Evening Telegraph</i>,
+        late pink edition</Annotation>, in the <Annotation annotationId="050012cabstands">cabman's shelter</Annotation>, at <Annotation annotationId="070015buttbridge">Butt bridge</Annotation>.
       </p>
       <span data-edition="ed1961" data-page="675"></span><span data-edition="ed1932" data-page="581"></span>
       <p>
@@ -543,15 +543,15 @@ const Ithaca = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <p>
         In Bernard Kiernan's licensed premises 8, 9 and 10 little Britain
-        street: in <Annotation annotationId="080024davybyrnes" visited={visitedNotes.has("080024davybyrnes")} annotationSelect={() => {openNote("080024davybyrnes"); addToVisited("080024davybyrnes")}} activeAnnotationId={currentNoteId}>David Byrne's licensed premises, 14 Duke street</Annotation>: in <Annotation annotationId="060012liberatorsform" visited={visitedNotes.has("060012liberatorsform")} annotationSelect={() => {openNote("060012liberatorsform"); addToVisited("060012liberatorsform")}} activeAnnotationId={currentNoteId}>O'Connell
+        street: in <Annotation annotationId="080024davybyrnes">David Byrne's licensed premises, 14 Duke street</Annotation>: in <Annotation annotationId="060012liberatorsform">O'Connell
         street lower</Annotation>, outside Graham Lemon's when a dark man had placed in
         his hand a throwaway (subsequently thrown away), advertising Elijah,
         restorer of the church in Zion: in Lincoln place outside the premises of
         F. W. Sweny and Co (Limited), dispensing chemists, when, when Frederick
         M. (Bantam) Lyons had rapidly and successively requested, perused and
-        restituted the copy of the current issue of the <Annotation annotationId="050021freeman" visited={visitedNotes.has("050021freeman")} annotationSelect={() => {openNote("050021freeman"); addToVisited("050021freeman")}} activeAnnotationId={currentNoteId}><i>Freeman's Journal and
+        restituted the copy of the current issue of the <Annotation annotationId="050021freeman"><i>Freeman's Journal and
         National Press</i></Annotation> which he had been about to throw away (subsequently
-        thrown away), he had proceeded towards <Annotation annotationId="050010mosquebaths" visited={visitedNotes.has("050010mosquebaths")} annotationSelect={() => {openNote("050010mosquebaths"); addToVisited("050010mosquebaths")}} activeAnnotationId={currentNoteId}>the oriental edifice of
+        thrown away), he had proceeded towards <Annotation annotationId="050010mosquebaths">the oriental edifice of
         the Turkish and Warm Baths, 11 Leinster street</Annotation>, with the light of
         <span data-edition="ed1922" data-page="628"></span>
         inspiration shining in his countenance and bearing in his arms the
@@ -643,7 +643,7 @@ const Ithaca = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       <p>
         Concluding by inspection but erroneously that his silent companion was
         engaged in mental composition he reflected on the pleasures derived from
-        literature of instruction rather than of amusement as <Annotation annotationId="020033mademoney" visited={visitedNotes.has("020033mademoney")} annotationSelect={() => {openNote("020033mademoney"); addToVisited("020033mademoney")}} activeAnnotationId={currentNoteId}>he himself had
+        literature of instruction rather than of amusement as <Annotation annotationId="020033mademoney">he himself had
         applied to the works of William Shakespeare more than once for the
         solution of difficult problems in imaginary or real life</Annotation>.
       </p>
@@ -658,7 +658,7 @@ const Ithaca = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       <p>
         What lines concluded his first piece of original verse written by him,
         potential poet, at the age of 11 in 1877 on the occasion <span data-edition="ed1961" data-page="677"></span>of the offering
-        <span data-edition="ed1932" data-page="583"></span>of three prizes of 10/-, 5/- and 2/6 respectively for competition by <Annotation annotationId="160004newspapers" visited={visitedNotes.has("160004newspapers")} annotationSelect={() => {openNote("160004newspapers"); addToVisited("160004newspapers")}} activeAnnotationId={currentNoteId}>the
+        <span data-edition="ed1932" data-page="583"></span>of three prizes of 10/-, 5/- and 2/6 respectively for competition by <Annotation annotationId="160004newspapers">the
         <i>Shamrock</i>, a weekly newspaper</Annotation>?
       </p>
       <p><i>An ambition to squint <br/>
@@ -699,8 +699,8 @@ const Ithaca = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         What had prevented him from completing a topical song (music by R. G.
         Johnston) on the events of the past, or fixtures for the actual, years,
         entitled <i>If Brian Boru could but come back and see old Dublin now</i>,
-        commissioned by <Annotation annotationId="060040gaietytheatre" visited={visitedNotes.has("060040gaietytheatre")} annotationSelect={() => {openNote("060040gaietytheatre"); addToVisited("060040gaietytheatre")}} activeAnnotationId={currentNoteId}>Michael Gunn, lessee of the Gaiety Theatre, 46, 47, 48,
-        49 South King street</Annotation>, and to be introduced into <Annotation annotationId="010077pantomime" visited={visitedNotes.has("010077pantomime")} annotationSelect={() => {openNote("010077pantomime"); addToVisited("010077pantomime")}} activeAnnotationId={currentNoteId}>the sixth scene, the
+        commissioned by <Annotation annotationId="060040gaietytheatre">Michael Gunn, lessee of the Gaiety Theatre, 46, 47, 48,
+        49 South King street</Annotation>, and to be introduced into <Annotation annotationId="010077pantomime">the sixth scene, the
         valley of diamonds, of the second edition (30 January 1893) of the grand
         annual Christmas pantomime <i>Sinbad the Sailor</i></Annotation> (produced by R Shelton
         26 December 1892, written by Greenleaf Whittier, scenery by George
@@ -716,10 +716,10 @@ const Ithaca = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         1837) and the posticipated opening of the new municipal fish market:
         secondly, apprehension of opposition from extreme circles on the
         questions of the respective visits of Their Royal Highnesses the
-        duke and duchess of York (real) and of His Majesty <Annotation annotationId="030086dalcassians" visited={visitedNotes.has("030086dalcassians")} annotationSelect={() => {openNote("030086dalcassians"); addToVisited("030086dalcassians")}} activeAnnotationId={currentNoteId}>King Brian Boru</Annotation>
+        duke and duchess of York (real) and of His Majesty <Annotation annotationId="030086dalcassians">King Brian Boru</Annotation>
         (imaginary): thirdly, a conflict between professional etiquette and
         professional emulation concerning the recent erections of the Grand
-        Lyric Hall on Burgh Quay and <Annotation annotationId="110005theatreroyal" visited={visitedNotes.has("110005theatreroyal")} annotationSelect={() => {openNote("110005theatreroyal"); addToVisited("110005theatreroyal")}} activeAnnotationId={currentNoteId}> the Theatre Royal in Hawkins street</Annotation>:
+        Lyric Hall on Burgh Quay and <Annotation annotationId="110005theatreroyal"> the Theatre Royal in Hawkins street</Annotation>:
         fourthly, distraction resultant from compassion for Nelly Bouverist's
         non-intellectual, non-political, non-topical expression of countenance
         and concupiscence caused by Nelly 
@@ -732,7 +732,7 @@ const Ithaca = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         every one): sixthly, the rhymes, homophonous and cacophonous, associated
         with 
         <span data-edition="ed1939" data-page="477"> </span>
-        the names of <Annotation annotationId="060033corporation" visited={visitedNotes.has("060033corporation")} annotationSelect={() => {openNote("060033corporation"); addToVisited("060033corporation")}} activeAnnotationId={currentNoteId}>the new lord mayor, Daniel Tallon</Annotation>, the new high
+        the names of <Annotation annotationId="060033corporation">the new lord mayor, Daniel Tallon</Annotation>, the new high
         sheriff, Thomas Pile and the new solicitorgeneral, Dunbar Plunket
         Barton.
       </p>
@@ -789,9 +789,9 @@ const Ithaca = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         third connecting link between them?
       </p>
       <p>
-        <Annotation annotationId="060015riordan" visited={visitedNotes.has("060015riordan")} annotationSelect={() => {openNote("060015riordan"); addToVisited("060015riordan")}} activeAnnotationId={currentNoteId}>Mrs Riordan (Dante)</Annotation>, a widow of independent means, had resided in the
+        <Annotation annotationId="060015riordan">Mrs Riordan (Dante)</Annotation>, a widow of independent means, had resided in the
         house of Stephen's parents from 1 September 1888 to 29 December 1891 and
-        had also resided during the years 1892, 1893 and 1894 in the <Annotation annotationId="020066cityarms" visited={visitedNotes.has("020066cityarms")} annotationSelect={() => {openNote("020066cityarms"); addToVisited("020066cityarms")}} activeAnnotationId={currentNoteId}>City Arms
+        had also resided during the years 1892, 1893 and 1894 in the <Annotation annotationId="020066cityarms">City Arms
         Hotel</Annotation> owned by Elizabeth O'Dowd of 54 Prussia street where, during parts
         of the years 1893 and 1894, she had been a constant informant of Bloom
         who resided also in the same hotel, being at that time a clerk in the
@@ -844,7 +844,7 @@ const Ithaca = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <p>
         The indoor exercises, formerly intermittently practised, subsequently
-        abandoned, prescribed in <Annotation annotationId="040024sandow" visited={visitedNotes.has("040024sandow")} annotationSelect={() => {openNote("040024sandow"); addToVisited("040024sandow")}} activeAnnotationId={currentNoteId}>Eugen Sandow's <i>Physical Strength and How to
+        abandoned, prescribed in <Annotation annotationId="040024sandow">Eugen Sandow's <i>Physical Strength and How to
         Obtain It</i></Annotation> which, designed particularly for commercial men engaged in
         sedentary occupations, were to be made with mental concentration in
         front of a mirror so as to bring into play the various families of
@@ -856,7 +856,7 @@ const Ithaca = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <p>
         Though ringweight lifting had been beyond his strength and the full
-        circle gyration beyond his courage yet as a <Annotation annotationId="050020highschool" visited={visitedNotes.has("050020highschool")} annotationSelect={() => {openNote("050020highschool"); addToVisited("050020highschool")}} activeAnnotationId={currentNoteId}>High school</Annotation> scholar he
+        circle gyration beyond his courage yet as a <Annotation annotationId="050020highschool">High school</Annotation> scholar he
         had excelled in his stable and protracted execution of the half lever
         movement on the parallel bars in consequence of his abnormally developed
         abdominal muscles.
@@ -875,7 +875,7 @@ const Ithaca = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <p>
         He thought that he thought that he was a jew whereas he knew that he
-        knew that <Annotation annotationId="040083hewasajew" visited={visitedNotes.has("040083hewasajew")} annotationSelect={() => {openNote("040083hewasajew"); addToVisited("040083hewasajew")}} activeAnnotationId={currentNoteId}>he knew that he was not</Annotation>.
+        knew that <Annotation annotationId="040083hewasajew">he knew that he was not</Annotation>.
       </p>
       <span data-edition="ed1939" data-page="479"> </span>
       <span data-edition="ed1932" data-page="587"></span>
@@ -884,7 +884,7 @@ const Ithaca = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         parentages?
       </p>
       <p>
-        Bloom, only born male transubstantial heir of <Annotation annotationId="050026henryflower" visited={visitedNotes.has("050026henryflower")} annotationSelect={() => {openNote("050026henryflower"); addToVisited("050026henryflower")}} activeAnnotationId={currentNoteId}>Rudolf Virag (subsequently
+        Bloom, only born male transubstantial heir of <Annotation annotationId="050026henryflower">Rudolf Virag (subsequently
         Rudolph Bloom)</Annotation> of Szombathely, Vienna, Budapest, Milan, London and
         Dublin and of Ellen Higgins, second daughter of Julius Higgins (born
         Karoly) and Fanny Higgins (born Hegarty). Stephen, eldest surviving male
@@ -898,7 +898,7 @@ const Ithaca = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <p>
         Bloom (three times), by the reverend Mr Gilmer Johnston M. A., alone,
-        in the protestant church of Saint Nicholas Without, <Annotation annotationId="050014thecoombe" visited={visitedNotes.has("050014thecoombe")} annotationSelect={() => {openNote("050014thecoombe"); addToVisited("050014thecoombe")}} activeAnnotationId={currentNoteId}>Coombe</Annotation>, by James
+        in the protestant church of Saint Nicholas Without, <Annotation annotationId="050014thecoombe">Coombe</Annotation>, by James
         O'Connor, Philip Gilligan and James Fitzpatrick, together, under a pump
         in the village of Swords, and by the reverend Charles Malone C. C., in
         the church of the Three Patrons, Rathgar. Stephen (once) by the reverend
@@ -949,7 +949,7 @@ const Ithaca = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         kindergarten?
       </p>
       <p>
-        Yes, rendering obsolete popguns, elastic airbladders, <Annotation annotationId="050012cabstands" visited={visitedNotes.has("050012cabstands")} annotationSelect={() => {openNote("050012cabstands"); addToVisited("050012cabstands")}} activeAnnotationId={currentNoteId}>games of hazard</Annotation>,
+        Yes, rendering obsolete popguns, elastic airbladders, <Annotation annotationId="050012cabstands">games of hazard</Annotation>,
         catapults. They comprised astronomical kaleidoscopes exhibiting the twelve 
         <span data-edition="ed1922" data-page="635"></span>
         constellations of the zodiac from Aries to Pisces, miniature
@@ -1015,8 +1015,8 @@ const Ithaca = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         With it an abode of bliss.
       </p>
       <p>
-        <Annotation annotationId="050016pottedmeat" visited={visitedNotes.has("050016pottedmeat")} annotationSelect={() => {openNote("050016pottedmeat"); addToVisited("050016pottedmeat")}} activeAnnotationId={currentNoteId}>Manufactured by George Plumtree, 23 Merchants' quay, Dublin</Annotation>, put up in
-        4 oz. pots, and inserted by <Annotation annotationId="070019nannetti" visited={visitedNotes.has("070019nannetti")} annotationSelect={() => {openNote("070019nannetti"); addToVisited("070019nannetti")}} activeAnnotationId={currentNoteId}>Councillor Joseph P. Nannetti, M. P., Rotunda
+        <Annotation annotationId="050016pottedmeat">Manufactured by George Plumtree, 23 Merchants' quay, Dublin</Annotation>, put up in
+        4 oz. pots, and inserted by <Annotation annotationId="070019nannetti">Councillor Joseph P. Nannetti, M. P., Rotunda
         Ward, 19 Hardwicke street</Annotation>, under the obituary notices and anniversaries
         of deceases. The name on the label is Plumtree. A plumtree in a meatpot,
         registered trade mark. Beware of imitations. Peatmot. Trumplee. Moutpat.
@@ -1058,7 +1058,7 @@ const Ithaca = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       <p>
         The Queen's Hotel, Ennis, County Clare, where Rudolph Bloom (Rudolf
         Virag) died on the evening of the 27 June 1886, at some hour unstated,
-        in consequence of <Annotation annotationId="150007aconite" visited={visitedNotes.has("150007aconite")} annotationSelect={() => {openNote("150007aconite"); addToVisited("150007aconite")}} activeAnnotationId={currentNoteId}>an overdose of monkshood (aconite)</Annotation> selfadministered in
+        in consequence of <Annotation annotationId="150007aconite">an overdose of monkshood (aconite)</Annotation> selfadministered in
         the form of a neuralgic liniment composed of 2 parts of aconite liniment
         to 1 of chloroform liniment (purchased by him at 10.20 a.m. on the
         <span data-edition="ed1961" data-page="684"></span>morning of 27 June 1886 at the medical hall of Francis Dennehy, 17
@@ -1155,7 +1155,7 @@ const Ithaca = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         the implement of calligraphy in the encaustic pigment, exposed to
         the corrosive action of copperas, green vitriol and nutgall. Unusual
         polysyllables of foreign origin she interpreted phonetically or by false
-        analogy or by both: <Annotation annotationId="030087pastlife" visited={visitedNotes.has("030087pastlife")} annotationSelect={() => {openNote("030087pastlife"); addToVisited("030087pastlife")}} activeAnnotationId={currentNoteId}>metempsychosis (met him pike hoses)</Annotation>, <i>alias</i> (a
+        analogy or by both: <Annotation annotationId="030087pastlife">metempsychosis (met him pike hoses)</Annotation>, <i>alias</i> (a
         mendacious person mentioned in sacred scripture).
       </p>
       <p>
@@ -1224,7 +1224,7 @@ const Ithaca = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         name uncertain.
       </p>
       <p>
-        Were other anapocryphal illustrious sons of the law and children of <Annotation annotationId="040083hewasajew" visited={visitedNotes.has("040083hewasajew")} annotationSelect={() => {openNote("040083hewasajew"); addToVisited("040083hewasajew")}} activeAnnotationId={currentNoteId}>a
+        Were other anapocryphal illustrious sons of the law and children of <Annotation annotationId="040083hewasajew">a
         selected or rejected race</Annotation> mentioned?
       </p>
       <p>
@@ -1285,7 +1285,7 @@ const Ithaca = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         isolation of their synagogical and 
         <span data-edition="ed1939" data-page="484"> </span>
         ecclesiastical rites in ghetto (S.
-        Mary's Abbey) and <Annotation annotationId="070024differentchurches" visited={visitedNotes.has("070024differentchurches")} annotationSelect={() => {openNote("070024differentchurches"); addToVisited("070024differentchurches")}} activeAnnotationId={currentNoteId}>masshouse (Adam and Eve's tavern)</Annotation>: the proscription
+        Mary's Abbey) and <Annotation annotationId="070024differentchurches">masshouse (Adam and Eve's tavern)</Annotation>: the proscription
         of their national costumes in penal laws and jewish dress acts: the
         <span data-edition="ed1961" data-page="688"></span>restoration in Chanah David of Zion and the possibility of Irish
         political autonomy or devolution.
@@ -1348,7 +1348,7 @@ const Ithaca = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       <p>
         Visually, Stephen's: The traditional figure of hypostasis, depicted
         by Johannes Damascenus, Lentulus Romanus and Epiphanius Monachus as
-        leucodermic, sesquipedalian with <Annotation annotationId="010033epioinopaponton" visited={visitedNotes.has("010033epioinopaponton")} annotationSelect={() => {openNote("010033epioinopaponton"); addToVisited("010033epioinopaponton")}} activeAnnotationId={currentNoteId}>winedark hair</Annotation>. 
+        leucodermic, sesquipedalian with <Annotation annotationId="010033epioinopaponton">winedark hair</Annotation>. 
       </p>
       <p>
         Auditively, Bloom's: The
@@ -1361,7 +1361,7 @@ const Ithaca = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <p>
         In the church, Roman, Anglican or Nonconformist: exemplars, the very
-        reverend <Annotation annotationId="050052conmee" visited={visitedNotes.has("050052conmee")} annotationSelect={() => {openNote("050052conmee"); addToVisited("050052conmee")}} activeAnnotationId={currentNoteId}>John Conmee S. J.</Annotation>, the reverend T. Salmon, D. D., provost of
+        reverend <Annotation annotationId="050052conmee">John Conmee S. J.</Annotation>, the reverend T. Salmon, D. D., provost of
         Trinity college, Dr Alexander J. Dowie. At the bar, English or Irish:
         exemplars, Seymour Bushe, K. C., Rufus Isaacs, K. C. On the stage modern
         or Shakespearean: exemplars, Charles Wyndham, high comedian Osmond
@@ -1469,7 +1469,7 @@ const Ithaca = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         continued fraction of veridicity, the envy of
         opulence, the influence of retaliation, the sporadic reappearance of
         atavistic delinquency, the mitigating circumstances of fanaticism,
-        <Annotation annotationId="170021hypnotic" visited={visitedNotes.has("170021hypnotic")} annotationSelect={() => {openNote("170021hypnotic"); addToVisited("170021hypnotic")}} activeAnnotationId={currentNoteId}>hypnotic suggestion and somnambulism</Annotation>.
+        <Annotation annotationId="170021hypnotic">hypnotic suggestion and somnambulism</Annotation>.
       </p>
       <span data-edition="ed1986" data-page="567"></span>
       <p>
@@ -1491,7 +1491,7 @@ const Ithaca = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <p>
         Twice, in Holles street and in Ontario terrace, his daughter Millicent
-        (Milly) <Annotation annotationId="170021hypnotic" visited={visitedNotes.has("170021hypnotic")} annotationSelect={() => {openNote("170021hypnotic"); addToVisited("170021hypnotic")}} activeAnnotationId={currentNoteId}>at the ages of 6 and 8 years had uttered in sleep an exclamation
+        (Milly) <Annotation annotationId="170021hypnotic">at the ages of 6 and 8 years had uttered in sleep an exclamation
         of terror and had replied to the interrogations of two figures in night
         attire with a vacant mute expression.</Annotation>
       </p>
@@ -1528,7 +1528,7 @@ const Ithaca = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         Circular road in the company of Elsa Potter, followed by an individual
         of sinister aspect, she went half way down Stamer street and turned
         abruptly back (reason of change not stated). On the vigil of the 15th
-        anniversary of her birth she wrote a letter from <Annotation annotationId="010126mullingar" visited={visitedNotes.has("010126mullingar")} annotationSelect={() => {openNote("010126mullingar"); addToVisited("010126mullingar")}} activeAnnotationId={currentNoteId}>Mullingar, county
+        anniversary of her birth she wrote a letter from <Annotation annotationId="010126mullingar">Mullingar, county
         Westmeath</Annotation>, making a brief allusion to a local student (faculty and year
         not stated).
       </p>
@@ -1650,7 +1650,7 @@ const Ithaca = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         return a monosyllabic negative answer?
       </p>
       <p>
-        If he had known <Annotation annotationId="060038emilysinico" visited={visitedNotes.has("060038emilysinico")} annotationSelect={() => {openNote("060038emilysinico"); addToVisited("060038emilysinico")}} activeAnnotationId={currentNoteId}>the late Mrs Emily Sinico, accidentally killed at Sydney
+        If he had known <Annotation annotationId="060038emilysinico">the late Mrs Emily Sinico, accidentally killed at Sydney
         Parade railway station, 14 October 1903</Annotation>.
       </p>
       <p>
@@ -1689,9 +1689,9 @@ const Ithaca = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         instruction, place the residence of the instructress. To inaugurate
         a series of static semistatic and peripatetic intellectual dialogues,
         places the residence of both speakers (if both speakers were resident in
-        the same place), the <Annotation annotationId="010049shiptavern" visited={visitedNotes.has("010049shiptavern")} annotationSelect={() => {openNote("010049shiptavern"); addToVisited("010049shiptavern")}} activeAnnotationId={currentNoteId}><em>Ship</em> hotel and tavern, 6 Lower Abbey street (W. and
-        E. Connery, proprietors)</Annotation>, the <Annotation annotationId="010144nationallibrary" visited={visitedNotes.has("010144nationallibrary")} annotationSelect={() => {openNote("010144nationallibrary"); addToVisited("010144nationallibrary")}} activeAnnotationId={currentNoteId}>National Library of Ireland, 10 Kildare
-        street</Annotation>, the <Annotation annotationId="140035holles" visited={visitedNotes.has("140035holles")} annotationSelect={() => {openNote("140035holles"); addToVisited("140035holles")}} activeAnnotationId={currentNoteId}>National Maternity Hospital, 29, 30 and 31 Holles street</Annotation>, a
+        the same place), the <Annotation annotationId="010049shiptavern"><em>Ship</em> hotel and tavern, 6 Lower Abbey street (W. and
+        E. Connery, proprietors)</Annotation>, the <Annotation annotationId="010144nationallibrary">National Library of Ireland, 10 Kildare
+        street</Annotation>, the <Annotation annotationId="140035holles">National Maternity Hospital, 29, 30 and 31 Holles street</Annotation>, a
         public garden, the vicinity of a place of worship, a conjunction of two
         or more public thoroughfares, the point of bisection of a right line
         drawn between their residences (if both speakers were resident in
@@ -1703,15 +1703,15 @@ const Ithaca = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <p>
         The irreparability of the past: once at a performance of Albert
-        Hengler's circus in <Annotation annotationId="060011therotunda" visited={visitedNotes.has("060011therotunda")} annotationSelect={() => {openNote("060011therotunda"); addToVisited("060011therotunda")}} activeAnnotationId={currentNoteId}>the Rotunda, Rutland square,</Annotation> Dublin, an intuitive
+        Hengler's circus in <Annotation annotationId="060011therotunda">the Rotunda, Rutland square,</Annotation> Dublin, an intuitive
         particoloured clown in quest of paternity had penetrated from the ring
         to a place in the auditorium where 
         <span data-edition="ed1939" data-page="490"> </span>
         Bloom, solitary, was<span data-edition="ed1932" data-page="601"></span> publicly declared to an exhilarated audience that he (Bloom) was his
         (the clown's) papa. The imprevidibility of the future: once in the
-        summer of 1898 he (Bloom) had marked<Annotation annotationId="010019money" visited={visitedNotes.has("010019money")} annotationSelect={() => {openNote("010019money"); addToVisited("010019money")}} activeAnnotationId={currentNoteId}> a florin (2/-)</Annotation> with three notches
+        summer of 1898 he (Bloom) had marked<Annotation annotationId="010019money"> a florin (2/-)</Annotation> with three notches
         on the milled edge and tendered it in payment of an account due to and
-        received by J. and T. Davy, family grocers, 1 Charlemont Mall, <Annotation annotationId="060016canals" visited={visitedNotes.has("060016canals")} annotationSelect={() => {openNote("060016canals"); addToVisited("060016canals")}} activeAnnotationId={currentNoteId}>Grand
+        received by J. and T. Davy, family grocers, 1 Charlemont Mall, <Annotation annotationId="060016canals">Grand
         Canal</Annotation>, for circulation on the waters of civic finance, for possible,
         circuitous or direct, return.
       </p>
@@ -1785,7 +1785,7 @@ const Ithaca = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         What comforted his misapprehension?
       </p>
       <p>
-        That as a <Annotation annotationId="010146hugekey" visited={visitedNotes.has("010146hugekey")} annotationSelect={() => {openNote("010146hugekey"); addToVisited("010146hugekey")}} activeAnnotationId={currentNoteId}>competent keyless citizen</Annotation> he had proceeded energetically from
+        That as a <Annotation annotationId="010146hugekey">competent keyless citizen</Annotation> he had proceeded energetically from
         the unknown to the known through the incertitude of the void.
       </p>
       <p>
@@ -1850,7 +1850,7 @@ const Ithaca = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         precession of equinoxes: of Orion with belt and sextuple sun theta and
         nebula in which 100 of our solar systems could be contained: of moribund
         and of nascent new stars such as Nova in 1901: of our system plunging
-        towards the constellation of Hercules: of <Annotation annotationId="080008parallax" visited={visitedNotes.has("080008parallax")} annotationSelect={() => {openNote("080008parallax"); addToVisited("080008parallax")}} activeAnnotationId={currentNoteId}>the parallax or parallactic
+        towards the constellation of Hercules: of <Annotation annotationId="080008parallax">the parallax or parallactic
         drift of socalled fixed stars, in reality evermoving wanderers</Annotation> from
         immeasurably remote eons to infinitely remote futures in comparison with
         which the years, threescore and ten, of allotted human life formed a
@@ -1930,10 +1930,10 @@ const Ithaca = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       <p>
         The various colours significant of various degrees of vitality (white,
         yellow, crimson, vermilion, cinnabar): their degrees of brilliancy:
-        <Annotation annotationId="030152delta" visited={visitedNotes.has("030152delta")} annotationSelect={() => {openNote("030152delta"); addToVisited("030152delta")}} activeAnnotationId={currentNoteId}>their magnitudes</Annotation> <span data-edition="ed1986" data-page="574"></span><Annotation annotationId="030152delta" visited={visitedNotes.has("030152delta")} annotationSelect={() => {openNote("030152delta"); addToVisited("030152delta")}} activeAnnotationId={currentNoteId}>revealed up to and including the 7th</Annotation>: their positions:
+        <Annotation annotationId="030152delta">their magnitudes</Annotation> <span data-edition="ed1986" data-page="574"></span><Annotation annotationId="030152delta">revealed up to and including the 7th</Annotation>: their positions:
         the waggoner's star: Walsingham way: the chariot of David: the annular
-        cinctures of Saturn: the <Annotation annotationId="080031gasthensolid" visited={visitedNotes.has("080031gasthensolid")} annotationSelect={() => {openNote("080031gasthensolid"); addToVisited("080031gasthensolid")}} activeAnnotationId={currentNoteId}>condensation of spiral nebulae into suns</Annotation>: the
-        <Annotation annotationId="030152delta" visited={visitedNotes.has("030152delta")} annotationSelect={() => {openNote("030152delta"); addToVisited("030152delta")}} activeAnnotationId={currentNoteId}>interdependent gyrations of double suns</Annotation>: the independent synchronous
+        cinctures of Saturn: the <Annotation annotationId="080031gasthensolid">condensation of spiral nebulae into suns</Annotation>: the
+        <Annotation annotationId="030152delta">interdependent gyrations of double suns</Annotation>: the independent synchronous
         discoveries of Galileo, Simon Marius, Piazzi, Le Verrier, Herschel,
         Galle: the systematisations attempted by Bode and Kepler of cubes
         of distances and squares of times of revolution: the almost infinite
@@ -1945,12 +1945,12 @@ const Ithaca = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         of the younger astroscopist: the annual recurrence of meteoric <span data-edition="ed1932" data-page="605"></span>showers
         about the period of the feast of S. Lawrence (martyr, l0 August): the
         monthly recurrence known as the new moon with the old moon in her arms:
-        the posited influence of celestial on human bodies: <Annotation annotationId="030152delta" visited={visitedNotes.has("030152delta")} annotationSelect={() => {openNote("030152delta"); addToVisited("030152delta")}} activeAnnotationId={currentNoteId}>the appearance of a
+        the posited influence of celestial on human bodies: <Annotation annotationId="030152delta">the appearance of a
         star (1st magnitude) of exceeding brilliancy dominating by night and
         day (a new luminous sun generated by the collision and amalgamation in
         incandescence of two nonluminous exsuns) about the period of the
         birth of William Shakespeare over delta in the recumbent neversetting
-        constellation of Cassiopeia and of a star (2nd magnitude) of</Annotation> <span data-edition="ed1961" data-page="700"></span><Annotation annotationId="030152delta" visited={visitedNotes.has("030152delta")} annotationSelect={() => {openNote("030152delta"); addToVisited("030152delta")}} activeAnnotationId={currentNoteId}>similar
+        constellation of Cassiopeia and of a star (2nd magnitude) of</Annotation> <span data-edition="ed1961" data-page="700"></span><Annotation annotationId="030152delta">similar
         origin but of lesser brilliancy which had appeared in and disappeared
         from the constellation of the Corona Septentrionalis about the period
         of the birth of Leopold Bloom and of other stars of (presumably) similar
@@ -2032,7 +2032,7 @@ const Ithaca = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         In the second storey (rere) of his (Bloom's) house the light of a
         paraffin oil lamp with oblique shade projected on a screen of roller
         blind supplied by Frank O'Hara, window blind, curtain pole and revolving
-        shutter manufacturer, 16 <Annotation annotationId="170002aungierstreet" visited={visitedNotes.has("170002aungierstreet")} annotationSelect={() => {openNote("170002aungierstreet"); addToVisited("170002aungierstreet")}} activeAnnotationId={currentNoteId}>Aungier street</Annotation>.
+        shutter manufacturer, 16 <Annotation annotationId="170002aungierstreet">Aungier street</Annotation>.
       </p>
       <p>
         How did he elucidate the mystery of an invisible attractive person, his
@@ -2068,7 +2068,7 @@ const Ithaca = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       <p>
         The trajectories of their, first sequent, then simultaneous, urinations
         were dissimilar: Bloom's longer, less irruent, in the incomplete form of
-        the bifurcated penultimate alphabetical letter, who in his <Annotation annotationId="050020highschool" visited={visitedNotes.has("050020highschool")} annotationSelect={() => {openNote("050020highschool"); addToVisited("050020highschool")}} activeAnnotationId={currentNoteId}>ultimate
+        the bifurcated penultimate alphabetical letter, who in his <Annotation annotationId="050020highschool">ultimate
         year at High School (1880)</Annotation> had been capable of attaining the point
         of greatest altitude against the whole concurrent strength of the
         institution, 210 scholars: Stephen's higher, more sibilant, who in the
@@ -2086,7 +2086,7 @@ const Ithaca = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         (1st January, holiday of obligation to hear mass 
         <span data-edition="ed1922" data-page="655"></span>
         and abstain from
-        unnecessary servile work) and the problem as to <Annotation annotationId="010087prepuces" visited={visitedNotes.has("010087prepuces")} annotationSelect={() => {openNote("010087prepuces"); addToVisited("010087prepuces")}} activeAnnotationId={currentNoteId}>whether the divine
+        unnecessary servile work) and the problem as to <Annotation annotationId="010087prepuces">whether the divine
         prepuce, the carnal bridal ring of the holy Roman catholic apostolic
         church, conserved in Calcata, were deserving of simple hyperduly or of
         the fourth degree of latria</Annotation> accorded to the abscission of such divine
@@ -2126,8 +2126,8 @@ const Ithaca = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         (respectively) centrifugal and centripetal hands?
       </p>
       <p>
-        <Annotation annotationId="010012quarterto" visited={visitedNotes.has("010012quarterto")} annotationSelect={() => {openNote("010012quarterto"); addToVisited("010012quarterto")}} activeAnnotationId={currentNoteId}>The sound of the peal of the hour of the night by the chime of the bells
-        in the church</Annotation> of <Annotation annotationId="040008georgeschurch" visited={visitedNotes.has("040008georgeschurch")} annotationSelect={() => {openNote("040008georgeschurch"); addToVisited("040008georgeschurch")}} activeAnnotationId={currentNoteId}>Saint George.</Annotation>
+        <Annotation annotationId="010012quarterto">The sound of the peal of the hour of the night by the chime of the bells
+        in the church</Annotation> of <Annotation annotationId="040008georgeschurch">Saint George.</Annotation>
       </p>
       <p>
         What echoes of that sound were by both and each heard?
@@ -2136,13 +2136,13 @@ const Ithaca = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         By Stephen:
       </p>
       <p>
-        <Annotation annotationId="010012quarterto" visited={visitedNotes.has("010012quarterto")} annotationSelect={() => {openNote("010012quarterto"); addToVisited("010012quarterto")}} activeAnnotationId={currentNoteId}><i>Liliata rutilantium. Turma circumdet.</i> <br/>
+        <Annotation annotationId="010012quarterto"><i>Liliata rutilantium. Turma circumdet.</i> <br/>
         <i>Iubilantium te virginum. Chorus excipiat.</i></Annotation>
       </p>
       <p>
         By Bloom:
       </p>
-      <p><Annotation annotationId="010012quarterto" visited={visitedNotes.has("010012quarterto")} annotationSelect={() => {openNote("010012quarterto"); addToVisited("010012quarterto")}} activeAnnotationId={currentNoteId}><i>Heigho, heigho, <br/>
+      <p><Annotation annotationId="010012quarterto"><i>Heigho, heigho, <br/>
         Heigho, heigho.</i></Annotation>
       </p>
       <span data-edition="ed1922" data-page="656"></span>
@@ -2152,8 +2152,8 @@ const Ithaca = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         to Glasnevin in the north?
       </p>
       <p>
-        <Annotation annotationId="060034martincunningham" visited={visitedNotes.has("060034martincunningham")} annotationSelect={() => {openNote("060034martincunningham"); addToVisited("060034martincunningham")}} activeAnnotationId={currentNoteId}>Martin Cunningham</Annotation> (in bed), Jack Power (in bed), Simon Dedalus (in bed),
-        Ned Lambert (in bed), <Annotation annotationId="050037tomkernan" visited={visitedNotes.has("050037tomkernan")} annotationSelect={() => {openNote("050037tomkernan"); addToVisited("050037tomkernan")}} activeAnnotationId={currentNoteId}>Tom Kernan</Annotation> (in bed), Joe Hynes (in bed), John
+        <Annotation annotationId="060034martincunningham">Martin Cunningham</Annotation> (in bed), Jack Power (in bed), Simon Dedalus (in bed),
+        Ned Lambert (in bed), <Annotation annotationId="050037tomkernan">Tom Kernan</Annotation> (in bed), Joe Hynes (in bed), John
         Henry Menton (in bed), Bernard Corrigan (in bed), Patsy Dignam (in bed),
         Paddy Dignam (in the grave).
       </p>
@@ -2174,15 +2174,15 @@ const Ithaca = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <span data-edition="ed1939" data-page="496"> </span>
       <p>
-        Of what did bellchime and handtouch and footstep and <Annotation annotationId="040063happywarmth" visited={visitedNotes.has("040063happywarmth")} annotationSelect={() => {openNote("040063happywarmth"); addToVisited("040063happywarmth")}} activeAnnotationId={currentNoteId}>lonechill</Annotation> remind
+        Of what did bellchime and handtouch and footstep and <Annotation annotationId="040063happywarmth">lonechill</Annotation> remind
         him?
       </p>
       <p>
         Of companions now in various manners in different places defunct: Percy
-        Apjohn (<Annotation annotationId="010058bloodyswindle" visited={visitedNotes.has("010058bloodyswindle")} annotationSelect={() => {openNote("010058bloodyswindle"); addToVisited("010058bloodyswindle")}} activeAnnotationId={currentNoteId}>killed in action, Modder River</Annotation>), Philip Gilligan (phthisis,
-        Jervis <span data-edition="ed1986" data-page="578"></span>Street hospital), <Annotation annotationId="060034martincunningham" visited={visitedNotes.has("060034martincunningham")} annotationSelect={() => {openNote("060034martincunningham"); addToVisited("060034martincunningham")}} activeAnnotationId={currentNoteId}>Matthew F.</Annotation> <span data-edition="ed1961" data-page="704"></span><Annotation annotationId="060034martincunningham" visited={visitedNotes.has("060034martincunningham")} annotationSelect={() => {openNote("060034martincunningham"); addToVisited("060034martincunningham")}} activeAnnotationId={currentNoteId}>Kane (accidental drowning, Dublin
+        Apjohn (<Annotation annotationId="010058bloodyswindle">killed in action, Modder River</Annotation>), Philip Gilligan (phthisis,
+        Jervis <span data-edition="ed1986" data-page="578"></span>Street hospital), <Annotation annotationId="060034martincunningham">Matthew F.</Annotation> <span data-edition="ed1961" data-page="704"></span><Annotation annotationId="060034martincunningham">Kane (accidental drowning, Dublin
         Bay)</Annotation>, Philip Moisel (pyemia, Heytesbury street), Michael Hart (phthisis,
-        <Annotation annotationId="010068themater" visited={visitedNotes.has("010068themater")} annotationSelect={() => {openNote("010068themater"); addToVisited("010068themater")}} activeAnnotationId={currentNoteId}>Mater Misericordiae hospital</Annotation>), Patrick Dignam (<Annotation annotationId="040067poordignam" visited={visitedNotes.has("040067poordignam")} annotationSelect={() => {openNote("040067poordignam"); addToVisited("040067poordignam")}} activeAnnotationId={currentNoteId}>apoplexy</Annotation>, Sandymount).
+        <Annotation annotationId="010068themater">Mater Misericordiae hospital</Annotation>), Patrick Dignam (<Annotation annotationId="040067poordignam">apoplexy</Annotation>, Sandymount).
       </p>
       <span data-edition="ed1932" data-page="609"></span>
       <p>
@@ -2196,7 +2196,7 @@ const Ithaca = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         Had he ever been a spectator of those phenomena?
       </p>
       <p>
-        Once, in 1887, after a protracted performance of charades in <Annotation annotationId="040041dolphinsbarn" visited={visitedNotes.has("040041dolphinsbarn")} annotationSelect={() => {openNote("040041dolphinsbarn"); addToVisited("040041dolphinsbarn")}} activeAnnotationId={currentNoteId}>the house
+        Once, in 1887, after a protracted performance of charades in <Annotation annotationId="040041dolphinsbarn">the house
         of Luke Doyle, Kimmage</Annotation>, he had awaited with patience the apparition
         of the diurnal phenomenon, seated on a wall, his gaze turned in the
         direction of Mizrach, the east.
@@ -2239,7 +2239,7 @@ const Ithaca = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         the door to the ingleside near the compactly furled Union Jack (an
         alteration which he had frequently intended to execute): the blue and
         white checker inlaid majolicatopped table had been placed opposite the
-        door in the place vacated by the prune plush sofa: the walnut <Annotation annotationId="020027sideboard" visited={visitedNotes.has("020027sideboard")} annotationSelect={() => {openNote("020027sideboard"); addToVisited("020027sideboard")}} activeAnnotationId={currentNoteId}>sideboard</Annotation>
+        door in the place vacated by the prune plush sofa: the walnut <Annotation annotationId="020027sideboard">sideboard</Annotation>
         (a projecting angle of which had momentarily arrested his ingress) <span data-edition="ed1961" data-page="705"></span>had
         been moved from its position beside the door to a more advantageous but
         more perilous position <span data-edition="ed1986" data-page="579"></span>in front of the door: two chairs had been moved
@@ -2277,7 +2277,7 @@ const Ithaca = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         A vertical piano (Cadby) with exposed keyboard, its closed coffin
         supporting a pair of long yellow ladies' gloves and an emerald ashtray
         containing four consumed matches, a partly consumed cigarette and two
-        discoloured ends of cigarettes, its musicrest supporting the <Annotation annotationId="040035oldsweetsong" visited={visitedNotes.has("040035oldsweetsong")} annotationSelect={() => {openNote("040035oldsweetsong"); addToVisited("040035oldsweetsong")}} activeAnnotationId={currentNoteId}>music in
+        discoloured ends of cigarettes, its musicrest supporting the <Annotation annotationId="040035oldsweetsong">music in
         the key of G natural for voice and piano of <i>Love's Old Sweet Song</i>
         (words by G. Clifton Bingham, composed by J. L. Molloy, sung by Madam
         Antoinette Sterling)</Annotation> open at the last page with the final indications
@@ -2292,7 +2292,7 @@ const Ithaca = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         temple a contused tumescence: with attention, focussing his gaze on
         a large dull passive and a slender bright active: with solicitation,
         bending and downturning the upturned rugfringe: with amusement,
-        remembering <Annotation annotationId="010031snotgreen" visited={visitedNotes.has("010031snotgreen")} annotationSelect={() => {openNote("010031snotgreen"); addToVisited("010031snotgreen")}} activeAnnotationId={currentNoteId}>Dr Malachi Mulligan's scheme of colour containing the
+        remembering <Annotation annotationId="010031snotgreen">Dr Malachi Mulligan's scheme of colour containing the
         gradation of green</Annotation>: with pleasure, repeating the words and antecedent
         act and perceiving <span data-edition="ed1961" data-page="706"></span>through various channels of internal sensibility
         the consequent and concomitant tepid pleasant diffusion of gradual
@@ -2305,7 +2305,7 @@ const Ithaca = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         From an open box on the majolicatopped table he extracted a black
         diminutive cone, one inch in height, placed it on its circular base on
         a small tin plate, placed his candlestick on the right corner of the
-        mantelpiece, produced from his waistcoat <Annotation annotationId="040061agendath" visited={visitedNotes.has("040061agendath")} annotationSelect={() => {openNote("040061agendath"); addToVisited("040061agendath")}} activeAnnotationId={currentNoteId}>a folded page of prospectus
+        mantelpiece, produced from his waistcoat <Annotation annotationId="040061agendath">a folded page of prospectus
         (illustrated) entitled Agendath Netaim</Annotation>, unfolded the same, examined
         it <span data-edition="ed1932" data-page="611"></span>superficially, <span data-edition="ed1986" data-page="580"></span>rolled it into a thin cylinder, ignited it in the
         candleflame, applied it when ignited to the apex of the cone till the
@@ -2327,10 +2327,10 @@ const Ithaca = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       <span data-edition="ed1922" data-page="659"></span>
       <p>
         A timepiece of striated Connemara marble, stopped at the hour of 4.46
-        a.m. on the 21 March 1896, matrimonial gift of<Annotation annotationId="170008precedingseries" visited={visitedNotes.has("170008precedingseries")} annotationSelect={() => {openNote("170008precedingseries"); addToVisited("170008precedingseries")}} activeAnnotationId={currentNoteId}> Matthew Dillon</Annotation>: a dwarf
+        a.m. on the 21 March 1896, matrimonial gift of<Annotation annotationId="170008precedingseries"> Matthew Dillon</Annotation>: a dwarf
         tree of glacial arborescence under a transparent bellshade, matrimonial
-        gift of <Annotation annotationId="040041dolphinsbarn" visited={visitedNotes.has("040041dolphinsbarn")} annotationSelect={() => {openNote("040041dolphinsbarn"); addToVisited("040041dolphinsbarn")}} activeAnnotationId={currentNoteId}>Luke and Caroline Doyle</Annotation>: an embalmed owl, matrimonial gift of
-        <Annotation annotationId="170008precedingseries" visited={visitedNotes.has("170008precedingseries")} annotationSelect={() => {openNote("170008precedingseries"); addToVisited("170008precedingseries")}} activeAnnotationId={currentNoteId}>Alderman John Hooper</Annotation>.
+        gift of <Annotation annotationId="040041dolphinsbarn">Luke and Caroline Doyle</Annotation>: an embalmed owl, matrimonial gift of
+        <Annotation annotationId="170008precedingseries">Alderman John Hooper</Annotation>.
       </p>
       <span data-edition="ed1939" data-page="498"> </span>
       <p>
@@ -2410,13 +2410,13 @@ const Ithaca = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         <i>Thoughts from Spinoza</i> (maroon leather).
       </p>
       <p>
-        <Annotation annotationId="080008parallax" visited={visitedNotes.has("080008parallax")} annotationSelect={() => {openNote("080008parallax"); addToVisited("080008parallax")}} activeAnnotationId={currentNoteId}><i>The Story of the Heavens</i> by Sir Robert Ball (blue cloth).</Annotation> 
+        <Annotation annotationId="080008parallax"><i>The Story of the Heavens</i> by Sir Robert Ball (blue cloth).</Annotation> 
       </p>
       <p>
         Ellis's <i>Three Trips to Madagascar</i> (brown cloth, title obliterated).
       </p>
       <p>
-        <i>The Stark-Munro Letters</i> by A. Conan Doyle, property of the <Annotation annotationId="040043capelstreet" visited={visitedNotes.has("040043capelstreet")} annotationSelect={() => {openNote("040043capelstreet"); addToVisited("040043capelstreet")}} activeAnnotationId={currentNoteId}>City of
+        <i>The Stark-Munro Letters</i> by A. Conan Doyle, property of the <Annotation annotationId="040043capelstreet">City of
         Dublin Public Library, 106 Capel street</Annotation>, lent 21 May (Whitsun Eve) 1904,
         due 4 June 1904, 13 days overdue (black cloth binding, bearing white
         letternumber ticket).
@@ -2459,11 +2459,11 @@ const Ithaca = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       <span data-edition="ed1932" data-page="613"></span>
       <span data-edition="ed1922" data-page="661"></span>
       <p>
-        <Annotation annotationId="040026trackofthesun" visited={visitedNotes.has("040026trackofthesun")} annotationSelect={() => {openNote("040026trackofthesun"); addToVisited("040026trackofthesun")}} activeAnnotationId={currentNoteId}><i>In the Track of the Sun</i></Annotation> (yellow cloth, titlepage missing, recurrent
+        <Annotation annotationId="040026trackofthesun"><i>In the Track of the Sun</i></Annotation> (yellow cloth, titlepage missing, recurrent
         title intestation).
       </p>
       <p>
-        <Annotation annotationId="040024sandow" visited={visitedNotes.has("040024sandow")} annotationSelect={() => {openNote("040024sandow"); addToVisited("040024sandow")}} activeAnnotationId={currentNoteId}><i>Physical Strength and How to Obtain It</i></Annotation> by Eugen Sandow (red cloth).
+        <Annotation annotationId="040024sandow"><i>Physical Strength and How to Obtain It</i></Annotation> by Eugen Sandow (red cloth).
       </p>
       <p>
         <i>Short but yet Plain Elements of Geometry</i> written in French by F.
@@ -2500,7 +2500,7 @@ const Ithaca = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         contain?
       </p>
       <p>
-        The <Annotation annotationId="040018oldtweedy" visited={visitedNotes.has("040018oldtweedy")} annotationSelect={() => {openNote("040018oldtweedy"); addToVisited("040018oldtweedy")}} activeAnnotationId={currentNoteId}>name of a decisive battle (forgotten), frequently remembered by a
+        The <Annotation annotationId="040018oldtweedy">name of a decisive battle (forgotten), frequently remembered by a
         decisive officer, major Brian Cooper Tweedy (remembered)</Annotation>.
       </p>
       <p>
@@ -2519,7 +2519,7 @@ const Ithaca = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <p>
         The candour, nudity, pose, tranquility, youth, grace, sex, counsel of a
-        statue erect in the centre of the table, <Annotation annotationId="080005venus" visited={visitedNotes.has("080005venus")} annotationSelect={() => {openNote("080005venus"); addToVisited("080005venus")}} activeAnnotationId={currentNoteId}>an image of Narcissus</Annotation> purchased
+        statue erect in the centre of the table, <Annotation annotationId="080005venus">an image of Narcissus</Annotation> purchased
         by auction from P. A. Wren, 9 Bachelor's Walk.
       </p>
       <span data-edition="ed1932" data-page="614"></span>
@@ -2560,7 +2560,7 @@ const Ithaca = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         prurition, various points and surfaces of his partly exposed, wholly
         abluted skin. He inserted his left hand into the left lower pocket of
         his waistcoat and extracted and replaced a silver coin (1 shilling),
-        placed there (presumably) on <Annotation annotationId="060038emilysinico" visited={visitedNotes.has("060038emilysinico")} annotationSelect={() => {openNote("060038emilysinico"); addToVisited("060038emilysinico")}} activeAnnotationId={currentNoteId}>the occasion (17 October 1903) of the
+        placed there (presumably) on <Annotation annotationId="060038emilysinico">the occasion (17 October 1903) of the
         interment of Mrs Emily Sinico, Sydney Parade</Annotation>.
       </p>
       <span data-edition="ed1922" data-page="663"></span>
@@ -2805,12 +2805,12 @@ const Ithaca = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         What additional attractions might the grounds contain?
       </p>
       <p>
-        As addenda, a tennis and fives court, a shrubbery, <Annotation annotationId="050025botanicgardens" visited={visitedNotes.has("050025botanicgardens")} annotationSelect={() => {openNote("050025botanicgardens"); addToVisited("050025botanicgardens")}} activeAnnotationId={currentNoteId}>a glass summerhouse
+        As addenda, a tennis and fives court, a shrubbery, <Annotation annotationId="050025botanicgardens">a glass summerhouse
         with tropical palms, equipped in the best botanical manner,</Annotation> a rockery
         with waterspray, a beehive arranged <span data-edition="ed1961" data-page="713"></span>on humane principles, oval
         flowerbeds in rectangular grassplots set with eccentric ellipses of
         scarlet and chrome tulips, blue scillas, crocuses, polyanthus, sweet
-        William, sweet pea, lily of the valley <Annotation annotationId="170011jamesmackey" visited={visitedNotes.has("170011jamesmackey")} annotationSelect={() => {openNote("170011jamesmackey"); addToVisited("170011jamesmackey")}} activeAnnotationId={currentNoteId}>(bulbs obtainable from sir James
+        William, sweet pea, lily of the valley <Annotation annotationId="170011jamesmackey">(bulbs obtainable from sir James
         W. Mackey Limited, wholesale and retail seed and bulb merchants and
         nurserymen, agents for chemical manures, 23 Sackville street, upper)</Annotation>, an
         orchard, kitchen garden and vinery protected against illegal trespassers
@@ -2857,7 +2857,7 @@ const Ithaca = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         Bloom Cottage. Saint Leopold's. Flowerville.
       </p>
       <p>
-        Could <Annotation annotationId="040005seveneccles" visited={visitedNotes.has("040005seveneccles")} annotationSelect={() => {openNote("040005seveneccles"); addToVisited("040005seveneccles")}} activeAnnotationId={currentNoteId}>Bloom of 7 Eccles street</Annotation> foresee Bloom of Flowerville?
+        Could <Annotation annotationId="040005seveneccles">Bloom of 7 Eccles street</Annotation> foresee Bloom of Flowerville?
       </p>
       <p>
         In loose allwool garments with Harris tweed cap, price 8/6, and useful
@@ -2884,7 +2884,7 @@ const Ithaca = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         unmolested river boating in secure wherry or light curricle with kedge
         anchor on reaches free from weirs and rapids (period of estivation),
         vespertinal perambulation or equestrian circumprocession with inspection
-        of sterile landscape and contrastingly agreeable <Annotation annotationId="060036bogs" visited={visitedNotes.has("060036bogs")} annotationSelect={() => {openNote("060036bogs"); addToVisited("060036bogs")}} activeAnnotationId={currentNoteId}>cottagers' fires of
+        of sterile landscape and contrastingly agreeable <Annotation annotationId="060036bogs">cottagers' fires of
         smoking peat turves</Annotation> (period of hibernation). Indoor: discussion in
         tepid security of unsolved historical and 
         <span data-edition="ed1922" data-page="667"></span>
@@ -2927,7 +2927,7 @@ const Ithaca = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         <span data-edition="ed1939" data-page="504"> </span>
         of greater and lesser social inequality,
         of unbiassed homogeneous indisputable justice, tempered with mitigants
-        of the widest possible latitude but exactable <Annotation annotationId="010019money" visited={visitedNotes.has("010019money")} annotationSelect={() => {openNote("010019money"); addToVisited("010019money")}} activeAnnotationId={currentNoteId}>to the uttermost farthing</Annotation>
+        of the widest possible latitude but exactable <Annotation annotationId="010019money">to the uttermost farthing</Annotation>
         with confiscation of estate, real and personal, to the crown. Loyal to
         the highest constituted power in the land, actuated by an innate love of
         rectitude his aims would be the strict maintenance of public order,
@@ -2947,7 +2947,7 @@ const Ithaca = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         Prove that he had loved rectitude from his earliest youth.
       </p>
       <p>
-        To Master Percy Apjohn <Annotation annotationId="050020highschool" visited={visitedNotes.has("050020highschool")} annotationSelect={() => {openNote("050020highschool"); addToVisited("050020highschool")}} activeAnnotationId={currentNoteId}>at High School in 1880</Annotation> he had divulged his
+        To Master Percy Apjohn <Annotation annotationId="050020highschool">at High School in 1880</Annotation> he had divulged his
         disbelief in the tenets of the Irish (protestant) church (to which his
         father Rudolf Virag (later Rudolph Bloom) had been converted from the
         Israelitic faith and communion in 1865 by the Society for promoting
@@ -3006,11 +3006,11 @@ const Ithaca = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         8 m. p.m. at Ascot (Greenwich time), the message being received and
         available for betting purposes in Dublin at 2.59 p.m. (Dunsink time).
         The unexpected discovery of an object of great monetary value (precious
-        stone, valuable adhesive or impressed <Annotation annotationId="020080mauve" visited={visitedNotes.has("020080mauve")} annotationSelect={() => {openNote("020080mauve"); addToVisited("020080mauve")}} activeAnnotationId={currentNoteId}>postage stamps (7 shilling,
+        stone, valuable adhesive or impressed <Annotation annotationId="020080mauve">postage stamps (7 shilling,
         mauve, imperforate, Hamburg, 1866</Annotation>: 4 pence, rose, blue paper, perforate,
         Great Britain, 1855: 1 franc, stone, official, rouletted, diagonal
         surcharge, Luxemburg, 1878), antique dynastical ring, unique relic in
-        unusual <span data-edition="ed1932" data-page="621"></span>repositories or by unusual means: from the air (<Annotation annotationId="170009sinbadsailor" visited={visitedNotes.has("170009sinbadsailor")} annotationSelect={() => {openNote("170009sinbadsailor"); addToVisited("170009sinbadsailor")}} activeAnnotationId={currentNoteId}>dropped by an
+        unusual <span data-edition="ed1932" data-page="621"></span>repositories or by unusual means: from the air (<Annotation annotationId="170009sinbadsailor">dropped by an
         eagle</Annotation> in <span data-edition="ed1986" data-page="589"></span>flight), by fire (amid the carbonised remains of an incendiated
         edifice), in the sea (amid flotsam, jetsam, lagan and derelict), on
         <span data-edition="ed1961" data-page="717"></span>earth (in the gizzard of a comestible fowl). A Spanish prisoner's
@@ -3020,7 +3020,7 @@ const Ithaca = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         pounds sterling). A contract with an inconsiderate contractee for the
         delivery of 32 consignments of some given commodity in consideration of
         cash payment on delivery per delivery at the initial rate of ¼d. to be
-        increased constantly in the geometrical progression of 2 (¼d., ½d., 1d., 2d., 4d., 8d., 1s. 4d., 2s. 8d. to 32 terms). A prepared <Annotation annotationId="040059shortknock" visited={visitedNotes.has("040059shortknock")} annotationSelect={() => {openNote("040059shortknock"); addToVisited("040059shortknock")}} activeAnnotationId={currentNoteId}>scheme</Annotation>
+        increased constantly in the geometrical progression of 2 (¼d., ½d., 1d., 2d., 4d., 8d., 1s. 4d., 2s. 8d. to 32 terms). A prepared <Annotation annotationId="040059shortknock">scheme</Annotation>
         based on a study of the laws of probability to break the bank at Monte
         Carlo. A solution of the secular problem of the quadrature of the
         circle, government premium £1,000,000 sterling.
@@ -3029,8 +3029,8 @@ const Ithaca = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         Was vast wealth acquirable through industrial channels?
       </p>
       <p>
-        <Annotation annotationId="040061agendath" visited={visitedNotes.has("040061agendath")} annotationSelect={() => {openNote("040061agendath"); addToVisited("040061agendath")}} activeAnnotationId={currentNoteId}>The reclamation of dunams of waste arenary soil, proposed in the
-        prospectus of Agendath Netaim</Annotation>, <Annotation annotationId="040064bleibtreustrasse" visited={visitedNotes.has("040064bleibtreustrasse")} annotationSelect={() => {openNote("040064bleibtreustrasse"); addToVisited("040064bleibtreustrasse")}} activeAnnotationId={currentNoteId}>Bleibtreustrasse, Berlin, W. 15</Annotation>, by the
+        <Annotation annotationId="040061agendath">The reclamation of dunams of waste arenary soil, proposed in the
+        prospectus of Agendath Netaim</Annotation>, <Annotation annotationId="040064bleibtreustrasse">Bleibtreustrasse, Berlin, W. 15</Annotation>, by the
         cultivation of orange plantations and melonfields and reafforestation.
         The utilisation of waste paper, fells of sewer rodents, human excrement
         possessing chemical properties, in view of the vast production of the
@@ -3060,12 +3060,12 @@ const Ithaca = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         A scheme for the use of dogvans and goatvans for the delivery of early
         morning milk. A scheme for the development of Irish tourist <span data-edition="ed1932" data-page="622"></span>traffic in
         and around Dublin by means of petrolpropelled riverboats, <span data-edition="ed1961" data-page="718"></span>plying in the
-        fluvial fairway between Island bridge and  <Annotation annotationId="030099ringsend" visited={visitedNotes.has("030099ringsend")} annotationSelect={() => {openNote("030099ringsend"); addToVisited("030099ringsend")}} activeAnnotationId={currentNoteId}>Ringsend</Annotation>, charabancs, narrow
+        fluvial fairway between Island bridge and  <Annotation annotationId="030099ringsend">Ringsend</Annotation>, charabancs, narrow
         gauge local railways, and pleasure steamers for coastwise navigation
         (10/- per person per day, guide (trilingual) included). A scheme for
         the repristination of passenger and goods traffics over Irish waterways,
-        when freed from weedbeds. <Annotation annotationId="040037cattlemarket" visited={visitedNotes.has("040037cattlemarket")} annotationSelect={() => {openNote("040037cattlemarket"); addToVisited("040037cattlemarket")}} activeAnnotationId={currentNoteId}>A scheme to connect by tramline the Cattle
-        Market (North</Annotation> <span data-edition="ed1986" data-page="590"></span><Annotation annotationId="040037cattlemarket" visited={visitedNotes.has("040037cattlemarket")} annotationSelect={() => {openNote("040037cattlemarket"); addToVisited("040037cattlemarket")}} activeAnnotationId={currentNoteId}>Circular road and Prussia street) with the quays</Annotation> (Sheriff
+        when freed from weedbeds. <Annotation annotationId="040037cattlemarket">A scheme to connect by tramline the Cattle
+        Market (North</Annotation> <span data-edition="ed1986" data-page="590"></span><Annotation annotationId="040037cattlemarket">Circular road and Prussia street) with the quays</Annotation> (Sheriff
         street, lower, and East Wall), parallel with the Link line railway
         laid (in conjunction with the Great Southern and Western railway line)
         between the cattle park, Liffey junction, and terminus of Midland Great
@@ -3080,7 +3080,7 @@ const Ithaca = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         and Company, steamship owners, agents for steamers from Mediterranean,
         Spain, Portugal, France, Belgium and Holland and for Liverpool
         Underwriters' Association, the cost of acquired rolling stock for
-        animal transport and of additional mileage operated by the <Annotation annotationId="070003tramwaycompany" visited={visitedNotes.has("070003tramwaycompany")} annotationSelect={() => {openNote("070003tramwaycompany"); addToVisited("070003tramwaycompany")}} activeAnnotationId={currentNoteId}>Dublin United
+        animal transport and of additional mileage operated by the <Annotation annotationId="070003tramwaycompany">Dublin United
         Tramways Company, limited</Annotation>, to be covered by graziers' fees.
       </p>
       <span data-edition="ed1922" data-page="671"></span>
@@ -3121,7 +3121,7 @@ const Ithaca = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         life at least 2/7ths, viz., 20 years are passed in sleep. As a philosopher
         he knew that at the termination of any allotted life only an
         infinitesimal part of any person's desires has been realised. As a
-        physiologist he believed in the artificial placation of <Annotation annotationId="170021hypnotic" visited={visitedNotes.has("170021hypnotic")} annotationSelect={() => {openNote("170021hypnotic"); addToVisited("170021hypnotic")}} activeAnnotationId={currentNoteId}>malignant
+        physiologist he believed in the artificial placation of <Annotation annotationId="170021hypnotic">malignant
         agencies chiefly operative during somnolence</Annotation>.
       </p>
       <span data-edition="ed1939" data-page="507"> </span>
@@ -3163,25 +3163,25 @@ const Ithaca = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         from same department of same firm: an old sandglass which rolled
         <span data-edition="ed1961" data-page="720"></span>containing sand which rolled: a sealed prophecy (never unsealed) written
         by Leopold Bloom in 1886 concerning the consequences of the passing into
-        law of <Annotation annotationId="020037oldtory" visited={visitedNotes.has("020037oldtory")} annotationSelect={() => {openNote("020037oldtory"); addToVisited("020037oldtory")}} activeAnnotationId={currentNoteId}>William Ewart Gladstone's Home Rule bill of 1886</Annotation> (never passed
+        law of <Annotation annotationId="020037oldtory">William Ewart Gladstone's Home Rule bill of 1886</Annotation> (never passed
         into law): a bazaar ticket, N° 2004, of S. Kevin's Charity Fair, <span data-edition="ed1932" data-page="624"></span>price
         6d. 100 prizes: an infantile epistle, dated, small em monday, reading:
         capital pee Papli comma capital aitch How are you note of interrogation
         capital eye I am very well full stop new paragraph signature with
         flourishes capital em Milly no stop: a cameo brooch, property of Ellen
         Bloom (born Higgins), deceased: 3 typewritten letters, addressee, Henry
-        Flower, c/o P. O. Westland Row, addresser, Martha Clifford, <Annotation annotationId="040041dolphinsbarn" visited={visitedNotes.has("040041dolphinsbarn")} annotationSelect={() => {openNote("040041dolphinsbarn"); addToVisited("040041dolphinsbarn")}} activeAnnotationId={currentNoteId}>c/o P. O.
-        Dolphin's Barn</Annotation>: <Annotation annotationId="170012boustrophedontic" visited={visitedNotes.has("170012boustrophedontic")} annotationSelect={() => {openNote("170012boustrophedontic"); addToVisited("170012boustrophedontic")}} activeAnnotationId={currentNoteId}>the transliterated name and address of the addresser
+        Flower, c/o P. O. Westland Row, addresser, Martha Clifford, <Annotation annotationId="040041dolphinsbarn">c/o P. O.
+        Dolphin's Barn</Annotation>: <Annotation annotationId="170012boustrophedontic">the transliterated name and address of the addresser
         of the 3 letters in reversed alphabetic boustrophedontic punctated
         quadrilinear cryptogram (vowels suppressed) N. IGS. /WI. UU. OX/W. OKS.
-        MH/Y. IM</Annotation>: a press cutting from <Annotation annotationId="160004newspapers" visited={visitedNotes.has("160004newspapers")} annotationSelect={() => {openNote("160004newspapers"); addToVisited("160004newspapers")}} activeAnnotationId={currentNoteId}>an English weekly periodical <i>Modern
+        MH/Y. IM</Annotation>: a press cutting from <Annotation annotationId="160004newspapers">an English weekly periodical <i>Modern
         Society</i></Annotation>, subject corporal chastisement in girls' schools: a pink ribbon
         which had festooned an Easter egg in the year 1899: two partly uncoiled
         rubber preservatives with reserve pockets, purchased by post from Box
         32, P. O., Charing Cross, London, W. C.: <span data-edition="ed1986" data-page="592"></span>1 pack of 1 dozen creamlaid
         envelopes and feintruled notepaper, watermarked, now reduced by 3: some
         assorted Austrian-Hungarian coins: 2 coupons of the Royal and Privileged
-        Hungarian Lottery: a lowpower magnifying glass: 2 <Annotation annotationId="010127photogirl" visited={visitedNotes.has("010127photogirl")} annotationSelect={() => {openNote("010127photogirl"); addToVisited("010127photogirl")}} activeAnnotationId={currentNoteId}>erotic photocards</Annotation>
+        Hungarian Lottery: a lowpower magnifying glass: 2 <Annotation annotationId="010127photogirl">erotic photocards</Annotation>
         showing a) buccal coition between nude señorita (rere presentation,
         superior position) and nude torero (fore presentation, inferior
         position) b) anal violation by male religious (fully clothed, eyes
@@ -3193,7 +3193,7 @@ const Ithaca = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         <span data-edition="ed1939" data-page="508"> </span>
         of Queen Victoria: a chart of the measurements
         of Leopold Bloom compiled before, during and after 2 months' consecutive
-        use of <Annotation annotationId="040024sandow" visited={visitedNotes.has("040024sandow")} annotationSelect={() => {openNote("040024sandow"); addToVisited("040024sandow")}} activeAnnotationId={currentNoteId}>Sandow-Whiteley's pulley exerciser</Annotation> (men's 15/-, athlete's 20/-)
+        use of <Annotation annotationId="040024sandow">Sandow-Whiteley's pulley exerciser</Annotation> (men's 15/-, athlete's 20/-)
         viz., chest 28 in. and 29½ in., biceps 9 in. and 10 in., forearm 8½
         and 9 in., thigh 10 in. and 12 in., calf 11 in. and 12 in.: 1 prospectus of
         the Wonderworker, the world's greatest remedy for rectal complaints,
@@ -3221,7 +3221,7 @@ const Ithaca = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <p>
         Numerous. From clergyman, British naval officer, wellknown author, city
-        man, hospital nurse, lady, mother of five, <Annotation annotationId="090001absentminded" visited={visitedNotes.has("090001absentminded")} annotationSelect={() => {openNote("090001absentminded"); addToVisited("090001absentminded")}} activeAnnotationId={currentNoteId}>absentminded beggar</Annotation>. 
+        man, hospital nurse, lady, mother of five, <Annotation annotationId="090001absentminded">absentminded beggar</Annotation>. 
       </p>
       <p>
         How did absentminded beggar's concluding testimonial conclude?
@@ -3263,7 +3263,7 @@ const Ithaca = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <span data-edition="ed1961" data-page="722"></span>
       <p>
-        Documents: <Annotation annotationId="040030leopoldbloom" visited={visitedNotes.has("040030leopoldbloom")} annotationSelect={() => {openNote("040030leopoldbloom"); addToVisited("040030leopoldbloom")}} activeAnnotationId={currentNoteId}>the birth certificate of Leopold Paula Bloom</Annotation>: <Annotation annotationId="130007scottishwidows" visited={visitedNotes.has("130007scottishwidows")} annotationSelect={() => {openNote("130007scottishwidows"); addToVisited("130007scottishwidows")}} activeAnnotationId={currentNoteId}>an endowment
+        Documents: <Annotation annotationId="040030leopoldbloom">the birth certificate of Leopold Paula Bloom</Annotation>: <Annotation annotationId="130007scottishwidows">an endowment
         assurance policy of £500 in the Scottish Widows' Assurance
         Society</Annotation>, intestated Millicent (Milly) Bloom, coming into force at 25
         years as with profit policy of £430, £462-10-0 and £500 at
@@ -3297,7 +3297,7 @@ const Ithaca = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         An indistinct daguerreotype of Rudolph Virag and his father Leopold
         Virag executed in the year 1852 in the portrait atelier of their
         (respectively) 1st and 2nd cousin, Stefan Virag of Szesfehervar,
-        Hungary. <Annotation annotationId="060043passover" visited={visitedNotes.has("060043passover")} annotationSelect={() => {openNote("060043passover"); addToVisited("060043passover")}} activeAnnotationId={currentNoteId}>An ancient hagadah book in which a pair of hornrimmed convex
+        Hungary. <Annotation annotationId="060043passover">An ancient hagadah book in which a pair of hornrimmed convex
         spectacles inserted marked the passage of thanksgiving in the ritual
         prayers for Pessach (Passover)</Annotation>: a photocard of the Queen's Hotel,
         Ennis, proprietor, Rudolph Bloom: an envelope addressed: <i>To My Dear Son
@@ -3312,7 +3312,7 @@ const Ithaca = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       <p>
         Tomorrow will be a week that I received... it is no use Leopold to be
         ... with your dear mother... that is not more to stand... to her...
-        all for me is out... be kind to <Annotation annotationId="060004athos" visited={visitedNotes.has("060004athos")} annotationSelect={() => {openNote("060004athos"); addToVisited("060004athos")}} activeAnnotationId={currentNoteId}>Athos</Annotation>, Leopold... my dear son...
+        all for me is out... be kind to <Annotation annotationId="060004athos">Athos</Annotation>, Leopold... my dear son...
         always... of me... <i>das Herz... Gott... dein</i>...
       </p>
       <span data-edition="ed1961" data-page="723"></span>
@@ -3322,7 +3322,7 @@ const Ithaca = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <p>
         An old man, widower, unkempt of hair, in bed, with head covered,
-        sighing: an infirm dog, Athos: <Annotation annotationId="150007aconite" visited={visitedNotes.has("150007aconite")} annotationSelect={() => {openNote("150007aconite"); addToVisited("150007aconite")}} activeAnnotationId={currentNoteId}>aconite, resorted to by increasing doses
+        sighing: an infirm dog, Athos: <Annotation annotationId="150007aconite">aconite, resorted to by increasing doses
         of grains and scruples as a palliative of recrudescent neuralgia</Annotation>: the
         face in death of a septuagenarian suicide by poison.
       </p>
@@ -3356,7 +3356,7 @@ const Ithaca = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         What first reminiscence had he of Rudolph Bloom (deceased)?
       </p>
       <p>
-        Rudolph Bloom (deceased) narrated to his son Leopold Bloom (aged 6) <Annotation annotationId="060030retrospective" visited={visitedNotes.has("060030retrospective")} annotationSelect={() => {openNote("060030retrospective"); addToVisited("060030retrospective")}} activeAnnotationId={currentNoteId}>a
+        Rudolph Bloom (deceased) narrated to his son Leopold Bloom (aged 6) <Annotation annotationId="060030retrospective">a
         retrospective arrangement</Annotation> of migrations and settlements in and between
         Dublin, London, Florence, Milan, Vienna, Budapest, Szombathely with
         statements of satisfaction (his grandfather having seen Maria Theresia,
@@ -3462,7 +3462,7 @@ const Ithaca = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         What considerations rendered it not irrational?
       </p>
       <p>
-        <Annotation annotationId="080028multiply" visited={visitedNotes.has("080028multiply")} annotationSelect={() => {openNote("080028multiply"); addToVisited("080028multiply")}} activeAnnotationId={currentNoteId}>The parties concerned, uniting, had increased and multiplied</Annotation>, which
+        <Annotation annotationId="080028multiply">The parties concerned, uniting, had increased and multiplied</Annotation>, which
         being done, offspring produced and educed to maturity, the parties, if
         not disunited were obliged to reunite for increase and multiplication,
         which was absurd, to form by reunion the original couple of uniting
@@ -3481,7 +3481,7 @@ const Ithaca = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         In Ireland?
       </p>
       <p>
-        <Annotation annotationId="170019localities" visited={visitedNotes.has("170019localities")} annotationSelect={() => {openNote("170019localities"); addToVisited("170019localities")}} activeAnnotationId={currentNoteId}>The cliffs of Moher, the windy wilds of Connemara, lough Neagh with
+        <Annotation annotationId="170019localities">The cliffs of Moher, the windy wilds of Connemara, lough Neagh with
         submerged petrified city, the Giant's Causeway, Fort Camden and Fort
         Carlisle, the Golden Vale of Tipperary, the islands of Aran, the
         pastures of royal Meath, Brigid's elm in Kildare, the Queen's Island
@@ -3492,7 +3492,7 @@ const Ithaca = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         Abroad?
       </p>
       <p>
-        Ceylon (with spicegardens supplying tea to <Annotation annotationId="050037tomkernan" visited={visitedNotes.has("050037tomkernan")} annotationSelect={() => {openNote("050037tomkernan"); addToVisited("050037tomkernan")}} activeAnnotationId={currentNoteId}>Thomas Kernan, agent for
+        Ceylon (with spicegardens supplying tea to <Annotation annotationId="050037tomkernan">Thomas Kernan, agent for
         Pulbrook, Robertson and Co, 2 Mincing Lane, London, E. C., 5 Dame
         street, Dublin)</Annotation>, Jerusalem, the holy city <span data-edition="ed1961" data-page="726"></span>(with mosque of Omar and gate
         of Damascus, goal of aspiration), the straits of Gibraltar (the unique
@@ -3522,7 +3522,7 @@ const Ithaca = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         What public advertisement would divulge the occultation of the departed?
       </p>
       <p>
-        £5 reward, lost, stolen or strayed from <Annotation annotationId="040005seveneccles" visited={visitedNotes.has("040005seveneccles")} annotationSelect={() => {openNote("040005seveneccles"); addToVisited("040005seveneccles")}} activeAnnotationId={currentNoteId}>his residence 7 Eccles
+        £5 reward, lost, stolen or strayed from <Annotation annotationId="040005seveneccles">his residence 7 Eccles
         street</Annotation>, missing gent about 40, answering to the name of Bloom, Leopold
         (Poldy), height 5 ft. 9½ inches, full build, olive complexion, may
         have since grown a beard, when last seen was wearing a black suit. Above
@@ -3577,7 +3577,7 @@ const Ithaca = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         <span data-edition="ed1932" data-page="631"></span>rendering perilous: the necessity for repose, obviating movement: the
         proximity of an occupied bed, obviating research: the anticipation of
         warmth (human) tempered with coolness (linen), obviating desire and
-        rendering desirable: <Annotation annotationId="080005venus" visited={visitedNotes.has("080005venus")} annotationSelect={() => {openNote("080005venus"); addToVisited("080005venus")}} activeAnnotationId={currentNoteId}>the statue of Narcissus</Annotation>, sound without echo,
+        rendering desirable: <Annotation annotationId="080005venus">the statue of Narcissus</Annotation>, sound without echo,
         desired desire.
       </p>
       <p>
@@ -3602,14 +3602,14 @@ const Ithaca = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         funeral (rite of Samuel): the advertisement of Alexander Keyes (Urim and
         <span data-edition="ed1922" data-page="680"></span>
         Thummim): the <span data-edition="ed1961" data-page="728"></span>unsubstantial lunch (rite of Melchisedek): the visit to
-        <Annotation annotationId="010144nationallibrary" visited={visitedNotes.has("010144nationallibrary")} annotationSelect={() => {openNote("010144nationallibrary"); addToVisited("010144nationallibrary")}} activeAnnotationId={currentNoteId}>museum and national library</Annotation> (holy place): the bookhunt along Bedford
+        <Annotation annotationId="010144nationallibrary">museum and national library</Annotation> (holy place): the bookhunt along Bedford
         row, Merchants' Arch, Wellington Quay (Simchath Torah): the music in the
         Ormond Hotel (Shira Shirim): the altercation with a truculent troglodyte
         in Bernard Kiernan's premises (holocaust): a blank period of time
         including a cardrive, a visit to a house of mourning, a leavetaking
         (wilderness): the eroticism produced by feminine exhibitionism (rite of
         Onan): the prolonged delivery of Mrs Mina Purefoy (heave offering):
-        the visit to the disorderly house of Mrs Bella Cohen, <Annotation annotationId="150005nighttown" visited={visitedNotes.has("150005nighttown")} annotationSelect={() => {openNote("150005nighttown"); addToVisited("150005nighttown")}} activeAnnotationId={currentNoteId}>82 Tyrone
+        the visit to the disorderly house of Mrs Bella Cohen, <Annotation annotationId="150005nighttown">82 Tyrone
         street, lower</Annotation> and subsequent brawl and chance medley in Beaver street
         (Armageddon): nocturnal perambulation to and from the cabman's shelter,
         Butt Bridge (atonement).
@@ -3619,7 +3619,7 @@ const Ithaca = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         conclude lest he should not conclude involuntarily apprehend?
       </p>
       <p>
-        <Annotation annotationId="170017loudlonecrack" visited={visitedNotes.has("170017loudlonecrack")} annotationSelect={() => {openNote("170017loudlonecrack"); addToVisited("170017loudlonecrack")}} activeAnnotationId={currentNoteId}>The cause of a brief sharp unforeseen heard loud lone crack</Annotation> emitted by
+        <Annotation annotationId="170017loudlonecrack">The cause of a brief sharp unforeseen heard loud lone crack</Annotation> emitted by
         the insentient material of a strainveined timber table.
       </p>
       <span data-edition="ed1986" data-page="599"></span>
@@ -3638,7 +3638,7 @@ const Ithaca = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         of artificial light, silently suddenly comprehend?
       </p>
       <p>
-        <Annotation annotationId="170016wherewasmoses" visited={visitedNotes.has("170016wherewasmoses")} annotationSelect={() => {openNote("170016wherewasmoses"); addToVisited("170016wherewasmoses")}} activeAnnotationId={currentNoteId}>Where was Moses when the candle went out?</Annotation>
+        <Annotation annotationId="170016wherewasmoses">Where was Moses when the candle went out?</Annotation>
       </p>
       <p>
         What imperfections in a perfect day did Bloom, walking, charged with
@@ -3651,7 +3651,7 @@ const Ithaca = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         Robertson and Co, 5 Dame Street, Dublin, and 2 Mincing Lane, London E.
         C.): to certify the presence or absence of posterior rectal orifice in
         the case of Hellenic female divinities: to obtain admission (gratuitous
-        or paid) to the <Annotation annotationId="050032leah" visited={visitedNotes.has("050032leah")} annotationSelect={() => {openNote("050032leah"); addToVisited("050032leah")}} activeAnnotationId={currentNoteId}>performance of <em>Leah</em></Annotation> <Annotation annotationId="060040gaietytheatre" visited={visitedNotes.has("060040gaietytheatre")} annotationSelect={() => {openNote("060040gaietytheatre"); addToVisited("060040gaietytheatre")}} activeAnnotationId={currentNoteId}>by Mrs Bandmann Palmer at the Gaiety
+        or paid) to the <Annotation annotationId="050032leah">performance of <em>Leah</em></Annotation> <Annotation annotationId="060040gaietytheatre">by Mrs Bandmann Palmer at the Gaiety
         Theatre</Annotation>, 46, 47, 48, 49 South King street. 
       </p>
       <span data-edition="ed1922" data-page="681"></span><span data-edition="ed1961" data-page="729"></span>
@@ -3660,8 +3660,8 @@ const Ithaca = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <span data-edition="ed1939" data-page="514"> </span>
       <p>
-        The face of her father, the late Major Brian Cooper Tweedy, <Annotation annotationId="030118royaldublins" visited={visitedNotes.has("030118royaldublins")} annotationSelect={() => {openNote("030118royaldublins"); addToVisited("030118royaldublins")}} activeAnnotationId={currentNoteId}>Royal Dublin
-        Fusiliers</Annotation>, of Gibraltar and <Annotation annotationId="040041dolphinsbarn" visited={visitedNotes.has("040041dolphinsbarn")} annotationSelect={() => {openNote("040041dolphinsbarn"); addToVisited("040041dolphinsbarn")}} activeAnnotationId={currentNoteId}>Rehoboth, Dolphin's Barn</Annotation>.
+        The face of her father, the late Major Brian Cooper Tweedy, <Annotation annotationId="030118royaldublins">Royal Dublin
+        Fusiliers</Annotation>, of Gibraltar and <Annotation annotationId="040041dolphinsbarn">Rehoboth, Dolphin's Barn</Annotation>.
       </p>
       <p>
         What recurrent impressions of the same were possible by hypothesis?
@@ -3678,9 +3678,9 @@ const Ithaca = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         perceived by him?
       </p>
       <p>
-        A pair of new inodorous halfsilk black ladies' hose, <Annotation annotationId="020080mauve" visited={visitedNotes.has("020080mauve")} annotationSelect={() => {openNote("020080mauve"); addToVisited("020080mauve")}} activeAnnotationId={currentNoteId}>a pair of new
+        A pair of new inodorous halfsilk black ladies' hose, <Annotation annotationId="020080mauve">a pair of new
         violet garters</Annotation>, a pair of outsize ladies' drawers of India mull, cut on
-        generous lines, redolent of opoponax, jessamine and <Annotation annotationId="100002tobacco" visited={visitedNotes.has("100002tobacco")} annotationSelect={() => {openNote("100002tobacco"); addToVisited("100002tobacco")}} activeAnnotationId={currentNoteId}>Muratti's Turkish
+        generous lines, redolent of opoponax, jessamine and <Annotation annotationId="100002tobacco">Muratti's Turkish
         cigarettes</Annotation> and containing a long bright steel safety pin, folded
         curvilinear, a camisole of batiste with thin lace border, an accordion
         underskirt of blue silk moirette, all these objects being disposed
@@ -3694,8 +3694,8 @@ const Ithaca = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       <p>
         A commode, one leg fractured, totally covered by square cretonne
         <span data-edition="ed1932" data-page="633"></span>cutting, apple design, on which rested a lady's black straw hat.
-        <Annotation annotationId="040057orangekeyed" visited={visitedNotes.has("040057orangekeyed")} annotationSelect={() => {openNote("040057orangekeyed"); addToVisited("040057orangekeyed")}} activeAnnotationId={currentNoteId}>Orangekeyed ware</Annotation>, bought of Henry Price, basket, fancy goods, chinaware
-        and ironmongery manufacturer, <Annotation annotationId="080003moorestreet" visited={visitedNotes.has("080003moorestreet")} annotationSelect={() => {openNote("080003moorestreet"); addToVisited("080003moorestreet")}} activeAnnotationId={currentNoteId}>21, 22, 23 Moore Street</Annotation>, disposed
+        <Annotation annotationId="040057orangekeyed">Orangekeyed ware</Annotation>, bought of Henry Price, basket, fancy goods, chinaware
+        and ironmongery manufacturer, <Annotation annotationId="080003moorestreet">21, 22, 23 Moore Street</Annotation>, disposed
         irregularly on the washstand and floor and consisting of basin, soapdish
         and brushtray (on the washstand, together), pitcher and night article
         (on the floor, separate).
@@ -3718,7 +3718,7 @@ const Ithaca = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       <p>
         With circumspection, as invariably when entering an abode (his own or
         not his own): with solicitude, the snakespiral springs of the mattress
-        being old, the  <Annotation annotationId="040085brassquoits" visited={visitedNotes.has("040085brassquoits")} annotationSelect={() => {openNote("040085brassquoits"); addToVisited("040085brassquoits")}} activeAnnotationId={currentNoteId}>brass quoits</Annotation> and pendent viper radii loose and tremulous
+        being old, the  <Annotation annotationId="040085brassquoits">brass quoits</Annotation> and pendent viper radii loose and tremulous
         under stress and strain: prudently, as entering a lair or ambush of
         lust or adders: lightly, the less to disturb: reverently, the bed of
         conception and of birth, of consummation of marriage and of breach of
@@ -3730,7 +3730,7 @@ const Ithaca = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       <p>
         New clean bedlinen, additional odours, the presence of a human form,
         female, hers, the imprint of a human form, male, not his, some crumbs,
-        <Annotation annotationId="050016pottedmeat" visited={visitedNotes.has("050016pottedmeat")} annotationSelect={() => {openNote("050016pottedmeat"); addToVisited("050016pottedmeat")}} activeAnnotationId={currentNoteId}>some flakes of potted meat</Annotation>, recooked, which he removed.
+        <Annotation annotationId="050016pottedmeat">some flakes of potted meat</Annotation>, recooked, which he removed.
       </p>
       <span data-edition="ed1939" data-page="515"> </span>
       <p>
@@ -3744,15 +3744,15 @@ const Ithaca = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         alone in a series originating in and repeated to infinity.
       </p>
       <p>
-        <Annotation annotationId="170008precedingseries" visited={visitedNotes.has("170008precedingseries")} annotationSelect={() => {openNote("170008precedingseries"); addToVisited("170008precedingseries")}} activeAnnotationId={currentNoteId}>What preceding series?</Annotation>
+        <Annotation annotationId="170008precedingseries">What preceding series?</Annotation>
       </p>
       <p>
         Assuming Mulvey to be the first term of his series, Penrose, Bartell
-        d'Arcy, <Annotation annotationId="040092professorgoodwin" visited={visitedNotes.has("040092professorgoodwin")} annotationSelect={() => {openNote("040092professorgoodwin"); addToVisited("040092professorgoodwin")}} activeAnnotationId={currentNoteId}>professor Goodwin</Annotation>, Julius Mastiansky, John Henry Menton, Father
+        d'Arcy, <Annotation annotationId="040092professorgoodwin">professor Goodwin</Annotation>, Julius Mastiansky, John Henry Menton, Father
         <span data-edition="ed1986" data-page="601"></span>Bernard Corrigan, a farmer at the Royal Dublin Society's Horse <span data-edition="ed1932" data-page="634"></span>Show,
         Maggot O'Reilly, Matthew Dillon, Valentine Blake Dillon (Lord Mayor
         of Dublin), Christopher Callinan, Lenehan, an Italian organgrinder,
-        an unknown gentleman in <Annotation annotationId="060040gaietytheatre" visited={visitedNotes.has("060040gaietytheatre")} annotationSelect={() => {openNote("060040gaietytheatre"); addToVisited("060040gaietytheatre")}} activeAnnotationId={currentNoteId}>the Gaiety Theatre</Annotation>, Benjamin Dollard, Simon
+        an unknown gentleman in <Annotation annotationId="060040gaietytheatre">the Gaiety Theatre</Annotation>, Benjamin Dollard, Simon
         Dedalus, Andrew (Pisser) Burke, Joseph Cuffe, Wisdom Hely, Alderman John
         Hooper, Dr Francis Brady, Father Sebastian of Mount Argus, a bootblack
         at the General Post Office, Hugh E. (Blazes) Boylan and so each and so
@@ -3861,7 +3861,7 @@ const Ithaca = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         What retribution, if any?
       </p>
       <p>
-        <Annotation annotationId="080030cenarteco" visited={visitedNotes.has("080030cenarteco")} annotationSelect={() => {openNote("080030cenarteco"); addToVisited("080030cenarteco")}} activeAnnotationId={currentNoteId}>Assassination, never, as two wrongs did not make one right. Duel by
+        <Annotation annotationId="080030cenarteco">Assassination, never, as two wrongs did not make one right. Duel by
         combat, no.</Annotation> Divorce, not now. Exposure by mechanical artifice (automatic
         bed) or individual testimony (concealed ocular witnesses), not <span data-edition="ed1932" data-page="636"></span>yet. Suit
         for damages by legal influence or simulation of assault with evidence of
@@ -3893,7 +3893,7 @@ const Ithaca = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         proposition (parsed as feminine subject, auxiliary verb
         and quasimonosyllabic onomatopoeic past participle with complementary
         masculine agent) in the passive voice: the continued product of
-        seminators by generation: the continual <Annotation annotationId="180010dewy" visited={visitedNotes.has("180010dewy")} annotationSelect={() => {openNote("180010dewy"); addToVisited("180010dewy")}} activeAnnotationId={currentNoteId}>production of semen by
+        seminators by generation: the continual <Annotation annotationId="180010dewy">production of semen by
         distillation</Annotation>: the futility of triumph or protest or vindication: the
         inanity of extolled virtue: the lethargy of nescient matter: the apathy
         of the stars.
@@ -3907,7 +3907,7 @@ const Ithaca = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         hemispheres, in all habitable lands and islands explored or unexplored
         (the land of the midnight sun, the islands of the blessed, the isles of
         Greece, the land of promise), of adipose anterior and posterior female
-        hemispheres, redolent of milk and honey and of <Annotation annotationId="040063happywarmth" visited={visitedNotes.has("040063happywarmth")} annotationSelect={() => {openNote("040063happywarmth"); addToVisited("040063happywarmth")}} activeAnnotationId={currentNoteId}>excretory sanguine and
+        hemispheres, redolent of milk and honey and of <Annotation annotationId="040063happywarmth">excretory sanguine and
         seminal warmth</Annotation>, reminiscent of secular families of curves of amplitude,
         insusceptible of moods of impression or of contrarieties of expression,
         expressive of mute immutable mature animality.
@@ -3953,7 +3953,7 @@ const Ithaca = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         in the vicinity of the licensed premises of Bernard Kiernan and Co,
         Limited, 8, 9 and 10 Little Britain street, the erotic provocation
         and response thereto caused by the exhibitionism of Gertrude (Gerty),
-        surname unknown. Positive: <Annotation annotationId="110002atfourshe" visited={visitedNotes.has("110002atfourshe")} annotationSelect={() => {openNote("110002atfourshe"); addToVisited("110002atfourshe")}} activeAnnotationId={currentNoteId}>he included mention of a performance by Mrs
+        surname unknown. Positive: <Annotation annotationId="110002atfourshe">he included mention of a performance by Mrs
         Bandmann Palmer of <i>Leah</i> at the Gaiety Theatre</Annotation>, 46, 47, 48, 49 South King
         street, an invitation to supper at Wynn's (Murphy's) Hotel, 35, 36 and
         37 Lower Abbey street, a volume of peccaminous pornographical tendency
@@ -3995,7 +3995,7 @@ const Ithaca = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         with ejaculation of semen within the natural female organ, having last
         taken place 5 weeks previous, viz. 27 November 1893, to the birth on 29
         December 1893 of second (and only male) issue, deceased 9 January 1894,
-        <Annotation annotationId="040096sheknew" visited={visitedNotes.has("040096sheknew")} annotationSelect={() => {openNote("040096sheknew"); addToVisited("040096sheknew")}} activeAnnotationId={currentNoteId}>aged 11 days</Annotation>, there remained a period of 10 years, 5 months and 18 days
+        <Annotation annotationId="040096sheknew">aged 11 days</Annotation>, there remained a period of 10 years, 5 months and 18 days
         during which carnal intercourse had been incomplete, without ejaculation
         of semen within the natural female organ. By the narrator a limitation
         of activity, mental and 
@@ -4056,7 +4056,7 @@ const Ithaca = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         reclined laterally, left, with right and left legs flexed, the index
         finger and thumb of the right hand resting on the bridge of the nose, in
         the attitude depicted in a snapshot photograph made by Percy Apjohn, the
-        childman weary, <Annotation annotationId="050024nakedwomb" visited={visitedNotes.has("050024nakedwomb")} annotationSelect={() => {openNote("050024nakedwomb"); addToVisited("050024nakedwomb")}} activeAnnotationId={currentNoteId}>the manchild in the womb</Annotation>.
+        childman weary, <Annotation annotationId="050024nakedwomb">the manchild in the womb</Annotation>.
       </p>
       <span data-edition="ed1922" data-page="688"></span>
       <p>
@@ -4070,7 +4070,7 @@ const Ithaca = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         With?
       </p>
       <p>
-        <Annotation annotationId="170009sinbadsailor" visited={visitedNotes.has("170009sinbadsailor")} annotationSelect={() => {openNote("170009sinbadsailor"); addToVisited("170009sinbadsailor")}} activeAnnotationId={currentNoteId}>Sinbad the Sailor and Tinbad the Tailor and Jinbad the Jailer and
+        <Annotation annotationId="170009sinbadsailor">Sinbad the Sailor and Tinbad the Tailor and Jinbad the Jailer and
         Whinbad the Whaler</Annotation> and Ninbad the Nailer and Finbad the Failer and
         Binbad the Bailer and Pinbad the Pailer and Minbad the Mailer and Hinbad
         the Hailer and Rinbad the Railer and Dinbad the Kailer and Vinbad the
@@ -4080,7 +4080,7 @@ const Ithaca = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         When?
       </p>
       <p>
-        <Annotation annotationId="170009sinbadsailor" visited={visitedNotes.has("170009sinbadsailor")} annotationSelect={() => {openNote("170009sinbadsailor"); addToVisited("170009sinbadsailor")}} activeAnnotationId={currentNoteId}>Going to dark bed there was a square round Sinbad the Sailor roc's auk's
+        <Annotation annotationId="170009sinbadsailor">Going to dark bed there was a square round Sinbad the Sailor roc's auk's
         egg in the night of the bed of all the auks of the rocs of Darkinbad the
         Brightdayler.</Annotation>
       </p>

--- a/src/content/chapters/Lestrygonians.js
+++ b/src/content/chapters/Lestrygonians.js
@@ -1,36 +1,36 @@
 import Annotation from "../../components/Annotation";
 
 
-const Lestrygonians = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
+const Lestrygonians = () => {
   return (
     <div>
       <p></p>
-      <center><Annotation annotationId="080000lestrygonians" visited={visitedNotes.has("080000lestrygonians")} annotationSelect={() => {openNote("080000lestrygonians"); addToVisited("080000lestrygonians")}} activeAnnotationId={currentNoteId}><font size="+2">[8]</font></Annotation></center>
+      <center><Annotation annotationId="080000lestrygonians"><font size="+2">[8]</font></Annotation></center>
       <br/>
       Pineapple rock, lemon platt, butter scotch. A sugarsticky girl
-      shovelling scoopfuls of creams for a <Annotation annotationId="100013christianbrother" visited={visitedNotes.has("100013christianbrother")} annotationSelect={() => {openNote("100013christianbrother"); addToVisited("100013christianbrother")}} activeAnnotationId={currentNoteId}>christian brother</Annotation>. Some school
-      treat. Bad for their tummies. <Annotation annotationId="080017grahamlemons" visited={visitedNotes.has("080017grahamlemons")} annotationSelect={() => {openNote("080017grahamlemons"); addToVisited("080017grahamlemons")}} activeAnnotationId={currentNoteId}>Lozenge and comfit manufacturer to His
+      shovelling scoopfuls of creams for a <Annotation annotationId="100013christianbrother">christian brother</Annotation>. Some school
+      treat. Bad for their tummies. <Annotation annotationId="080017grahamlemons">Lozenge and comfit manufacturer to His
       Majesty the King. God. Save. Our. Sitting on his throne sucking red
       jujubes white.</Annotation>
       <p></p>
       <p>
         A sombre Y.M.C.A. young man, watchful among the warm sweet fumes of
-        <Annotation annotationId="080017grahamlemons" visited={visitedNotes.has("080017grahamlemons")} annotationSelect={() => {openNote("080017grahamlemons"); addToVisited("080017grahamlemons")}} activeAnnotationId={currentNoteId}>Graham Lemon's</Annotation>, placed a throwaway in a hand of Mr Bloom.
+        <Annotation annotationId="080017grahamlemons">Graham Lemon's</Annotation>, placed a throwaway in a hand of Mr Bloom.
       </p>
       <p>
         Heart to heart talks.
       </p>
       <p>
-        <Annotation annotationId="040082highgradeha" visited={visitedNotes.has("040082highgradeha")} annotationSelect={() => {openNote("040082highgradeha"); addToVisited("040082highgradeha")}} activeAnnotationId={currentNoteId}>Bloo... Me? No.</Annotation>
+        <Annotation annotationId="040082highgradeha">Bloo... Me? No.</Annotation>
       </p>
       <p>
         Blood of the Lamb.
       </p>
       <p>
         His slow feet walked him riverward, reading. Are you saved? All are
-        washed in the blood of the lamb. <Annotation annotationId="010041killergod" visited={visitedNotes.has("010041killergod")} annotationSelect={() => {openNote("010041killergod"); addToVisited("010041killergod")}} activeAnnotationId={currentNoteId}>God wants blood victim.</Annotation> Birth, hymen,
-        martyr, war, foundation of a building, sacrifice, <Annotation annotationId="030110altarshorns" visited={visitedNotes.has("030110altarshorns")} annotationSelect={() => {openNote("030110altarshorns"); addToVisited("030110altarshorns")}} activeAnnotationId={currentNoteId}>kidney burntoffering</Annotation>,
-        <span data-edition="ed1932" data-page="133">  </span><Annotation annotationId="010018druids" visited={visitedNotes.has("010018druids")} annotationSelect={() => {openNote("010018druids"); addToVisited("010018druids")}} activeAnnotationId={currentNoteId}>druids' altars</Annotation>. Elijah is coming. Dr John Alexander Dowie restorer of
+        washed in the blood of the lamb. <Annotation annotationId="010041killergod">God wants blood victim.</Annotation> Birth, hymen,
+        martyr, war, foundation of a building, sacrifice, <Annotation annotationId="030110altarshorns">kidney burntoffering</Annotation>,
+        <span data-edition="ed1932" data-page="133">  </span><Annotation annotationId="010018druids">druids' altars</Annotation>. Elijah is coming. Dr John Alexander Dowie restorer of
         the church in Zion is coming.
       </p>
       <p>
@@ -40,7 +40,7 @@ const Lestrygonians = ({openNote, currentNoteId, visitedNotes, addToVisited}) =>
       Paying game.  Torry and Alexander last year. Polygamy. His wife will put the stopper
       on that. Where was that ad some Birmingham firm the luminous crucifix.
       Our Saviour. Wake up in the dead of night and see him on the wall,
-      hanging. Pepper's ghost idea. <Annotation annotationId="050033eccehomo" visited={visitedNotes.has("050033eccehomo")} annotationSelect={() => {openNote("050033eccehomo"); addToVisited("050033eccehomo")}} activeAnnotationId={currentNoteId}>Iron nails ran in.</Annotation>
+      hanging. Pepper's ghost idea. <Annotation annotationId="050033eccehomo">Iron nails ran in.</Annotation>
       <p></p>
       <p>
         Phosphorus it must be done with. If you leave a bit of codfish for
@@ -55,16 +55,16 @@ const Lestrygonians = ({openNote, currentNoteId, visitedNotes, addToVisited}) =>
         <span data-edition="ed1922" data-page="144"> </span> Dedalus' daughter there still outside Dillon's auctionrooms. Must be
         selling off some old furniture. Knew her eyes at once from the father.
         Lobbing about waiting for him. Home always breaks up when the mother
-        goes. Fifteen children he had. Birth every year almost. <Annotation annotationId="080028multiply" visited={visitedNotes.has("080028multiply")} annotationSelect={() => {openNote("080028multiply"); addToVisited("080028multiply")}} activeAnnotationId={currentNoteId}>That's in their
+        goes. Fifteen children he had. Birth every year almost. <Annotation annotationId="080028multiply">That's in their
         theology or the priest won't give the poor woman the confession, the
         absolution. Increase and multiply.</Annotation> Did you ever hear such an idea? Eat
         you out of house and home. No families themselves to feed. Living on the
-        <Annotation annotationId="030019kidneysofwheat" visited={visitedNotes.has("030019kidneysofwheat")} annotationSelect={() => {openNote("030019kidneysofwheat"); addToVisited("030019kidneysofwheat")}} activeAnnotationId={currentNoteId}>fat of the land</Annotation>. Their butteries <span data-edition="ed1961" data-page="151">  </span>and larders. I'd like to see them do
+        <Annotation annotationId="030019kidneysofwheat">fat of the land</Annotation>. Their butteries <span data-edition="ed1961" data-page="151">  </span>and larders. I'd like to see them do
         the black fast <span data-edition="ed1986" data-page="124"> </span>Yom Kippur. Crossbuns. One meal and a collation for fear
         he'd collapse on the altar. A housekeeper of one of those fellows if you
         could pick it out of her. 
         <span data-edition="ed1939" data-page="111"> </span>
-        Never pick it out of her. Like getting <Annotation annotationId="010019money" visited={visitedNotes.has("010019money")} annotationSelect={() => {openNote("010019money"); addToVisited("010019money")}} activeAnnotationId={currentNoteId}>L.s.d.</Annotation>
+        Never pick it out of her. Like getting <Annotation annotationId="010019money">L.s.d.</Annotation>
         out of him. Does himself well. No guests. All for number one. Watching
         his water. Bring your own bread and butter. His reverence mum's the
         word.
@@ -75,7 +75,7 @@ const Lestrygonians = ({openNote, currentNoteId, visitedNotes, addToVisited}) =>
         Proof of the pudding. Undermines the constitution.
       </p>
       <p>
-        As he set foot on O'Connell bridge <Annotation annotationId="080019brewerybarge" visited={visitedNotes.has("080019brewerybarge")} annotationSelect={() => {openNote("080019brewerybarge"); addToVisited("080019brewerybarge")}} activeAnnotationId={currentNoteId}>a puffball of smoke plumed up from
+        As he set foot on O'Connell bridge <Annotation annotationId="080019brewerybarge">a puffball of smoke plumed up from
         the parapet. Brewery barge with export stout.</Annotation> England. Sea air sours it,
         I heard. Be interesting some day get a pass through Hancock to see the
         brewery. Regular world in itself. Vats of porter wonderful. Rats get in
@@ -87,7 +87,7 @@ const Lestrygonians = ({openNote, currentNoteId, visitedNotes, addToVisited}) =>
       <p>
         Looking down he saw flapping strongly, wheeling between the gaunt
         quaywalls, gulls. Rough weather outside. If I threw myself down? Reuben
-        J's son must have swallowed a good bellyful of <Annotation annotationId="030039sewage" visited={visitedNotes.has("030039sewage")} annotationSelect={() => {openNote("030039sewage"); addToVisited("030039sewage")}} activeAnnotationId={currentNoteId}>that sewage</Annotation>. One and
+        J's son must have swallowed a good bellyful of <Annotation annotationId="030039sewage">that sewage</Annotation>. One and
         eightpence too much. Hhhhm. It's the droll way he comes out with the
         things. Knows how to tell a story too.
       </p>
@@ -138,7 +138,7 @@ const Lestrygonians = ({openNote, currentNoteId, visitedNotes, addToVisited}) =>
       </p>
       <p>
         They wheeled flapping weakly. I'm not going to throw any more. Penny
-        quite enough. Lot of thanks I get. Not even a caw. They spread <Annotation annotationId="020054footandmouth" visited={visitedNotes.has("020054footandmouth")} annotationSelect={() => {openNote("020054footandmouth"); addToVisited("020054footandmouth")}} activeAnnotationId={currentNoteId}>foot and
+        quite enough. Lot of thanks I get. Not even a caw. They spread <Annotation annotationId="020054footandmouth">foot and
         mouth disease</Annotation> too. 
         <span data-edition="ed1939" data-page="112"> </span>
         If you cram a turkey say on chestnutmeal it tastes
@@ -160,14 +160,14 @@ const Lestrygonians = ({openNote, currentNoteId, visitedNotes, addToVisited}) =>
         <i>Trousers.</i>
       </p>
       <p>
-        Good idea that. Wonder if he pays rent to <Annotation annotationId="060033corporation" visited={visitedNotes.has("060033corporation")} annotationSelect={() => {openNote("060033corporation"); addToVisited("060033corporation")}} activeAnnotationId={currentNoteId}>the corporation</Annotation>. How can you
+        Good idea that. Wonder if he pays rent to <Annotation annotationId="060033corporation">the corporation</Annotation>. How can you
         own water really? It's always flowing in a stream, never the same, which
         in the stream of life we trace. Because life is a stream. All kinds of
-        places are good for ads. That quack doctor for the clap used to be <Annotation annotationId="080027greenhouses" visited={visitedNotes.has("080027greenhouses")} annotationSelect={() => {openNote("080027greenhouses"); addToVisited("080027greenhouses")}} activeAnnotationId={currentNoteId}> stuck
+        places are good for ads. That quack doctor for the clap used to be <Annotation annotationId="080027greenhouses"> stuck
         up in all the greenhouses</Annotation>. Never see it now. Strictly confidential. Dr
         Hy Franks. Didn't cost him a red like Maginni the dancing master self
         advertisement. Got fellows to stick them up or stick them up himself for
-        that matter <Annotation annotationId="040082highgradeha" visited={visitedNotes.has("040082highgradeha")} annotationSelect={() => {openNote("040082highgradeha"); addToVisited("040082highgradeha")}} activeAnnotationId={currentNoteId}>on the q. t.</Annotation> running in to loosen a button. <Annotation annotationId="150016writingonthewall" visited={visitedNotes.has("150016writingonthewall")} annotationSelect={() => {openNote("150016writingonthewall"); addToVisited("150016writingonthewall")}} activeAnnotationId={currentNoteId}> Flybynight.
+        that matter <Annotation annotationId="040082highgradeha">on the q. t.</Annotation> running in to loosen a button. <Annotation annotationId="150016writingonthewall"> Flybynight.
         Just the place too. POST NO BILLS. POST 110 PILLS.</Annotation> Some chap with a dose
         burning him.
       </p>
@@ -193,8 +193,8 @@ const Lestrygonians = ({openNote, currentNoteId, visitedNotes, addToVisited}) =>
       </p>
       <p>
         Mr Bloom moved forward raising his troubled eyes. Think no more about
-        that. After one. <Annotation annotationId="080007ballastoffice" visited={visitedNotes.has("080007ballastoffice")} annotationSelect={() => {openNote("080007ballastoffice"); addToVisited("080007ballastoffice")}} activeAnnotationId={currentNoteId}>Timeball on the ballastoffice is down. Dunsink time.</Annotation>
-        <Annotation annotationId="080008parallax" visited={visitedNotes.has("080008parallax")} annotationSelect={() => {openNote("080008parallax"); addToVisited("080008parallax")}} activeAnnotationId={currentNoteId}>Fascinating little book that is of sir Robert Ball's.</Annotation> <Annotation annotationId="080008parallax" visited={visitedNotes.has("080008parallax")} annotationSelect={() => {openNote("080008parallax"); addToVisited("080008parallax")}} activeAnnotationId={currentNoteId}>Parallax. I never
+        that. After one. <Annotation annotationId="080007ballastoffice">Timeball on the ballastoffice is down. Dunsink time.</Annotation>
+        <Annotation annotationId="080008parallax">Fascinating little book that is of sir Robert Ball's.</Annotation> <Annotation annotationId="080008parallax">Parallax. I never
         exactly understood. There's a priest. Could ask him. Par it's Greek:
         parallel, parallax.</Annotation> Met him pike hoses she called it till I told her
         about the transmigration. O rocks!
@@ -229,7 +229,7 @@ const Lestrygonians = ({openNote, currentNoteId, visitedNotes, addToVisited}) =>
         too. Curiosity. Pillar of salt. Wouldn't have it of course because 
         <span data-edition="ed1939" data-page="113"> </span>
         he didn't think of it himself first. Or the inkbottle I suggested with a
-        false stain of black celluloid. <Annotation annotationId="050016pottedmeat" visited={visitedNotes.has("050016pottedmeat")} annotationSelect={() => {openNote("050016pottedmeat"); addToVisited("050016pottedmeat")}} activeAnnotationId={currentNoteId}>His ideas for ads like Plumtree's potted
+        false stain of black celluloid. <Annotation annotationId="050016pottedmeat">His ideas for ads like Plumtree's potted
         under the obituaries, cold meat department.</Annotation> You can't lick 'em. What?
         Our envelopes. Hello, Jones, where are you going? Can't stop, Robinson,
         I am hastening to purchase <span data-edition="ed1961" data-page="154">  </span>the only reliable inkeraser 
@@ -248,18 +248,18 @@ const Lestrygonians = ({openNote, currentNoteId, visitedNotes, addToVisited}) =>
         pawnbroker's daughter. It was a nun they say invented barbed wire.
       </p>
       <p>
-        He crossed Westmoreland street when <Annotation annotationId="040082highgradeha" visited={visitedNotes.has("040082highgradeha")} annotationSelect={() => {openNote("040082highgradeha"); addToVisited("040082highgradeha")}} activeAnnotationId={currentNoteId}>apostrophe S</Annotation> had plodded by. Rover
+        He crossed Westmoreland street when <Annotation annotationId="040082highgradeha">apostrophe S</Annotation> had plodded by. Rover
         cycleshop. Those races are on today. How long ago is that? Year Phil
-        Gilligan died. <Annotation annotationId="040049pleasantoldtimes" visited={visitedNotes.has("040049pleasantoldtimes")} annotationSelect={() => {openNote("040049pleasantoldtimes"); addToVisited("040049pleasantoldtimes")}} activeAnnotationId={currentNoteId}>We were in Lombard street west.</Annotation> Wait: was in Thom's.
+        Gilligan died. <Annotation annotationId="040049pleasantoldtimes">We were in Lombard street west.</Annotation> Wait: was in Thom's.
         Got the job in Wisdom Hely's year we married. Six years. Ten years ago:
-        ninetyfour he died yes that's right <Annotation annotationId="080001arnotts" visited={visitedNotes.has("080001arnotts")} annotationSelect={() => {openNote("080001arnotts"); addToVisited("080001arnotts")}} activeAnnotationId={currentNoteId}>the big fire at Arnott's</Annotation>. Val <Annotation annotationId="060033corporation" visited={visitedNotes.has("060033corporation")} annotationSelect={() => {openNote("060033corporation"); addToVisited("060033corporation")}} activeAnnotationId={currentNoteId}>Dillon
+        ninetyfour he died yes that's right <Annotation annotationId="080001arnotts">the big fire at Arnott's</Annotation>. Val <Annotation annotationId="060033corporation">Dillon
         was lord mayor. The Glencree dinner. Alderman Robert O'Reilly</Annotation> emptying
         the port into his soup before the flag fell. Bobbob lapping it for the
         inner alderman. Couldn't hear what the band played. For what we have
         already received may the Lord make us. Milly was a kiddy then. Molly
         had that elephantgrey dress with the braided frogs. Mantailored with
         selfcovered buttons. She didn't like it <span data-edition="ed1932" data-page="137">  </span>because I sprained my ankle
-        first day she wore choir picnic at <Annotation annotationId="010010mountains" visited={visitedNotes.has("010010mountains")} annotationSelect={() => {openNote("010010mountains"); addToVisited("010010mountains")}} activeAnnotationId={currentNoteId}>the Sugarloaf</Annotation>. As if that. Old
+        first day she wore choir picnic at <Annotation annotationId="010010mountains">the Sugarloaf</Annotation>. As if that. Old
         Goodwin's tall hat done up with some sticky stuff. Flies' picnic
         too. Never put a dress on her back like <span data-edition="ed1986" data-page="127"> </span>it. Fitted her like a glove,
         shoulders and hips. Just beginning to plump it out well. Rabbit pie we
@@ -276,8 +276,8 @@ const Lestrygonians = ({openNote, currentNoteId, visitedNotes, addToVisited}) =>
         He walked along the curbstone.
       </p>
       <p>
-        Stream of life. What was the name of that priestylooking <span data-edition="ed1961" data-page="155">  </span>chap was <Annotation annotationId="170008precedingseries" visited={visitedNotes.has("170008precedingseries")} annotationSelect={() => {openNote("170008precedingseries"); addToVisited("170008precedingseries")}} activeAnnotationId={currentNoteId}>always
-        squinting in when he passed</Annotation>? Weak eyes, woman. <Annotation annotationId="040049pleasantoldtimes" visited={visitedNotes.has("040049pleasantoldtimes")} annotationSelect={() => {openNote("040049pleasantoldtimes"); addToVisited("040049pleasantoldtimes")}} activeAnnotationId={currentNoteId}>Stopped in Citron's saint
+        Stream of life. What was the name of that priestylooking <span data-edition="ed1961" data-page="155">  </span>chap was <Annotation annotationId="170008precedingseries">always
+        squinting in when he passed</Annotation>? Weak eyes, woman. <Annotation annotationId="040049pleasantoldtimes">Stopped in Citron's saint
         Kevin's parade.</Annotation> Pen something. Pendennis? My memory is getting. Pen
         ...? of course it's years ago. Noise of the trams probably. Well, if he
         couldn't remember the dayfather's name that he sees every day.  
@@ -294,8 +294,8 @@ const Lestrygonians = ({openNote, currentNoteId, visitedNotes, addToVisited}) =>
         oakroom of the Mansion house. He and I behind. Sheet of her music blew
         out of my hand against 
         <span data-edition="ed1939" data-page="114"> </span>
-        the <Annotation annotationId="050020highschool" visited={visitedNotes.has("050020highschool")} annotationSelect={() => {openNote("050020highschool"); addToVisited("050020highschool")}} activeAnnotationId={currentNoteId}>High school</Annotation> railings. Lucky it didn't.
-        Thing like that spoils the effect of a night for her. <Annotation annotationId="040092professorgoodwin" visited={visitedNotes.has("040092professorgoodwin")} annotationSelect={() => {openNote("040092professorgoodwin"); addToVisited("040092professorgoodwin")}} activeAnnotationId={currentNoteId}>Professor Goodwin
+        the <Annotation annotationId="050020highschool">High school</Annotation> railings. Lucky it didn't.
+        Thing like that spoils the effect of a night for her. <Annotation annotationId="040092professorgoodwin">Professor Goodwin
         linking her in front. Shaky on his pins, poor old sot. His farewell
         concerts. Positively last appearance on any stage. May be for months and
         may be for never.</Annotation> Remember her laughing at the wind, her blizzard collar
@@ -325,17 +325,17 @@ const Lestrygonians = ({openNote, currentNoteId, visitedNotes, addToVisited}) =>
       </p>
       <p>
         —{" "}In the pink, Mr Bloom said gaily. Milly has a position down in
-        <Annotation annotationId="010126mullingar" visited={visitedNotes.has("010126mullingar")} annotationSelect={() => {openNote("010126mullingar"); addToVisited("010126mullingar")}} activeAnnotationId={currentNoteId}>Mullingar</Annotation>, you know.
+        <Annotation annotationId="010126mullingar">Mullingar</Annotation>, you know.
       </p>
       <p>
-        —{" "}<Annotation annotationId="080029dontbetalking" visited={visitedNotes.has("080029dontbetalking")} annotationSelect={() => {openNote("080029dontbetalking"); addToVisited("080029dontbetalking")}} activeAnnotationId={currentNoteId}>Go away! Isn't that grand for her?</Annotation>
+        —{" "}<Annotation annotationId="080029dontbetalking">Go away! Isn't that grand for her?</Annotation>
       </p>
       <p>
         —{" "}Yes. In a photographer's there. Getting on like a house on fire. How
         are all your charges?
       </p>
       <p>
-        —{" "}<Annotation annotationId="080029dontbetalking" visited={visitedNotes.has("080029dontbetalking")} annotationSelect={() => {openNote("080029dontbetalking"); addToVisited("080029dontbetalking")}} activeAnnotationId={currentNoteId}>All on the baker's list</Annotation>, Mrs Breen said.
+        —{" "}<Annotation annotationId="080029dontbetalking">All on the baker's list</Annotation>, Mrs Breen said.
       </p>
       <p>
         How many has she? No other in sight.
@@ -382,8 +382,8 @@ const Lestrygonians = ({openNote, currentNoteId, visitedNotes, addToVisited}) =>
         Mrs Breen turned up her two large eyes. Hasn't lost them anyhow.
       </p>
       <p>
-        —{" "}<Annotation annotationId="080029dontbetalking" visited={visitedNotes.has("080029dontbetalking")} annotationSelect={() => {openNote("080029dontbetalking"); addToVisited("080029dontbetalking")}} activeAnnotationId={currentNoteId}>O, don't be talking! she said. He's a caution to rattlesnakes.</Annotation> He's
-        in there now with his lawbooks finding out the law of libel. <Annotation annotationId="080029dontbetalking" visited={visitedNotes.has("080029dontbetalking")} annotationSelect={() => {openNote("080029dontbetalking"); addToVisited("080029dontbetalking")}} activeAnnotationId={currentNoteId}> He has me
+        —{" "}<Annotation annotationId="080029dontbetalking">O, don't be talking! she said. He's a caution to rattlesnakes.</Annotation> He's
+        in there now with his lawbooks finding out the law of libel. <Annotation annotationId="080029dontbetalking"> He has me
         heartscalded.</Annotation> Wait till I show you.
       </p>
       <p>
@@ -444,7 +444,7 @@ const Lestrygonians = ({openNote, currentNoteId, visitedNotes, addToVisited}) =>
       </p>
       <span data-edition="ed1922" data-page="150">  </span>
       <p>
-        —{" "}<Annotation annotationId="080010upup" visited={visitedNotes.has("080010upup")} annotationSelect={() => {openNote("080010upup"); addToVisited("080010upup")}} activeAnnotationId={currentNoteId}>U.P.: up</Annotation>, she said. Someone taking a rise out of him. It's a great
+        —{" "}<Annotation annotationId="080010upup">U.P.: up</Annotation>, she said. Someone taking a rise out of him. It's a great
         shame for them whoever he is.
       </p>
       <p>
@@ -475,7 +475,7 @@ const Lestrygonians = ({openNote, currentNoteId, visitedNotes, addToVisited}) =>
         Pungent mockturtle oxtail mulligatawny. I'm hungry too. Flakes of pastry
         on the gusset of her dress: daub of sugary flour stuck to her cheek.
         Rhubarb tart with liberal fillings, rich fruit interior. Josie Powell
-        that was. <Annotation annotationId="040041dolphinsbarn" visited={visitedNotes.has("040041dolphinsbarn")} annotationSelect={() => {openNote("040041dolphinsbarn"); addToVisited("040041dolphinsbarn")}} activeAnnotationId={currentNoteId}>In Luke Doyle's long ago. Dolphin's Barn, the charades.</Annotation> U.P.:
+        that was. <Annotation annotationId="040041dolphinsbarn">In Luke Doyle's long ago. Dolphin's Barn, the charades.</Annotation> U.P.:
         up.
       </p>
       <p>
@@ -488,7 +488,7 @@ const Lestrygonians = ({openNote, currentNoteId, visitedNotes, addToVisited}) =>
         —{" "}Mina Purefoy? she said.
       </p>
       <p>
-        <Annotation annotationId="040065matcham" visited={visitedNotes.has("040065matcham")} annotationSelect={() => {openNote("040065matcham"); addToVisited("040065matcham")}} activeAnnotationId={currentNoteId}>Philip Beaufoy I was thinking. Playgoers' Club. Matcham often thinks of
+        <Annotation annotationId="040065matcham">Philip Beaufoy I was thinking. Playgoers' Club. Matcham often thinks of
         the masterstroke.</Annotation> Did I pull the chain? Yes. The last act.
       </p>
       <span data-edition="ed1932" data-page="140">  </span>
@@ -497,7 +497,7 @@ const Lestrygonians = ({openNote, currentNoteId, visitedNotes, addToVisited}) =>
       </p>
       <p>
         —{" "}I just called to ask on the way in is she over it. She's in <span data-edition="ed1961" data-page="158">  </span>the
-        <Annotation annotationId="040086mrsthornton" visited={visitedNotes.has("040086mrsthornton")} annotationSelect={() => {openNote("040086mrsthornton"); addToVisited("040086mrsthornton")}} activeAnnotationId={currentNoteId}>lying-in hospital</Annotation> in <Annotation annotationId="140035holles" visited={visitedNotes.has("140035holles")} annotationSelect={() => {openNote("140035holles"); addToVisited("140035holles")}} activeAnnotationId={currentNoteId}>Holles street</Annotation>. <Annotation annotationId="140038drhorne" visited={visitedNotes.has("140038drhorne")} annotationSelect={() => {openNote("140038drhorne"); addToVisited("140038drhorne")}} activeAnnotationId={currentNoteId}>Dr Horne</Annotation> got her in. She's three
+        <Annotation annotationId="040086mrsthornton">lying-in hospital</Annotation> in <Annotation annotationId="140035holles">Holles street</Annotation>. <Annotation annotationId="140038drhorne">Dr Horne</Annotation> got her in. She's three
         days bad now.
       </p>
       <p>
@@ -583,24 +583,24 @@ const Lestrygonians = ({openNote, currentNoteId, visitedNotes, addToVisited}) =>
         with him.
       </p>
       <p>
-        U.P.: up. I'll take my oath that's Alf Bergan or <Annotation annotationId="030113richiegoulding" visited={visitedNotes.has("030113richiegoulding")} annotationSelect={() => {openNote("030113richiegoulding"); addToVisited("030113richiegoulding")}} activeAnnotationId={currentNoteId}>Richie Goulding. Wrote
+        U.P.: up. I'll take my oath that's Alf Bergan or <Annotation annotationId="030113richiegoulding">Richie Goulding. Wrote
         it for a lark in the Scotch house I bet anything.</Annotation> Round to Menton's
         office. His oyster eyes staring at the postcard. Be a feast for the
         gods.
       </p>
       <p>
-        He passed the <Annotation annotationId="080012irishtimes" visited={visitedNotes.has("080012irishtimes")} annotationSelect={() => {openNote("080012irishtimes"); addToVisited("080012irishtimes")}} activeAnnotationId={currentNoteId}><i>Irish Times</i></Annotation>. There might be other answers lying there.
+        He passed the <Annotation annotationId="080012irishtimes"><i>Irish Times</i></Annotation>. There might be other answers lying there.
         Like to answer them all. Good system for criminals. Code. At their lunch
         now. Clerk with the glasses there doesn't know me. O, leave them there
-        to simmer. <Annotation annotationId="080012irishtimes" visited={visitedNotes.has("080012irishtimes")} annotationSelect={() => {openNote("080012irishtimes"); addToVisited("080012irishtimes")}} activeAnnotationId={currentNoteId}>Enough bother wading through fortyfour of them. Wanted, smart
+        to simmer. <Annotation annotationId="080012irishtimes">Enough bother wading through fortyfour of them. Wanted, smart
         lady typist to aid gentleman in literary work.</Annotation> I called you naughty
         darling because I do not like that other world. Please tell me what is
         the meaning. Please tell me what perfume does your wife. Tell me who
         made the world. The way they spring those questions on you. And the
-        other one Lizzie Twigg. <Annotation annotationId="010039mightymother" visited={visitedNotes.has("010039mightymother")} annotationSelect={() => {openNote("010039mightymother"); addToVisited("010039mightymother")}} activeAnnotationId={currentNoteId}>My literary efforts have had the good fortune to
+        other one Lizzie Twigg. <Annotation annotationId="010039mightymother">My literary efforts have had the good fortune to
         meet with the approval of the eminent</Annotation> 
         <span data-edition="ed1922" data-page="152">  </span> 
-        <Annotation annotationId="010039mightymother" visited={visitedNotes.has("010039mightymother")} annotationSelect={() => {openNote("010039mightymother"); addToVisited("010039mightymother")}} activeAnnotationId={currentNoteId}>poet A. E. (Mr Geo. Russell).</Annotation> No
+        <Annotation annotationId="010039mightymother">poet A. E. (Mr Geo. Russell).</Annotation> No
         time to do her hair drinking sloppy tea with a book of poetry.
       </p>
       <span data-edition="ed1939" data-page="117"> </span>
@@ -610,22 +610,22 @@ const Lestrygonians = ({openNote, currentNoteId, visitedNotes, addToVisited}) =>
         counter. Resp. girl (R.C.) wishes to hear of post in fruit or pork shop.
         James Carlisle made that. Six and a half per cent dividend. Made a big
         deal on Coates's shares. Ca' canny. Cunning old Scotch hunks. All the
-        toady news. Our gracious and popular vicereine. Bought <Annotation annotationId="160004newspapers" visited={visitedNotes.has("160004newspapers")} annotationSelect={() => {openNote("160004newspapers"); addToVisited("160004newspapers")}} activeAnnotationId={currentNoteId}>the <i>Irish Field</i></Annotation>
+        toady news. Our gracious and popular vicereine. Bought <Annotation annotationId="160004newspapers">the <i>Irish Field</i></Annotation>
         now. Lady Mountcashel has quite recovered after her confinement and
         rode out with the Ward Union staghounds at the enlargement yesterday
         at Rathoath. Uneatable fox. Pothunters too. Fear injects juices make
         it tender enough for them. Riding astride. Sit her horse like a man.
         Weightcarrying huntress. No sidesaddle or pillion for her, not for Joe.
-        First to the meet and in at the death. <Annotation annotationId="050043horseywomen" visited={visitedNotes.has("050043horseywomen")} annotationSelect={() => {openNote("050043horseywomen"); addToVisited("050043horseywomen")}} activeAnnotationId={currentNoteId}>Strong as a brood mare some of
+        First to the meet and in at the death. <Annotation annotationId="050043horseywomen">Strong as a brood mare some of
         those horsey women.</Annotation> Swagger around livery stables. Toss off a glass
-        of brandy neat while you'd say knife. <span data-edition="ed1986" data-page="131"> </span>That one at <Annotation annotationId="050034grosvenor" visited={visitedNotes.has("050034grosvenor")} annotationSelect={() => {openNote("050034grosvenor"); addToVisited("050034grosvenor")}} activeAnnotationId={currentNoteId}>the Grosvenor</Annotation> this
+        of brandy neat while you'd say knife. <span data-edition="ed1986" data-page="131"> </span>That one at <Annotation annotationId="050034grosvenor">the Grosvenor</Annotation> this
         morning. Up with her on the car: wishswish. Stonewall or fivebarred gate
         put her mount to it. Think that pugnosed driver did it out of spite. Who
-        is this she was like? O yes! <Annotation annotationId="080016shelbourne" visited={visitedNotes.has("080016shelbourne")} annotationSelect={() => {openNote("080016shelbourne"); addToVisited("080016shelbourne")}} activeAnnotationId={currentNoteId}>Mrs Miriam Dandrade that sold me her old
+        is this she was like? O yes! <Annotation annotationId="080016shelbourne">Mrs Miriam Dandrade that sold me her old
         wraps and black underclothes in the Shelbourne hotel.</Annotation> Divorced Spanish
         American. Didn't take a feather out of her my handling them. As if I was
         her clotheshorse. Saw her in the viceregal party when Stubbs <span data-edition="ed1961" data-page="160">  </span>the park
-        ranger got me in with Whelan of <Annotation annotationId="070017dailyexpress" visited={visitedNotes.has("070017dailyexpress")} annotationSelect={() => {openNote("070017dailyexpress"); addToVisited("070017dailyexpress")}} activeAnnotationId={currentNoteId}>the <i>Express</i></Annotation>. Scavenging what <span data-edition="ed1932" data-page="142">  </span>the
+        ranger got me in with Whelan of <Annotation annotationId="070017dailyexpress">the <i>Express</i></Annotation>. Scavenging what <span data-edition="ed1932" data-page="142">  </span>the
         quality left. High tea. Mayonnaise I poured on the plums thinking it was
         custard. Her ears ought to have tingled for a few weeks after. Want to
         be a bull for her. Born courtesan. No nursery work for her, thanks.
@@ -635,7 +635,7 @@ const Lestrygonians = ({openNote, currentNoteId, visitedNotes, addToVisited}) =>
         and milk and soda lunch in the educational dairy. Eating
         with a stopwatch, thirtytwo chews to the minute. Still his
         muttonchop whiskers grew. Supposed to be well connected. Theodore's
-        cousin in <Annotation annotationId="080013dublincastle" visited={visitedNotes.has("080013dublincastle")} annotationSelect={() => {openNote("080013dublincastle"); addToVisited("080013dublincastle")}} activeAnnotationId={currentNoteId}>Dublin Castle</Annotation>. One tony relative in every family. Hardy
+        cousin in <Annotation annotationId="080013dublincastle">Dublin Castle</Annotation>. One tony relative in every family. Hardy
         annuals he presents her with. Saw him out at the Three Jolly Topers
         marching along bareheaded and his eldest boy carrying one in a
         marketnet. The squallers. Poor thing! Then having to give the breast
@@ -644,12 +644,12 @@ const Lestrygonians = ({openNote, currentNoteId, visitedNotes, addToVisited}) =>
       </p>
       <p>
         He stood at Fleet street crossing. Luncheon interval a sixpenny at
-        Rowe's? Must look up that ad in the <Annotation annotationId="010144nationallibrary" visited={visitedNotes.has("010144nationallibrary")} annotationSelect={() => {openNote("010144nationallibrary"); addToVisited("010144nationallibrary")}} activeAnnotationId={currentNoteId}>national library</Annotation>. An eightpenny in
+        Rowe's? Must look up that ad in the <Annotation annotationId="010144nationallibrary">national library</Annotation>. An eightpenny in
         the Burton. Better. On my way.
       </p>
       <span data-edition="ed1922" data-page="153"> </span>
       <p>
-        He walked on past Bolton's Westmoreland house. <Annotation annotationId="050037tomkernan" visited={visitedNotes.has("050037tomkernan")} annotationSelect={() => {openNote("050037tomkernan"); addToVisited("050037tomkernan")}} activeAnnotationId={currentNoteId}>Tea. Tea. Tea. I forgot
+        He walked on past Bolton's Westmoreland house. <Annotation annotationId="050037tomkernan">Tea. Tea. Tea. I forgot
         to tap Tom Kernan.</Annotation>
       </p>
       <p>
@@ -666,7 +666,7 @@ const Lestrygonians = ({openNote, currentNoteId, visitedNotes, addToVisited}) =>
         feed fools on. They could easily have big establishments whole thing
         quite painless out of all the taxes give every child born five quid at
         compound interest up to twentyone five per cent is a hundred shillings
-        and five tiresome pounds <Annotation annotationId="080028multiply" visited={visitedNotes.has("080028multiply")} annotationSelect={() => {openNote("080028multiply"); addToVisited("080028multiply")}} activeAnnotationId={currentNoteId}>multiply</Annotation> by twenty decimal system encourage
+        and five tiresome pounds <Annotation annotationId="080028multiply">multiply</Annotation> by twenty decimal system encourage
         <span data-edition="ed1939" data-page="118"> </span>
         people to put by money save hundred and ten and a bit twentyone years
         want to work it out on paper come to a tidy sum, more than you think.
@@ -680,7 +680,7 @@ const Lestrygonians = ({openNote, currentNoteId, visitedNotes, addToVisited}) =>
         Funny sight two of them together, their bellies out. Molly and Mrs
         Moisel. Mothers' meeting. Phthisis retires for the time being, then
         returns. <span data-edition="ed1986" data-page="132"> </span>How flat they look after all of a sudden! Peaceful eyes. Weight
-        off their minds. <Annotation annotationId="040086mrsthornton" visited={visitedNotes.has("040086mrsthornton")} annotationSelect={() => {openNote("040086mrsthornton"); addToVisited("040086mrsthornton")}} activeAnnotationId={currentNoteId}>Old Mrs Thornton</Annotation> was a jolly old soul. All my babies,
+        off their minds. <Annotation annotationId="040086mrsthornton">Old Mrs Thornton</Annotation> was a jolly old soul. All my babies,
         <span data-edition="ed1932" data-page="143">  </span>she said. The spoon of pap in her mouth before she fed them. O, that's
         nyumnyum. Got her hand crushed by old Tom Wall's son. His first bow to
         the public. Head like a prize pumpkin. Snuffy Dr Murren. People knocking
@@ -689,7 +689,7 @@ const Lestrygonians = ({openNote, currentNoteId, visitedNotes, addToVisited}) =>
         gratitude in people. Humane doctors, most of them.
       </p>
       <p>
-        Before the huge high door of <Annotation annotationId="020047johnblackwood" visited={visitedNotes.has("020047johnblackwood")} annotationSelect={() => {openNote("020047johnblackwood"); addToVisited("020047johnblackwood")}} activeAnnotationId={currentNoteId}>the Irish house of parliament</Annotation> a flock of
+        Before the huge high door of <Annotation annotationId="020047johnblackwood">the Irish house of parliament</Annotation> a flock of
         pigeons flew. Their little frolic after meals. Who will we do it on? I
         pick the fellow in black. Here goes. Here's good luck. Must be thrilling
         from the air. Apjohn, myself and Owen Goldberg up in the trees near
@@ -711,55 +711,55 @@ const Lestrygonians = ({openNote, currentNoteId, visitedNotes, addToVisited}) =>
         He crossed under Tommy Moore's roguish finger. They did right to put him
         up over a urinal: meeting of the waters. Ought to be places for women.
         Running into cakeshops. Settle my hat straight. <i>There is not in this
-        wide world a vallee</i>. Great song of <Annotation annotationId="040027conroy" visited={visitedNotes.has("040027conroy")} annotationSelect={() => {openNote("040027conroy"); addToVisited("040027conroy")}} activeAnnotationId={currentNoteId}>Julia Morkan's. Kept her voice up to
+        wide world a vallee</i>. Great song of <Annotation annotationId="040027conroy">Julia Morkan's. Kept her voice up to
         the very last.</Annotation> Pupil of Michael Balfe's, wasn't she?
       </p>
       <p>
-        He gazed after the last broad tunic. <Annotation annotationId="040084sizeable" visited={visitedNotes.has("040084sizeable")} annotationSelect={() => {openNote("040084sizeable"); addToVisited("040084sizeable")}} activeAnnotationId={currentNoteId}>Nasty customers to tackle.</Annotation> Jack
+        He gazed after the last broad tunic. <Annotation annotationId="040084sizeable">Nasty customers to tackle.</Annotation> Jack
         Power could a tale unfold: father a G man. If a fellow gave them trouble
         being lagged they let him have it hot and heavy in the bridewell.
         Can't blame them after all with the job they have especially the young
-        hornies. That horsepoliceman  <Annotation annotationId="080021joechamberlain" visited={visitedNotes.has("080021joechamberlain")} annotationSelect={() => {openNote("080021joechamberlain"); addToVisited("080021joechamberlain")}} activeAnnotationId={currentNoteId}>the day Joe Chamberlain was given his
+        hornies. That horsepoliceman  <Annotation annotationId="080021joechamberlain">the day Joe Chamberlain was given his
         degree in Trinity</Annotation> he got a run for his money. My word he did! His
         horse's hoofs clattering after us down Abbey street. Lucky I had <span data-edition="ed1961" data-page="162">  </span>the
-        presence of mind to dive into <Annotation annotationId="080021joechamberlain" visited={visitedNotes.has("080021joechamberlain")} annotationSelect={() => {openNote("080021joechamberlain"); addToVisited("080021joechamberlain")}} activeAnnotationId={currentNoteId}>Manning's</Annotation> or I was souped. He did come a
+        presence of mind to dive into <Annotation annotationId="080021joechamberlain">Manning's</Annotation> or I was souped. He did come a
         wallop, by George. Must have cracked his skull on the cobblestones. I
-        oughtn't to have got myself <Annotation annotationId="080021joechamberlain" visited={visitedNotes.has("080021joechamberlain")} annotationSelect={() => {openNote("080021joechamberlain"); addToVisited("080021joechamberlain")}} activeAnnotationId={currentNoteId}>swept along with those medicals. And the
+        oughtn't to have got myself <Annotation annotationId="080021joechamberlain">swept along with those medicals. And the
         Trinity jibs in their mortarboards. Looking for trouble.</Annotation> Still I got to
-        know that young Dixon who <Annotation annotationId="040040bluebottle" visited={visitedNotes.has("040040bluebottle")} annotationSelect={() => {openNote("040040bluebottle"); addToVisited("040040bluebottle")}} activeAnnotationId={currentNoteId}>dressed that sting</Annotation> for me in <Annotation annotationId="010068themater" visited={visitedNotes.has("010068themater")} annotationSelect={() => {openNote("010068themater"); addToVisited("010068themater")}} activeAnnotationId={currentNoteId}>the Mater</Annotation> and now
+        know that young Dixon who <Annotation annotationId="040040bluebottle">dressed that sting</Annotation> for me in <Annotation annotationId="010068themater">the Mater</Annotation> and now
         he's in Holles street where Mrs Purefoy. Wheels within wheels. Police
         whistle in my ears still. All skedaddled. Why he fixed on me. Give me in
-        charge. <Annotation annotationId="080021joechamberlain" visited={visitedNotes.has("080021joechamberlain")} annotationSelect={() => {openNote("080021joechamberlain"); addToVisited("080021joechamberlain")}} activeAnnotationId={currentNoteId}>Right here it began.</Annotation>
+        charge. <Annotation annotationId="080021joechamberlain">Right here it began.</Annotation>
       </p>
       <span data-edition="ed1932" data-page="144">  </span>
       <p>
-        <Annotation annotationId="080021joechamberlain" visited={visitedNotes.has("080021joechamberlain")} annotationSelect={() => {openNote("080021joechamberlain"); addToVisited("080021joechamberlain")}} activeAnnotationId={currentNoteId}>—{" "}Up the Boers!</Annotation>
+        <Annotation annotationId="080021joechamberlain">—{" "}Up the Boers!</Annotation>
       </p>
       <p>
-        <Annotation annotationId="080021joechamberlain" visited={visitedNotes.has("080021joechamberlain")} annotationSelect={() => {openNote("080021joechamberlain"); addToVisited("080021joechamberlain")}} activeAnnotationId={currentNoteId}>—{" "}Three cheers for De Wet!</Annotation>
+        <Annotation annotationId="080021joechamberlain">—{" "}Three cheers for De Wet!</Annotation>
       </p>
       <p>
-        —{" "}<Annotation annotationId="080023sourappletree" visited={visitedNotes.has("080023sourappletree")} annotationSelect={() => {openNote("080023sourappletree"); addToVisited("080023sourappletree")}} activeAnnotationId={currentNoteId}>We'll hang Joe Chamberlain on a sourapple tree.</Annotation>
+        —{" "}<Annotation annotationId="080023sourappletree">We'll hang Joe Chamberlain on a sourapple tree.</Annotation>
       </p>
       <span data-edition="ed1986" data-page="133"> </span>
       <p>
-        Silly billies: mob of young cubs yelling their guts out. <Annotation annotationId="110007croppyboy" visited={visitedNotes.has("110007croppyboy")} annotationSelect={() => {openNote("110007croppyboy"); addToVisited("110007croppyboy")}} activeAnnotationId={currentNoteId}>Vinegar hill.</Annotation>
+        Silly billies: mob of young cubs yelling their guts out. <Annotation annotationId="110007croppyboy">Vinegar hill.</Annotation>
         The Butter exchange band. Few years' time half of them magistrates and
         civil servants. War 
         <span data-edition="ed1939" data-page="119"> </span>
-        comes on: <Annotation annotationId="010058bloodyswindle" visited={visitedNotes.has("010058bloodyswindle")} annotationSelect={() => {openNote("010058bloodyswindle"); addToVisited("010058bloodyswindle")}} activeAnnotationId={currentNoteId}>into the army</Annotation> helterskelter: same fellows
+        comes on: <Annotation annotationId="010058bloodyswindle">into the army</Annotation> helterskelter: same fellows
         used to whether on the scaffold high.
       </p>
       <p>
         Never know who you're talking to. Corny Kelleher he has Harvey Duff in
-        his eye. <Annotation annotationId="040089denzille" visited={visitedNotes.has("040089denzille")} annotationSelect={() => {openNote("040089denzille"); addToVisited("040089denzille")}} activeAnnotationId={currentNoteId}>Like that Peter or Denis or James Carey that blew the gaff on
-        the invincibles.</Annotation> <Annotation annotationId="060033corporation" visited={visitedNotes.has("060033corporation")} annotationSelect={() => {openNote("060033corporation"); addToVisited("060033corporation")}} activeAnnotationId={currentNoteId}>Member of the corporation</Annotation> too. Egging raw youths on to
-        get in the know all the time <Annotation annotationId="080013dublincastle" visited={visitedNotes.has("080013dublincastle")} annotationSelect={() => {openNote("080013dublincastle"); addToVisited("080013dublincastle")}} activeAnnotationId={currentNoteId}>drawing secret service pay from the castle</Annotation>.
+        his eye. <Annotation annotationId="040089denzille">Like that Peter or Denis or James Carey that blew the gaff on
+        the invincibles.</Annotation> <Annotation annotationId="060033corporation">Member of the corporation</Annotation> too. Egging raw youths on to
+        get in the know all the time <Annotation annotationId="080013dublincastle">drawing secret service pay from the castle</Annotation>.
         Drop him like a hot potato. Why those plainclothes men are always
         courting slaveys. Easily twig a man used to uniform. Squarepushing up
         against a backdoor. Maul her a bit. Then the next thing on the menu. And
         who is the gentleman 
-        <span data-edition="ed1922" data-page="155"> </span><Annotation annotationId="090012brogue" visited={visitedNotes.has("090012brogue")} annotationSelect={() => {openNote("090012brogue"); addToVisited("090012brogue")}} activeAnnotationId={currentNoteId}>does be visiting</Annotation> there? Was the young master saying
+        <span data-edition="ed1922" data-page="155"> </span><Annotation annotationId="090012brogue">does be visiting</Annotation> there? Was the young master saying
         anything? Peeping Tom through the keyhole. Decoy duck. Hotblooded young
         student fooling round her fat arms ironing.
       </p>
@@ -777,17 +777,17 @@ const Lestrygonians = ({openNote, currentNoteId, visitedNotes, addToVisited}) =>
         —{" "}Ah, get along with your great times coming.
       </p>
       <p>
-        Barmaids too. <Annotation annotationId="100002tobacco" visited={visitedNotes.has("100002tobacco")} annotationSelect={() => {openNote("100002tobacco"); addToVisited("100002tobacco")}} activeAnnotationId={currentNoteId}>Tobaccoshopgirls.</Annotation>
+        Barmaids too. <Annotation annotationId="100002tobacco">Tobaccoshopgirls.</Annotation>
       </p>
       <p>
-        <Annotation annotationId="020073fenians" visited={visitedNotes.has("020073fenians")} annotationSelect={() => {openNote("020073fenians"); addToVisited("020073fenians")}} activeAnnotationId={currentNoteId}>James Stephens</Annotation>' idea was the best. He knew them. Circles of ten so that
+        <Annotation annotationId="020073fenians">James Stephens</Annotation>' idea was the best. He knew them. Circles of ten so that
         a fellow couldn't round on more than his own ring. Sinn Fein. Back out
-        you get the knife. Hidden hand. Stay in. The firing squad. <Annotation annotationId="020073fenians" visited={visitedNotes.has("020073fenians")} annotationSelect={() => {openNote("020073fenians"); addToVisited("020073fenians")}} activeAnnotationId={currentNoteId}>Turnkey's
+        you get the knife. Hidden hand. Stay in. The firing squad. <Annotation annotationId="020073fenians">Turnkey's
         daughter got him out of Richmond, off from Lusk. Putting up in the
         Buckingham Palace hotel under their very noses.</Annotation> Garibaldi.
       </p>
       <p>
-        You must have a certain fascination: Parnell. <Annotation annotationId="030037griffith" visited={visitedNotes.has("030037griffith")} annotationSelect={() => {openNote("030037griffith"); addToVisited("030037griffith")}} activeAnnotationId={currentNoteId}>Arthur Griffith</Annotation> <span data-edition="ed1961" data-page="163">  </span>is a
+        You must have a certain fascination: Parnell. <Annotation annotationId="030037griffith">Arthur Griffith</Annotation> <span data-edition="ed1961" data-page="163">  </span>is a
         squareheaded fellow but he has no go in him for the mob. Want to gas about
         our lovely land. Gammon and spinach. Dublin Bakery Company's tearoom.
         Debating societies. That republicanism is the best form of government.
@@ -798,7 +798,7 @@ const Lestrygonians = ({openNote, currentNoteId, visitedNotes, addToVisited}) =>
         before it gets too cold. Halffed enthusiasts. Penny roll and a walk with
         the band. No grace for the carver. The thought that the other chap pays
         best sauce in the world. Make themselves thoroughly at <span data-edition="ed1932" data-page="145">  </span>home. Show us
-        over those apricots, meaning peaches. The not far distant day. <Annotation annotationId="040006homerulesun" visited={visitedNotes.has("040006homerulesun")} annotationSelect={() => {openNote("040006homerulesun"); addToVisited("040006homerulesun")}} activeAnnotationId={currentNoteId}>Home Rule
+        over those apricots, meaning peaches. The not far distant day. <Annotation annotationId="040006homerulesun">Home Rule
         sun rising up in the northwest.</Annotation>
       </p>
       <p>
@@ -819,7 +819,7 @@ const Lestrygonians = ({openNote, currentNoteId, visitedNotes, addToVisited}) =>
         <span data-edition="ed1922" data-page="156">  </span>piledup bricks, stones. Changing hands. This owner, that.
         Landlord never dies they say. Other steps into his shoes when he gets
         his notice to quit. They buy the place up with gold and still they have
-        all the gold. <Annotation annotationId="040059shortknock" visited={visitedNotes.has("040059shortknock")} annotationSelect={() => {openNote("040059shortknock"); addToVisited("040059shortknock")}} activeAnnotationId={currentNoteId}>Swindle in it somewhere.</Annotation> Piled up in cities, worn away age
+        all the gold. <Annotation annotationId="040059shortknock">Swindle in it somewhere.</Annotation> Piled up in cities, worn away age
         after age. Pyramids in sand. Built on bread and onions. Slaves Chinese
         <span data-edition="ed1939" data-page="120"> </span>
         wall. Babylon. Big stones left. Round towers. Rest rubble, sprawling
@@ -847,7 +847,7 @@ const Lestrygonians = ({openNote, currentNoteId, visitedNotes, addToVisited}) =>
       <p>
         There he is: the brother. Image of him. Haunting face. Now that's a
         coincidence. Course hundreds of times you think of a person and don't
-        meet him. Like a man walking in his sleep. No-one knows him. Must be <Annotation annotationId="060033corporation" visited={visitedNotes.has("060033corporation")} annotationSelect={() => {openNote("060033corporation"); addToVisited("060033corporation")}} activeAnnotationId={currentNoteId}>a
+        meet him. Like a man walking in his sleep. No-one knows him. Must be <Annotation annotationId="060033corporation">a
         corporation meeting</Annotation> today. They say he never put on the city marshal's
         uniform since he got the job. Charley Boulger used to come out on
         his high horse, cocked hat, puffed, powdered and shaved. Look at the
@@ -877,8 +877,8 @@ const Lestrygonians = ({openNote, currentNoteId, visitedNotes, addToVisited}) =>
       <p>
         And there he is too. Now that's really a coincidence: second time.
         Coming events cast their shadows before. With the approval of the
-        eminent <span data-edition="ed1986" data-page="135"> </span>poet, Mr Geo. Russell. That might be Lizzie Twigg with him. <Annotation annotationId="010039mightymother" visited={visitedNotes.has("010039mightymother")} annotationSelect={() => {openNote("010039mightymother"); addToVisited("010039mightymother")}} activeAnnotationId={currentNoteId}>A.
-        E.: what does that mean? Initials perhaps.</Annotation> <Annotation annotationId="020036filibegs" visited={visitedNotes.has("020036filibegs")} annotationSelect={() => {openNote("020036filibegs"); addToVisited("020036filibegs")}} activeAnnotationId={currentNoteId}>Albert Edward</Annotation>, Arthur Edmund,
+        eminent <span data-edition="ed1986" data-page="135"> </span>poet, Mr Geo. Russell. That might be Lizzie Twigg with him. <Annotation annotationId="010039mightymother">A.
+        E.: what does that mean? Initials perhaps.</Annotation> <Annotation annotationId="020036filibegs">Albert Edward</Annotation>, Arthur Edmund,
         Alphonsus Eb Ed El Esquire. What was he saying? The ends of the world
         with a Scotch accent. Tentacles: octopus. Something occult: symbolism.
         Holding forth. She's taking it all in. Not saying a word. To aid
@@ -887,8 +887,8 @@ const Lestrygonians = ({openNote, currentNoteId, visitedNotes, addToVisited}) =>
       <p>
         His eyes followed the high figure in homespun, beard and bicycle,
         a listening woman at his side. Coming from the vegetarian. Only
-        weggebobbles and fruit. Don't eat a beefsteak. <Annotation annotationId="030087pastlife" visited={visitedNotes.has("030087pastlife")} annotationSelect={() => {openNote("030087pastlife"); addToVisited("030087pastlife")}} activeAnnotationId={currentNoteId}>If you do the eyes of
-        that cow will pursue you through all</Annotation> <span data-edition="ed1961" data-page="165">  </span><Annotation annotationId="030087pastlife" visited={visitedNotes.has("030087pastlife")} annotationSelect={() => {openNote("030087pastlife"); addToVisited("030087pastlife")}} activeAnnotationId={currentNoteId}>eternity.</Annotation> They say it's healthier.
+        weggebobbles and fruit. Don't eat a beefsteak. <Annotation annotationId="030087pastlife">If you do the eyes of
+        that cow will pursue you through all</Annotation> <span data-edition="ed1961" data-page="165">  </span><Annotation annotationId="030087pastlife">eternity.</Annotation> They say it's healthier.
         Windandwatery though. Tried it. Keep you on the run all day. Bad as
         a bloater. Dreams all night. Why do they call that thing they gave me
         nutsteak? Nutarians. Fruitarians. To give you the idea you are eating
@@ -930,7 +930,7 @@ const Lestrygonians = ({openNote, currentNoteId, visitedNotes, addToVisited}) =>
         imagine it's there you can almost see it. Can't see it.
       </p>
       <p>
-        <Annotation annotationId="080008parallax" visited={visitedNotes.has("080008parallax")} annotationSelect={() => {openNote("080008parallax"); addToVisited("080008parallax")}} activeAnnotationId={currentNoteId}>He faced about and, standing between the awnings, held out his right
+        <Annotation annotationId="080008parallax">He faced about and, standing between the awnings, held out his right
         hand at arm's length towards the sun. Wanted to try that often. Yes:
         completely. The tip of his little finger blotted out the sun's disk.
         Must be the focus where the rays cross. If I had black glasses.</Annotation>
@@ -941,7 +941,7 @@ const Lestrygonians = ({openNote, currentNoteId, visitedNotes, addToVisited}) =>
       </p>
       <span data-edition="ed1986" data-page="136"> </span><span data-edition="ed1961" data-page="166">  </span>
       <p>
-        <Annotation annotationId="080008parallax" visited={visitedNotes.has("080008parallax")} annotationSelect={() => {openNote("080008parallax"); addToVisited("080008parallax")}} activeAnnotationId={currentNoteId}>Now that I come to think of it, that ball falls at Greenwich time. It's
+        <Annotation annotationId="080008parallax">Now that I come to think of it, that ball falls at Greenwich time. It's
         the clock is worked by an electric wire from Dunsink. Must go out there
         some first Saturday of the month. If I could get an introduction to
         professor Joly or learn up something about his family. That would do to:
@@ -959,7 +959,7 @@ const Lestrygonians = ({openNote, currentNoteId, visitedNotes, addToVisited}) =>
       </p>
       <p>
         Never know anything about it. Waste of time. Gasballs spinning about,
-        crossing each other, passing. Same old dingdong always. <Annotation annotationId="080031gasthensolid" visited={visitedNotes.has("080031gasthensolid")} annotationSelect={() => {openNote("080031gasthensolid"); addToVisited("080031gasthensolid")}} activeAnnotationId={currentNoteId}>Gas: then solid:
+        crossing each other, passing. Same old dingdong always. <Annotation annotationId="080031gasthensolid">Gas: then solid:
         then world: then cold: then dead shell drifting around, frozen rock</Annotation>,
         like that pineapple rock. The moon. Must be a new moon out, she said. I
         believe there is.
@@ -979,18 +979,18 @@ const Lestrygonians = ({openNote, currentNoteId, visitedNotes, addToVisited}) =>
       </p>
       <span data-edition="ed1939" data-page="122"> </span>
       <p>
-        Mr Bloom, quickbreathing, slowlier walking, passed <Annotation annotationId="080018adamcourt" visited={visitedNotes.has("080018adamcourt")} annotationSelect={() => {openNote("080018adamcourt"); addToVisited("080018adamcourt")}} activeAnnotationId={currentNoteId}>Adam court</Annotation>.
+        Mr Bloom, quickbreathing, slowlier walking, passed <Annotation annotationId="080018adamcourt">Adam court</Annotation>.
       </p>
       <p>
         With a keep quiet relief his eyes took note: this is street here
-        middle of the day <Annotation annotationId="050038bobdoran" visited={visitedNotes.has("050038bobdoran")} annotationSelect={() => {openNote("050038bobdoran"); addToVisited("050038bobdoran")}} activeAnnotationId={currentNoteId}>Bob Doran</Annotation>'s bottle shoulders. On his annual bend,
+        middle of the day <Annotation annotationId="050038bobdoran">Bob Doran</Annotation>'s bottle shoulders. On his annual bend,
         M'Coy said. They drink in order to say or do something or <i>cherchez la
-        femme</i>. Up in <Annotation annotationId="050014thecoombe" visited={visitedNotes.has("050014thecoombe")} annotationSelect={() => {openNote("050014thecoombe"); addToVisited("050014thecoombe")}} activeAnnotationId={currentNoteId}>the Coombe</Annotation> with chummies and streetwalkers and then the
+        femme</i>. Up in <Annotation annotationId="050014thecoombe">the Coombe</Annotation> with chummies and streetwalkers and then the
         rest of the year as sober as a judge.
       </p>
       <p>
-        Yes. Thought so. Sloping into <Annotation annotationId="080018adamcourt" visited={visitedNotes.has("080018adamcourt")} annotationSelect={() => {openNote("080018adamcourt"); addToVisited("080018adamcourt")}} activeAnnotationId={currentNoteId}>the Empire</Annotation>. Gone. Plain soda would do 
-        <span data-edition="ed1922" data-page="159">  </span>him good. Where Pat Kinsella had his <Annotation annotationId="080018adamcourt" visited={visitedNotes.has("080018adamcourt")} annotationSelect={() => {openNote("080018adamcourt"); addToVisited("080018adamcourt")}} activeAnnotationId={currentNoteId}>Harp theatre</Annotation> before Whitbred ran the
+        Yes. Thought so. Sloping into <Annotation annotationId="080018adamcourt">the Empire</Annotation>. Gone. Plain soda would do 
+        <span data-edition="ed1922" data-page="159">  </span>him good. Where Pat Kinsella had his <Annotation annotationId="080018adamcourt">Harp theatre</Annotation> before Whitbred ran the
         Queen's. Broth of a boy. Dion Boucicault business with his harvestmoon
         face in a poky bonnet. Three Purty Maids from School. How time flies,
         eh? Showing long red pantaloons under his skirts. Drinkers, drinking,
@@ -1001,7 +1001,7 @@ const Lestrygonians = ({openNote, currentNoteId, visitedNotes, addToVisited}) =>
       </p>
       <p>
         I was happier then. Or was that I? Or am I now I? Twentyeight I was. She
-        twentythree. When we left Lombard street west something changed. <Annotation annotationId="040087poorlittlerudy" visited={visitedNotes.has("040087poorlittlerudy")} annotationSelect={() => {openNote("040087poorlittlerudy"); addToVisited("040087poorlittlerudy")}} activeAnnotationId={currentNoteId}>Could
+        twentythree. When we left Lombard street west something changed. <Annotation annotationId="040087poorlittlerudy">Could
         never like it again after Rudy. Can't bring back time</Annotation>. Like holding
         water in your hand. Would you go back to then? Just beginning then.
         Would you? Are you not happy in your home you poor little naughty boy?
@@ -1009,9 +1009,9 @@ const Lestrygonians = ({openNote, currentNoteId, visitedNotes, addToVisited}) =>
       </p>
       <p>
         Grafton street gay with housed awnings lured his senses. Muslin prints,
-        silkdames and dowagers, <Annotation annotationId="040091jingle" visited={visitedNotes.has("040091jingle")} annotationSelect={() => {openNote("040091jingle"); addToVisited("040091jingle")}} activeAnnotationId={currentNoteId}> jingle of harnesses, hoofthuds lowringing</Annotation> <span data-edition="ed1986" data-page="137"> </span>in the
+        silkdames and dowagers, <Annotation annotationId="040091jingle"> jingle of harnesses, hoofthuds lowringing</Annotation> <span data-edition="ed1986" data-page="137"> </span>in the
         baking causeway. Thick feet that woman has in the white stockings. Hope
-        the rain mucks them up on her. Countrybred chawbacon. All the <Annotation annotationId="040004beefheels" visited={visitedNotes.has("040004beefheels")} annotationSelect={() => {openNote("040004beefheels"); addToVisited("040004beefheels")}} activeAnnotationId={currentNoteId}>beef to
+        the rain mucks them up on her. Countrybred chawbacon. All the <Annotation annotationId="040004beefheels">beef to
         the heels</Annotation> were in. Always gives a woman clumsy feet. Molly looks out of
         plumb.
       </p>
@@ -1041,11 +1041,11 @@ const Lestrygonians = ({openNote, currentNoteId, visitedNotes, addToVisited}) =>
       </p>
       <p>
         High voices. Sunwarm silk. Jingling harnesses. All for a woman, home and
-        houses, silkwebs, silver, rich fruits spicy from Jaffa. <Annotation annotationId="040061agendath" visited={visitedNotes.has("040061agendath")} annotationSelect={() => {openNote("040061agendath"); addToVisited("040061agendath")}} activeAnnotationId={currentNoteId}>Agendath Netaim.</Annotation>
+        houses, silkwebs, silver, rich fruits spicy from Jaffa. <Annotation annotationId="040061agendath">Agendath Netaim.</Annotation>
         Wealth of the world.
       </p>
       <p>
-        <Annotation annotationId="040063happywarmth" visited={visitedNotes.has("040063happywarmth")} annotationSelect={() => {openNote("040063happywarmth"); addToVisited("040063happywarmth")}} activeAnnotationId={currentNoteId}>A warm human plumpness settled down on his brain.</Annotation> His brain yielded.
+        <Annotation annotationId="040063happywarmth">A warm human plumpness settled down on his brain.</Annotation> His brain yielded.
         Perfume of embraces all him assailed. With hungered flesh obscurely, he
         mutely craved to adore.
       </p>
@@ -1092,8 +1092,8 @@ const Lestrygonians = ({openNote, currentNoteId, visitedNotes, addToVisited}) =>
         him shovelled gurgling soup down his gullet. A man spitting back on his
         plate: halfmasticated gristle: no teeth to chewchewchew it. Chump
         chop <span data-edition="ed1986" data-page="138"> </span>from the grill. Bolting to get it over. Sad booser's eyes. Bitten
-        off more than he can chew. Am I like that? <Annotation annotationId="010052otherssee" visited={visitedNotes.has("010052otherssee")} annotationSelect={() => {openNote("010052otherssee"); addToVisited("010052otherssee")}} activeAnnotationId={currentNoteId}>See ourselves as others see
-        us.</Annotation> Hungry man is an angry man. Working tooth and jaw. Don't! O! <Annotation annotationId="050036saintpatrick" visited={visitedNotes.has("050036saintpatrick")} annotationSelect={() => {openNote("050036saintpatrick"); addToVisited("050036saintpatrick")}} activeAnnotationId={currentNoteId}>A bone!
+        off more than he can chew. Am I like that? <Annotation annotationId="010052otherssee">See ourselves as others see
+        us.</Annotation> Hungry man is an angry man. Working tooth and jaw. Don't! O! <Annotation annotationId="050036saintpatrick">A bone!
         That last pagan king of Ireland Cormac in the schoolpoem choked himself
         at Sletty southward of the Boyne. Wonder what he was eating. Something
         galoptious. Saint Patrick converted him to Christianity. Couldn't
@@ -1107,14 +1107,14 @@ const Lestrygonians = ({openNote, currentNoteId, visitedNotes, addToVisited}) =>
         —{" "}One stew.
       </p>
       <p>
-        Smells of men. His gorge rose. <Annotation annotationId="080022sawdust" visited={visitedNotes.has("080022sawdust")} annotationSelect={() => {openNote("080022sawdust"); addToVisited("080022sawdust")}} activeAnnotationId={currentNoteId}>Spaton sawdust, sweetish warmish
+        Smells of men. His gorge rose. <Annotation annotationId="080022sawdust">Spaton sawdust, sweetish warmish
         cigarette smoke, reek of plug, spilt beer, men's beery piss, the stale
         of ferment.</Annotation>
       </p>
       <p>
         Couldn't eat a morsel here. Fellow sharpening knife and fork to eat all
         before him, old chap picking his tootles. Slight spasm, full, chewing
-        the cud. Before and after. Grace after meals. <Annotation annotationId="010052otherssee" visited={visitedNotes.has("010052otherssee")} annotationSelect={() => {openNote("010052otherssee"); addToVisited("010052otherssee")}} activeAnnotationId={currentNoteId}>Look on this picture then
+        the cud. Before and after. Grace after meals. <Annotation annotationId="010052otherssee">Look on this picture then
         on that.</Annotation> Scoffing up stewgravy with sopping sippets of bread. Lick it
         off the plate, man! Get out of this.
       </p>
@@ -1146,16 +1146,16 @@ const Lestrygonians = ({openNote, currentNoteId, visitedNotes, addToVisited}) =>
         thu Unchster Bunk un Munchday. Ha? Did you, faith?
       </p>
       <p>
-        <Annotation annotationId="080009twofingers" visited={visitedNotes.has("080009twofingers")} annotationSelect={() => {openNote("080009twofingers"); addToVisited("080009twofingers")}} activeAnnotationId={currentNoteId}>Mr Bloom raised two fingers doubtfully to his lips. His eyes said:</Annotation>
+        <Annotation annotationId="080009twofingers">Mr Bloom raised two fingers doubtfully to his lips. His eyes said:</Annotation>
       </p>
       <p>
-        <Annotation annotationId="080009twofingers" visited={visitedNotes.has("080009twofingers")} annotationSelect={() => {openNote("080009twofingers"); addToVisited("080009twofingers")}} activeAnnotationId={currentNoteId}>—{" "}Not here. Don't see him.</Annotation>
+        <Annotation annotationId="080009twofingers">—{" "}Not here. Don't see him.</Annotation>
       </p>
       <p>
         Out. I hate dirty eaters.
       </p>
       <p>
-        He backed towards the door. Get a light snack in <Annotation annotationId="080024davybyrnes" visited={visitedNotes.has("080024davybyrnes")} annotationSelect={() => {openNote("080024davybyrnes"); addToVisited("080024davybyrnes")}} activeAnnotationId={currentNoteId}>Davy Byrne's</Annotation>. Stopgap.
+        He backed towards the door. Get a light snack in <Annotation annotationId="080024davybyrnes">Davy Byrne's</Annotation>. Stopgap.
         Keep me going. Had a good breakfast.
       </p>
       <span data-edition="ed1939" data-page="124"> </span>
@@ -1180,13 +1180,13 @@ const Lestrygonians = ({openNote, currentNoteId, visitedNotes, addToVisited}) =>
         and children cabmen priests parsons fieldmarshals archbishops. From
         <span data-edition="ed1932" data-page="151">  </span>Ailesbury road, Clyde road, artisans' dwellings, north Dublin union,
         lord mayor in his gingerbread coach, old queen in a bathchair. My
-        plate's empty. After you with <Annotation annotationId="050023holywater" visited={visitedNotes.has("050023holywater")} annotationSelect={() => {openNote("050023holywater"); addToVisited("050023holywater")}} activeAnnotationId={currentNoteId}>our incorporated drinkingcup</Annotation>. Like <Annotation annotationId="060022sirphilip" visited={visitedNotes.has("060022sirphilip")} annotationSelect={() => {openNote("060022sirphilip"); addToVisited("060022sirphilip")}} activeAnnotationId={currentNoteId}>sir
+        plate's empty. After you with <Annotation annotationId="050023holywater">our incorporated drinkingcup</Annotation>. Like <Annotation annotationId="060022sirphilip">sir
         Philip Crampton's fountain</Annotation>. Rub off the microbes with your handkerchief.
         Next chap rubs on a new batch with his. Father O'Flynn would make
         hares of them all. Have rows all the same. All for number one. Children
         fighting for the scrapings of the pot. Want a souppot as big as the
         Phoenix park. Harpooning flitches and hindquarters out of it. Hate
-        people all round you. <Annotation annotationId="020066cityarms" visited={visitedNotes.has("020066cityarms")} annotationSelect={() => {openNote("020066cityarms"); addToVisited("020066cityarms")}} activeAnnotationId={currentNoteId}>City Arms hotel</Annotation> <i>table d'hôte</i> <span data-edition="ed1961" data-page="170">  </span>she called it.
+        people all round you. <Annotation annotationId="020066cityarms">City Arms hotel</Annotation> <i>table d'hôte</i> <span data-edition="ed1961" data-page="170">  </span>she called it.
         Soup, joint and sweet. Never know whose thoughts you're chewing. Then
         who'd wash up 
         <span data-edition="ed1922" data-page="162">  </span>
@@ -1197,23 +1197,23 @@ const Lestrygonians = ({openNote, currentNoteId, visitedNotes, addToVisited}) =>
         After all there's a lot in that vegetarian fine flavour of things from
         the earth garlic of course it stinks Italian organgrinders crisp
         of onions mushrooms truffles. Pain to the animal too. Pluck and draw
-        fowl. <Annotation annotationId="040037cattlemarket" visited={visitedNotes.has("040037cattlemarket")} annotationSelect={() => {openNote("040037cattlemarket"); addToVisited("040037cattlemarket")}} activeAnnotationId={currentNoteId}>Wretched brutes there at the cattlemarket</Annotation> waiting for the poleaxe
+        fowl. <Annotation annotationId="040037cattlemarket">Wretched brutes there at the cattlemarket</Annotation> waiting for the poleaxe
         to split their skulls open. Moo. Poor trembling calves. Meh. Staggering
         bob. Bubble and squeak. Butchers' buckets wobble lights. Give us that
         brisket off the hook. Plup. Rawhead and bloody bones. Flayed glasseyed
-        sheep hung from their haunches, <Annotation annotationId="080022sawdust" visited={visitedNotes.has("080022sawdust")} annotationSelect={() => {openNote("080022sawdust"); addToVisited("080022sawdust")}} activeAnnotationId={currentNoteId}>sheepsnouts bloodypapered snivelling
+        sheep hung from their haunches, <Annotation annotationId="080022sawdust">sheepsnouts bloodypapered snivelling
         nosejam on sawdust</Annotation>. Top and lashers going out. Don't maul them pieces,
         young one.
       </p>
       <p>
         Hot fresh blood they prescribe for decline. Blood always needed.
-        Insidious. <Annotation annotationId="060000hades" visited={visitedNotes.has("060000hades")} annotationSelect={() => {openNote("060000hades"); addToVisited("060000hades")}} activeAnnotationId={currentNoteId}>Lick it up smokinghot, thick sugary. Famished ghosts.</Annotation>
+        Insidious. <Annotation annotationId="060000hades">Lick it up smokinghot, thick sugary. Famished ghosts.</Annotation>
       </p>
       <p>
         Ah, I'm hungry.
       </p>
       <p>
-        He entered <Annotation annotationId="080024davybyrnes" visited={visitedNotes.has("080024davybyrnes")} annotationSelect={() => {openNote("080024davybyrnes"); addToVisited("080024davybyrnes")}} activeAnnotationId={currentNoteId}>Davy Byrne's. Moral pub. He doesn't chat. Stands a drink now
+        He entered <Annotation annotationId="080024davybyrnes">Davy Byrne's. Moral pub. He doesn't chat. Stands a drink now
         and then.</Annotation> But in leapyear once in four. Cashed a cheque for me once.
       </p>
       <p>
@@ -1233,11 +1233,11 @@ const Lestrygonians = ({openNote, currentNoteId, visitedNotes, addToVisited}) =>
         see.
       </p>
       <p>
-        Sardines on the shelves. Almost taste them by looking. <Annotation annotationId="080025musteredandbred" visited={visitedNotes.has("080025musteredandbred")} annotationSelect={() => {openNote("080025musteredandbred"); addToVisited("080025musteredandbred")}} activeAnnotationId={currentNoteId}>Sandwich? Ham
-        and his descendants mustered and bred there.</Annotation> Potted meats. <Annotation annotationId="050016pottedmeat" visited={visitedNotes.has("050016pottedmeat")} annotationSelect={() => {openNote("050016pottedmeat"); addToVisited("050016pottedmeat")}} activeAnnotationId={currentNoteId}>What is home
+        Sardines on the shelves. Almost taste them by looking. <Annotation annotationId="080025musteredandbred">Sandwich? Ham
+        and his descendants mustered and bred there.</Annotation> Potted meats. <Annotation annotationId="050016pottedmeat">What is home
         without Plumtree's potted meat? Incomplete. What a stupid ad! Under the
         obituary notices they stuck it.</Annotation> All up a plumtree. Dignam's potted meat.
-        <Annotation annotationId="080006toosalty" visited={visitedNotes.has("080006toosalty")} annotationSelect={() => {openNote("080006toosalty"); addToVisited("080006toosalty")}} activeAnnotationId={currentNoteId}>Cannibals would with lemon and rice. White</Annotation> <span data-edition="ed1932" data-page="152">  </span><Annotation annotationId="080006toosalty" visited={visitedNotes.has("080006toosalty")} annotationSelect={() => {openNote("080006toosalty"); addToVisited("080006toosalty")}} activeAnnotationId={currentNoteId}>missionary too salty. Like
+        <Annotation annotationId="080006toosalty">Cannibals would with lemon and rice. White</Annotation> <span data-edition="ed1932" data-page="152">  </span><Annotation annotationId="080006toosalty">missionary too salty. Like
         pickled pork.</Annotation> Expect the chief consumes the parts of honour. Ought to be
         tough from exercise. His wives in a row to watch the effect. <i>There was
         a right royal old nigger. Who ate or something the somethings of the
@@ -1249,7 +1249,7 @@ const Lestrygonians = ({openNote, currentNoteId, visitedNotes, addToVisited}) =>
         they call now. Yom Kippur fast spring cleaning of inside. Peace and
         war depend on some fellow's digestion. Religions. Christmas turkeys and
         geese. Slaughter of innocents. Eat drink and be merry. Then casual wards
-        full after. Heads bandaged. <Annotation annotationId="080020mitycheese" visited={visitedNotes.has("080020mitycheese")} annotationSelect={() => {openNote("080020mitycheese"); addToVisited("080020mitycheese")}} activeAnnotationId={currentNoteId}>Cheese digests all but itself. Mity cheese.</Annotation>
+        full after. Heads bandaged. <Annotation annotationId="080020mitycheese">Cheese digests all but itself. Mity cheese.</Annotation>
       </p>
       <p>
         —{" "}Have you a cheese sandwich?
@@ -1293,7 +1293,7 @@ const Lestrygonians = ({openNote, currentNoteId, visitedNotes, addToVisited}) =>
         —{" "}No. O, that's the style. Who's getting it up?
       </p>
       <p>
-        The <Annotation annotationId="040044curate" visited={visitedNotes.has("040044curate")} annotationSelect={() => {openNote("040044curate"); addToVisited("040044curate")}} activeAnnotationId={currentNoteId}>curate</Annotation> served.
+        The <Annotation annotationId="040044curate">curate</Annotation> served.
       </p>
       <p>
         —{" "}How much is that?
@@ -1327,7 +1327,7 @@ const Lestrygonians = ({openNote, currentNoteId, visitedNotes, addToVisited}) =>
         mixed up in it?
       </p>
       <p>
-        A warm shock of air heat of mustard <Annotation annotationId="080014hanched" visited={visitedNotes.has("080014hanched")} annotationSelect={() => {openNote("080014hanched"); addToVisited("080014hanched")}} activeAnnotationId={currentNoteId}>hanched</Annotation> on Mr <span data-edition="ed1961" data-page="172">  </span>Bloom's heart. He
+        A warm shock of air heat of mustard <Annotation annotationId="080014hanched">hanched</Annotation> on Mr <span data-edition="ed1961" data-page="172">  </span>Bloom's heart. He
         raised his eyes and met the stare of a bilious clock. Two. Pub clock
         five minutes fast. Time going on. Hands moving. Two. Not yet.
       </p>
@@ -1354,7 +1354,7 @@ const Lestrygonians = ({openNote, currentNoteId, visitedNotes, addToVisited}) =>
       </p>
       <p>
         —{" "}He had a good slice of luck, Jack Mooney was telling me, over that
-        boxingmatch Myler Keogh won again that soldier in the <Annotation annotationId="010013barracks" visited={visitedNotes.has("010013barracks")} annotationSelect={() => {openNote("010013barracks"); addToVisited("010013barracks")}} activeAnnotationId={currentNoteId}>Portobello
+        boxingmatch Myler Keogh won again that soldier in the <Annotation annotationId="010013barracks">Portobello
         barracks</Annotation>. By God, he had the little kipper down in the county Carlow he
         was telling me...
       </p>
@@ -1438,8 +1438,8 @@ const Lestrygonians = ({openNote, currentNoteId, visitedNotes, addToVisited}) =>
         Will I tell him that horse Lenehan? He knows already. Better let him
         forget. Go and lose more. Fool and his money. Dewdrop coming down again.
         Cold nose he'd have kissing a woman. Still they might like. Prickly
-        beards they like. Dogs' cold noses. <Annotation annotationId="060015riordan" visited={visitedNotes.has("060015riordan")} annotationSelect={() => {openNote("060015riordan"); addToVisited("060015riordan")}} activeAnnotationId={currentNoteId}>Old Mrs Riordan</Annotation> with the rumbling
-        stomach's Skye terrier in the <Annotation annotationId="020066cityarms" visited={visitedNotes.has("020066cityarms")} annotationSelect={() => {openNote("020066cityarms"); addToVisited("020066cityarms")}} activeAnnotationId={currentNoteId}>City Arms hotel</Annotation>. Molly fondling him in her
+        beards they like. Dogs' cold noses. <Annotation annotationId="060015riordan">Old Mrs Riordan</Annotation> with the rumbling
+        stomach's Skye terrier in the <Annotation annotationId="020066cityarms">City Arms hotel</Annotation>. Molly fondling him in her
         lap. O, the big doggybowwowsywowsy!
       </p>
       <p>
@@ -1461,9 +1461,9 @@ const Lestrygonians = ({openNote, currentNoteId, visitedNotes, addToVisited}) =>
         Gaudy colour warns you off. One fellow told another and so on. Try it
         on the dog first. Led on by the smell or the look. <span data-edition="ed1932" data-page="155">  </span>Tempting fruit.
         Ice cones. Cream. Instinct. Orangegroves for instance. Need artificial
-        irrigation. <Annotation annotationId="040064bleibtreustrasse" visited={visitedNotes.has("040064bleibtreustrasse")} annotationSelect={() => {openNote("040064bleibtreustrasse"); addToVisited("040064bleibtreustrasse")}} activeAnnotationId={currentNoteId}>Bleibtreustrasse.</Annotation> Yes but what about oysters. Unsightly like
+        irrigation. <Annotation annotationId="040064bleibtreustrasse">Bleibtreustrasse.</Annotation> Yes but what about oysters. Unsightly like
         a clot of phlegm. Filthy <span data-edition="ed1961" data-page="174">  </span>shells. Devil to open them too. Who found them
-        out? Garbage, <Annotation annotationId="030039sewage" visited={visitedNotes.has("030039sewage")} annotationSelect={() => {openNote("030039sewage"); addToVisited("030039sewage")}} activeAnnotationId={currentNoteId}>sewage they feed on</Annotation>. Fizz and <Annotation annotationId="060020redbank" visited={visitedNotes.has("060020redbank")} annotationSelect={() => {openNote("060020redbank"); addToVisited("060020redbank")}} activeAnnotationId={currentNoteId}>Red bank oysters. Effect
+        out? Garbage, <Annotation annotationId="030039sewage">sewage they feed on</Annotation>. Fizz and <Annotation annotationId="060020redbank">Red bank oysters. Effect
         on the sexual. Aphrodis. He was in the Red Bank</Annotation> this morning. Was he
         oyster old fish at table perhaps he young flesh in bed no June has
         no ar no oysters. But there are people like tainted game.
@@ -1491,10 +1491,10 @@ const Lestrygonians = ({openNote, currentNoteId, visitedNotes, addToVisited}) =>
         halfnaked ladies. May I tempt you to a little more filleted lemon sole,
         miss Dubedat? Yes, do bedad. And she did bedad. Huguenot name I expect
         that. A miss Dubedat lived in Killiney, I remember. <i>Du, de, la,</i> French.
-        <Annotation annotationId="080008parallax" visited={visitedNotes.has("080008parallax")} annotationSelect={() => {openNote("080008parallax"); addToVisited("080008parallax")}} activeAnnotationId={currentNoteId}>Still it's the same fish</Annotation> perhaps old <Annotation annotationId="080003moorestreet" visited={visitedNotes.has("080003moorestreet")} annotationSelect={() => {openNote("080003moorestreet"); addToVisited("080003moorestreet")}} activeAnnotationId={currentNoteId}>Micky Hanlon of Moore street</Annotation> ripped
+        <Annotation annotationId="080008parallax">Still it's the same fish</Annotation> perhaps old <Annotation annotationId="080003moorestreet">Micky Hanlon of Moore street</Annotation> ripped
         the guts out of making money hand over fist, finger in fishes' gills,
         can't write his name on a cheque, think he was painting the landscape
-        with his mouth twisted. Moooikill A Aitcha Ha ignorant as <Annotation annotationId="020076brogues" visited={visitedNotes.has("020076brogues")} annotationSelect={() => {openNote("020076brogues"); addToVisited("020076brogues")}} activeAnnotationId={currentNoteId}>a kish of
+        with his mouth twisted. Moooikill A Aitcha Ha ignorant as <Annotation annotationId="020076brogues">a kish of
         brogues</Annotation>, worth fifty thousand pounds.
       </p>
       <p>
@@ -1509,13 +1509,13 @@ const Lestrygonians = ({openNote, currentNoteId, visitedNotes, addToVisited}) =>
         Fields of undersea, the lines faint brown in grass, buried cities.
         Pillowed on my coat she had her hair, earwigs in the heather scrub
         my hand under her nape, you'll toss me all. O wonder! Coolsoft with
-        ointments <Annotation annotationId="180006lordbyron" visited={visitedNotes.has("180006lordbyron")} annotationSelect={() => {openNote("180006lordbyron"); addToVisited("180006lordbyron")}} activeAnnotationId={currentNoteId}>her hand touched me, caressed: her eyes upon me did not turn
-        away</Annotation>. <Annotation annotationId="180006lordbyron" visited={visitedNotes.has("180006lordbyron")} annotationSelect={() => {openNote("180006lordbyron"); addToVisited("180006lordbyron")}} activeAnnotationId={currentNoteId}>Ravished over her I lay</Annotation>, full lips full open, kissed her mouth.
+        ointments <Annotation annotationId="180006lordbyron">her hand touched me, caressed: her eyes upon me did not turn
+        away</Annotation>. <Annotation annotationId="180006lordbyron">Ravished over her I lay</Annotation>, full lips full open, kissed her mouth.
         Yum. Softly she gave me in my mouth the seedcake warm and chewed.
         Mawkish pulp her mouth had mumbled sweet and sour with spittle. Joy: I ate
         it: joy. Young life, her lips that gave me pouting. Soft, warm, sticky
         gumjelly lips. Flowers her eyes were, take me, willing eyes. 
-        <span data-edition="ed1922" data-page="167">  </span><Annotation annotationId="030038pebbles" visited={visitedNotes.has("030038pebbles")} annotationSelect={() => {openNote("030038pebbles"); addToVisited("030038pebbles")}} activeAnnotationId={currentNoteId}>Pebbles fell.</Annotation> She lay still. A goat. No-one. High on Ben Howth 
+        <span data-edition="ed1922" data-page="167">  </span><Annotation annotationId="030038pebbles">Pebbles fell.</Annotation> She lay still. A goat. No-one. High on Ben Howth 
         <span data-edition="ed1939" data-page="128"> </span>
         rhododendrons a
         nannygoat walking surefooted, dropping currants. Screened under ferns
@@ -1533,16 +1533,16 @@ const Lestrygonians = ({openNote, currentNoteId, visitedNotes, addToVisited}) =>
       <p>
         His downcast eyes followed the silent veining of the oaken slab. Beauty:
         it curves: curves are beauty. Shapely goddesses, Venus, Juno: curves the
-        world admires. <Annotation annotationId="080005venus" visited={visitedNotes.has("080005venus")} annotationSelect={() => {openNote("080005venus"); addToVisited("080005venus")}} activeAnnotationId={currentNoteId}>Can see them library museum standing in the round hall,
+        world admires. <Annotation annotationId="080005venus">Can see them library museum standing in the round hall,
         naked goddesses.</Annotation> Aids to digestion. They don't care what man looks. All
         to see. Never speaking. I mean to say to fellows like Flynn. Suppose she
         did Pygmalion and Galatea what would she say first? Mortal! Put you in
         your proper place. Quaffing nectar at mess with gods golden dishes, all
-        ambrosial. Not like <Annotation annotationId="010019money" visited={visitedNotes.has("010019money")} annotationSelect={() => {openNote("010019money"); addToVisited("010019money")}} activeAnnotationId={currentNoteId}>a tanner lunch</Annotation> we have, boiled mutton, carrots and
-        turnips, bottle of Allsop. <Annotation annotationId="040048slimmer" visited={visitedNotes.has("040048slimmer")} annotationSelect={() => {openNote("040048slimmer"); addToVisited("040048slimmer")}} activeAnnotationId={currentNoteId}>Nectar imagine it drinking electricity: gods'
+        ambrosial. Not like <Annotation annotationId="010019money">a tanner lunch</Annotation> we have, boiled mutton, carrots and
+        turnips, bottle of Allsop. <Annotation annotationId="040048slimmer">Nectar imagine it drinking electricity: gods'
         food. Lovely forms of woman sculped Junonian. Immortal lovely.</Annotation> And we
         stuffing food in one hole and out behind: food, chyle, blood, dung,
-        <span data-edition="ed1986" data-page="144"> </span>earth, food: have to feed it like stoking an engine. <Annotation annotationId="040015whitebutton" visited={visitedNotes.has("040015whitebutton")} annotationSelect={() => {openNote("040015whitebutton"); addToVisited("040015whitebutton")}} activeAnnotationId={currentNoteId}>They have no.</Annotation> Never
+        <span data-edition="ed1986" data-page="144"> </span>earth, food: have to feed it like stoking an engine. <Annotation annotationId="040015whitebutton">They have no.</Annotation> Never
         looked. I'll look today. Keeper won't see. Bend down let something fall
         see if she.
       </p>
@@ -1560,7 +1560,7 @@ const Lestrygonians = ({openNote, currentNoteId, visitedNotes, addToVisited}) =>
         —{" "}What is this he is? Isn't he in the insurance line?
       </p>
       <p>
-        —{" "}He's out of that long ago, Nosey Flynn said. <Annotation annotationId="050021freeman" visited={visitedNotes.has("050021freeman")} annotationSelect={() => {openNote("050021freeman"); addToVisited("050021freeman")}} activeAnnotationId={currentNoteId}>He does canvassing for
+        —{" "}He's out of that long ago, Nosey Flynn said. <Annotation annotationId="050021freeman">He does canvassing for
         the <i>Freeman.</i></Annotation>
       </p>
       <p>
@@ -1583,7 +1583,7 @@ const Lestrygonians = ({openNote, currentNoteId, visitedNotes, addToVisited}) =>
       </p>
       <p>
         —{" "}It's not the wife anyhow, Nosey Flynn said. I met him the day before 
-        <span data-edition="ed1922" data-page="168">  </span>yesterday and he <Annotation annotationId="080015nolanswife" visited={visitedNotes.has("080015nolanswife")} annotationSelect={() => {openNote("080015nolanswife"); addToVisited("080015nolanswife")}} activeAnnotationId={currentNoteId}>coming out of that Irish farm dairy John Wyse Nolan's
+        <span data-edition="ed1922" data-page="168">  </span>yesterday and he <Annotation annotationId="080015nolanswife">coming out of that Irish farm dairy John Wyse Nolan's
         wife has in Henry street</Annotation> with a jar of cream in his hand taking it home
         to his better half. She's well nourished, I tell you. Plovers on toast.
       </p>
@@ -1631,7 +1631,7 @@ const Lestrygonians = ({openNote, currentNoteId, visitedNotes, addToVisited}) =>
       </p>
       <p>
         —{" "}There was one woman, Nosey Flynn said, hid herself in a clock to find
-        out what they <Annotation annotationId="090012brogue" visited={visitedNotes.has("090012brogue")} annotationSelect={() => {openNote("090012brogue"); addToVisited("090012brogue")}} activeAnnotationId={currentNoteId}>do be doing</Annotation>. But be damned but they smelt her out and
+        out what they <Annotation annotationId="090012brogue">do be doing</Annotation>. But be damned but they smelt her out and
         swore her in on the spot a master <span data-edition="ed1961" data-page="177">  </span>mason. That was one of the saint
         Legers of Doneraile.
       </p>
@@ -1668,7 +1668,7 @@ const Lestrygonians = ({openNote, currentNoteId, visitedNotes, addToVisited}) =>
       </p>
       <span data-edition="ed1922" data-page="169">  </span>
       <p>
-        —{" "}<Annotation annotationId="080026blackandwhite" visited={visitedNotes.has("080026blackandwhite")} annotationSelect={() => {openNote("080026blackandwhite"); addToVisited("080026blackandwhite")}} activeAnnotationId={currentNoteId}>Nothing in black and white</Annotation>, Nosey Flynn said.
+        —{" "}<Annotation annotationId="080026blackandwhite">Nothing in black and white</Annotation>, Nosey Flynn said.
       </p>
       <p>
         Paddy Leonard and Bantam Lyons came in. Tom Rochford followed,
@@ -1700,7 +1700,7 @@ const Lestrygonians = ({openNote, currentNoteId, visitedNotes, addToVisited}) =>
         yours, Tom?
       </p>
       <p>
-        —{" "}How is <Annotation annotationId="030039sewage" visited={visitedNotes.has("030039sewage")} annotationSelect={() => {openNote("030039sewage"); addToVisited("030039sewage")}} activeAnnotationId={currentNoteId}>the main drainage</Annotation>? Nosey Flynn asked, sipping.
+        —{" "}How is <Annotation annotationId="030039sewage">the main drainage</Annotation>? Nosey Flynn asked, sipping.
       </p>
       <p>
         For answer Tom Rochford pressed his hand to his breastbone and
@@ -1729,7 +1729,7 @@ const Lestrygonians = ({openNote, currentNoteId, visitedNotes, addToVisited}) =>
         him.
       </p>
       <p>
-        —{" "}<Annotation annotationId="030039sewage" visited={visitedNotes.has("030039sewage")} annotationSelect={() => {openNote("030039sewage"); addToVisited("030039sewage")}} activeAnnotationId={currentNoteId}>That cursed dyspepsia</Annotation>, he said before drinking.
+        —{" "}<Annotation annotationId="030039sewage">That cursed dyspepsia</Annotation>, he said before drinking.
       </p>
       <p>
         —{" "}Breadsoda is very good, Davy Byrne said.
@@ -1776,7 +1776,7 @@ const Lestrygonians = ({openNote, currentNoteId, visitedNotes, addToVisited}) =>
       </p>
       <p>
         Mr Bloom walked towards Dawson street, his tongue brushing his teeth
-        smooth. Something green it would have to be: spinach, say. <Annotation annotationId="080011xrays" visited={visitedNotes.has("080011xrays")} annotationSelect={() => {openNote("080011xrays"); addToVisited("080011xrays")}} activeAnnotationId={currentNoteId}>Then with
+        smooth. Something green it would have to be: spinach, say. <Annotation annotationId="080011xrays">Then with
         those Röntgen rays searchlight you could.</Annotation>
       </p>
       <p>
@@ -1793,12 +1793,12 @@ const Lestrygonians = ({openNote, currentNoteId, visitedNotes, addToVisited}) =>
         He hummed, prolonging in solemn echo the closes of the bars:
       </p>
       <p>
-        <Annotation annotationId="080030cenarteco" visited={visitedNotes.has("080030cenarteco")} annotationSelect={() => {openNote("080030cenarteco"); addToVisited("080030cenarteco")}} activeAnnotationId={currentNoteId}><i>Don Giovanni, a cenar teco <br/>
+        <Annotation annotationId="080030cenarteco"><i>Don Giovanni, a cenar teco <br/>
         M'invitasti.</i></Annotation>
       </p>
       <p>
         Feel better. Burgundy. Good pick me up. Who distilled first? Some chap
-        in the blues. Dutch courage. That <i>Kilkenny People</i> in <Annotation annotationId="010144nationallibrary" visited={visitedNotes.has("010144nationallibrary")} annotationSelect={() => {openNote("010144nationallibrary"); addToVisited("010144nationallibrary")}} activeAnnotationId={currentNoteId}>the national
+        in the blues. Dutch courage. That <i>Kilkenny People</i> in <Annotation annotationId="010144nationallibrary">the national
         library</Annotation> now I must.
       </p>
       <p>
@@ -1825,7 +1825,7 @@ const Lestrygonians = ({openNote, currentNoteId, visitedNotes, addToVisited}) =>
       </p>
       <span data-edition="ed1922" data-page="171">  </span>
       <p>
-        Keyes: two months if I get <Annotation annotationId="070019nannetti" visited={visitedNotes.has("070019nannetti")} annotationSelect={() => {openNote("070019nannetti"); addToVisited("070019nannetti")}} activeAnnotationId={currentNoteId}>Nannetti</Annotation> to. That'll be two pounds ten about
+        Keyes: two months if I get <Annotation annotationId="070019nannetti">Nannetti</Annotation> to. That'll be two pounds ten about
         two pounds eight. Three Hynes owes me. Two eleven. Prescott's dyeworks
         van over there. If I get Billy Prescott's ad: two fifteen. Five guineas
         about. On the pig's back.
@@ -1840,7 +1840,7 @@ const Lestrygonians = ({openNote, currentNoteId, visitedNotes, addToVisited}) =>
       <span data-edition="ed1939" data-page="131"> </span>
       <span data-edition="ed1986" data-page="147"> </span>
       <p>
-        Tour the south then. What about <Annotation annotationId="040069seasidegirls" visited={visitedNotes.has("040069seasidegirls")} annotationSelect={() => {openNote("040069seasidegirls"); addToVisited("040069seasidegirls")}} activeAnnotationId={currentNoteId}>English wateringplaces? Brighton,
+        Tour the south then. What about <Annotation annotationId="040069seasidegirls">English wateringplaces? Brighton,
         Margate. Piers by moonlight. Her voice floating out. Those lovely
         seaside girls.</Annotation> Against John Long's a drowsing loafer lounged in heavy
         thought, gnawing a crusted knuckle. Handy man wants job. Small wages.
@@ -1871,7 +1871,7 @@ const Lestrygonians = ({openNote, currentNoteId, visitedNotes, addToVisited}) =>
       </p>
       <p>
         The cane moved out trembling to the left. Mr Bloom's eye followed its
-        line and saw again the dyeworks' van drawn up before <Annotation annotationId="040062bolandsbread" visited={visitedNotes.has("040062bolandsbread")} annotationSelect={() => {openNote("040062bolandsbread"); addToVisited("040062bolandsbread")}} activeAnnotationId={currentNoteId}>Drago's</Annotation>. Where I
+        line and saw again the dyeworks' van drawn up before <Annotation annotationId="040062bolandsbread">Drago's</Annotation>. Where I
         saw his brillantined hair just when I <span data-edition="ed1961" data-page="180">  </span>was. Horse drooping. Driver in
         John Long's. Slaking his drouth.
       </p>
@@ -1985,15 +1985,15 @@ const Lestrygonians = ({openNote, currentNoteId, visitedNotes, addToVisited}) =>
       <p>
         Poor fellow! Quite a boy. Terrible. Really terrible. What dreams would
         he have, not seeing? Life a dream for him. Where is the justice being
-        born that way? <Annotation annotationId="100008generalslocum" visited={visitedNotes.has("100008generalslocum")} annotationSelect={() => {openNote("100008generalslocum"); addToVisited("100008generalslocum")}} activeAnnotationId={currentNoteId}>All those women and children excursion beanfeast burned
+        born that way? <Annotation annotationId="100008generalslocum">All those women and children excursion beanfeast burned
         and drowned in New York.</Annotation> Holocaust. Karma they call that transmigration
         for sins you did in a past life the reincarnation met him pike hoses.
         Dear, dear, dear. Pity, of course: but somehow you can't cotton on to
         them someway.
       </p>
       <p>
-        <Annotation annotationId="080002sirfrederick" visited={visitedNotes.has("080002sirfrederick")} annotationSelect={() => {openNote("080002sirfrederick"); addToVisited("080002sirfrederick")}} activeAnnotationId={currentNoteId}>Sir Frederick Falkiner</Annotation> going into the freemasons' hall. Solemn as Troy.
-        After his good lunch in <Annotation annotationId="080002sirfrederick" visited={visitedNotes.has("080002sirfrederick")} annotationSelect={() => {openNote("080002sirfrederick"); addToVisited("080002sirfrederick")}} activeAnnotationId={currentNoteId}>Earlsfort terrace</Annotation>. Old legal cronies cracking
+        <Annotation annotationId="080002sirfrederick">Sir Frederick Falkiner</Annotation> going into the freemasons' hall. Solemn as Troy.
+        After his good lunch in <Annotation annotationId="080002sirfrederick">Earlsfort terrace</Annotation>. Old legal cronies cracking
         a magnum. Tales of the bench and assizes and annals of the bluecoat
         school. I <span data-edition="ed1986" data-page="149"> </span>sentenced him to ten years. I suppose he'd turn up his nose
         at that stuff I drank. Vintage wine for them, the year marked on a
@@ -2006,7 +2006,7 @@ const Lestrygonians = ({openNote, currentNoteId, visitedNotes, addToVisited}) =>
       </p>
       <p>
         Hello, placard. Mirus bazaar. His Excellency the lord lieutenant.
-        Sixteenth. Today it is. <Annotation annotationId="080004themessiah" visited={visitedNotes.has("080004themessiah")} annotationSelect={() => {openNote("080004themessiah"); addToVisited("080004themessiah")}} activeAnnotationId={currentNoteId}>In aid of funds for Mercer's hospital. <i>The
+        Sixteenth. Today it is. <Annotation annotationId="080004themessiah">In aid of funds for Mercer's hospital. <i>The
         Messiah</i> was first given for that.</Annotation> Yes. Handel. What about going out
         there: Ballsbridge. Drop in on Keyes. No use sticking to him like a
         leech. Wear out my welcome. Sure to know someone on the gate.
@@ -2027,7 +2027,7 @@ const Lestrygonians = ({openNote, currentNoteId, visitedNotes, addToVisited}) =>
       <span data-edition="ed1922" data-page="174"> </span>
       <p>
         Making for the museum gate with long windy strides he lifted his eyes.
-        <Annotation annotationId="010144nationallibrary" visited={visitedNotes.has("010144nationallibrary")} annotationSelect={() => {openNote("010144nationallibrary"); addToVisited("010144nationallibrary")}} activeAnnotationId={currentNoteId}>Handsome building. Sir Thomas Deane designed.</Annotation> Not following me?
+        <Annotation annotationId="010144nationallibrary">Handsome building. Sir Thomas Deane designed.</Annotation> Not following me?
       </p>
       <p>
         Didn't see me perhaps. Light in his eyes.
@@ -2064,7 +2064,7 @@ const Lestrygonians = ({openNote, currentNoteId, visitedNotes, addToVisited}) =>
       </p>
       <p>
         I am looking for that. Yes, that. Try all pockets. Handker. <i>Freeman.</i>
-        Where did I? Ah, yes. Trousers. Purse. <Annotation annotationId="040047potato" visited={visitedNotes.has("040047potato")} annotationSelect={() => {openNote("040047potato"); addToVisited("040047potato")}} activeAnnotationId={currentNoteId}>Potato.</Annotation> Where did I?
+        Where did I? Ah, yes. Trousers. Purse. <Annotation annotationId="040047potato">Potato.</Annotation> Where did I?
       </p>
       <p>
         Hurry. Walk quietly. Moment more. My heart.

--- a/src/content/chapters/LotusEaters.js
+++ b/src/content/chapters/LotusEaters.js
@@ -1,23 +1,23 @@
 import Annotation from "../../components/Annotation";
 
 
-const LotusEaters = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
+const LotusEaters = () => {
   return (
     <div>
       <p></p>
-      <center><Annotation annotationId="050000lotuseaters" visited={visitedNotes.has("050000lotuseaters")} annotationSelect={() => {openNote("050000lotuseaters"); addToVisited("050000lotuseaters")}} activeAnnotationId={currentNoteId}><font size="+2">[5]</font></Annotation></center>
+      <center><Annotation annotationId="050000lotuseaters"><font size="+2">[5]</font></Annotation></center>
       <br/>
-      By lorries along <Annotation annotationId="050005rogersonsquay" visited={visitedNotes.has("050005rogersonsquay")} annotationSelect={() => {openNote("050005rogersonsquay"); addToVisited("050005rogersonsquay")}} activeAnnotationId={currentNoteId}>sir John Rogerson's quay</Annotation> Mr Bloom walked soberly,
-      <Annotation annotationId="050011leasks" visited={visitedNotes.has("050011leasks")} annotationSelect={() => {openNote("050011leasks"); addToVisited("050011leasks")}} activeAnnotationId={currentNoteId}>past Windmill lane, Leask's the linseed crusher, the postal telegraph office.
+      By lorries along <Annotation annotationId="050005rogersonsquay">sir John Rogerson's quay</Annotation> Mr Bloom walked soberly,
+      <Annotation annotationId="050011leasks">past Windmill lane, Leask's the linseed crusher, the postal telegraph office.
       Could have given that address too. And past the sailors' home.</Annotation> He turned
-      from the morning noises of the quayside and walked through <Annotation annotationId="050007limestreet" visited={visitedNotes.has("050007limestreet")} annotationSelect={() => {openNote("050007limestreet"); addToVisited("050007limestreet")}} activeAnnotationId={currentNoteId}>Lime street.
+      from the morning noises of the quayside and walked through <Annotation annotationId="050007limestreet">Lime street.
       By Brady's cottages a boy for the skins lolled, his bucket of offal
       linked,</Annotation> smoking a chewed fagbutt. A smaller girl with scars of eczema
-      on her forehead eyed him, listlessly holding her battered caskhoop. <Annotation annotationId="100002tobacco" visited={visitedNotes.has("100002tobacco")} annotationSelect={() => {openNote("100002tobacco"); addToVisited("100002tobacco")}} activeAnnotationId={currentNoteId}>Tell
+      on her forehead eyed him, listlessly holding her battered caskhoop. <Annotation annotationId="100002tobacco">Tell
       him if he smokes he won't grow.</Annotation> O let him! His life isn't such a bed of
-      roses. Waiting outside <Annotation annotationId="050048pubs" visited={visitedNotes.has("050048pubs")} annotationSelect={() => {openNote("050048pubs"); addToVisited("050048pubs")}} activeAnnotationId={currentNoteId}>pubs</Annotation> to bring da home. <Annotation annotationId="050049comehometoma" visited={visitedNotes.has("050049comehometoma")} annotationSelect={() => {openNote("050049comehometoma"); addToVisited("050049comehometoma")}} activeAnnotationId={currentNoteId}>Come home to ma, da.</Annotation>
+      roses. Waiting outside <Annotation annotationId="050048pubs">pubs</Annotation> to bring da home. <Annotation annotationId="050049comehometoma">Come home to ma, da.</Annotation>
       Slack hour: won't be many there. He crossed Townsend street, passed
-      the frowning face of <Annotation annotationId="050009bethel" visited={visitedNotes.has("050009bethel")} annotationSelect={() => {openNote("050009bethel"); addToVisited("050009bethel")}} activeAnnotationId={currentNoteId}>Bethel. El, yes: house of: Aleph, Beth.</Annotation> And past
+      the frowning face of <Annotation annotationId="050009bethel">Bethel. El, yes: house of: Aleph, Beth.</Annotation> And past
       Nichols' the undertaker. At eleven it is. Time enough. Daresay Corny
       Kelleher bagged the job for O'Neill's. Singing with his eyes shut.
       Corny. Met her once in the park. In the dark. What a lark. Police tout.
@@ -28,13 +28,13 @@ const LotusEaters = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       <p>
         In Westland row he halted before the window of the Belfast and <span data-edition="ed1932" data-page="62"> </span>Oriental
         Tea Company and read the legends of leadpapered packets: choice blend,
-        finest quality, family tea. Rather warm. <Annotation annotationId="050037tomkernan" visited={visitedNotes.has("050037tomkernan")} annotationSelect={() => {openNote("050037tomkernan"); addToVisited("050037tomkernan")}} activeAnnotationId={currentNoteId}>Tea. Must get some from Tom
+        finest quality, family tea. Rather warm. <Annotation annotationId="050037tomkernan">Tea. Must get some from Tom
         Kernan.</Annotation> Couldn't ask him at a funeral, though. While his eyes still read
         blandly he took off his hat quietly inhaling his hairoil and sent his
         right hand with slow grace over his brow and hair. Very warm morning.
         Under their dropped lids his eyes found the tiny bow of the leather
-        headband inside his <Annotation annotationId="040082highgradeha" visited={visitedNotes.has("040082highgradeha")} annotationSelect={() => {openNote("040082highgradeha"); addToVisited("040082highgradeha")}} activeAnnotationId={currentNoteId}>high grade ha</Annotation>. Just there. His right hand came down
-        into the bowl of his hat. His fingers found quickly <Annotation annotationId="050015thecard" visited={visitedNotes.has("050015thecard")} annotationSelect={() => {openNote("050015thecard"); addToVisited("050015thecard")}} activeAnnotationId={currentNoteId}>a card behind the
+        headband inside his <Annotation annotationId="040082highgradeha">high grade ha</Annotation>. Just there. His right hand came down
+        into the bowl of his hat. His fingers found quickly <Annotation annotationId="050015thecard">a card behind the
         headband</Annotation> and transferred it to his waistcoat pocket.
       </p>
       <p>
@@ -44,17 +44,17 @@ const LotusEaters = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         must be: the garden of the world, big lazy leaves to float about on,
         cactuses, flowery meads, snaky lianas they call them. Wonder is it like
         that. Those Cinghalese lobbing about in the sun in <i>dolce far niente</i>,
-        not doing a hand's turn all day. <Annotation annotationId="050000lotuseaters" visited={visitedNotes.has("050000lotuseaters")} annotationSelect={() => {openNote("050000lotuseaters"); addToVisited("050000lotuseaters")}} activeAnnotationId={currentNoteId}>Sleep six months out of twelve.</Annotation> Too hot
+        not doing a hand's turn all day. <Annotation annotationId="050000lotuseaters">Sleep six months out of twelve.</Annotation> Too hot
         to quarrel. Influence of the climate. Lethargy. Flowers of idleness. The
-        air feeds most. Azotes. <Annotation annotationId="050025botanicgardens" visited={visitedNotes.has("050025botanicgardens")} annotationSelect={() => {openNote("050025botanicgardens"); addToVisited("050025botanicgardens")}} activeAnnotationId={currentNoteId}>Hothouse in Botanic gardens. Sensitive plants.
+        air feeds most. Azotes. <Annotation annotationId="050025botanicgardens">Hothouse in Botanic gardens. Sensitive plants.
         Waterlilies.</Annotation> Petals too tired <span data-edition="ed1986" data-page="58"> </span>to. Sleeping sickness <span data-edition="ed1961" data-page="71"> </span>in the air. Walk on
         roseleaves. Imagine trying to eat tripe and cowheel. Where was the chap
-        I saw in that picture somewhere? <Annotation annotationId="050019couldntsink" visited={visitedNotes.has("050019couldntsink")} annotationSelect={() => {openNote("050019couldntsink"); addToVisited("050019couldntsink")}} activeAnnotationId={currentNoteId}>Ah yes, in the dead sea floating on his
+        I saw in that picture somewhere? <Annotation annotationId="050019couldntsink">Ah yes, in the dead sea floating on his
         back, reading a book with a parasol open. Couldn't sink if you tried: so
         thick with salt. Because the weight of the water, no, the weight of
         the body in the water is equal to the weight of the what?</Annotation> Or is it the
         <span data-edition="ed1939" data-page="55"> </span>
-        volume is equal to the weight? It's a law something like that. <Annotation annotationId="050020highschool" visited={visitedNotes.has("050020highschool")} annotationSelect={() => {openNote("050020highschool"); addToVisited("050020highschool")}} activeAnnotationId={currentNoteId}>Vance in
+        volume is equal to the weight? It's a law something like that. <Annotation annotationId="050020highschool">Vance in
         High school cracking his fingerjoints, teaching. The college curriculum.</Annotation>
         Cracking curriculum. What is weight really when you say the weight?
         Thirtytwo feet per second per second. Law of falling bodies: per second
@@ -63,7 +63,7 @@ const LotusEaters = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <p>
         He turned away and sauntered across the road. How did she walk with her
-        sausages? Like that something. As he walked he took the folded <Annotation annotationId="050021freeman" visited={visitedNotes.has("050021freeman")} annotationSelect={() => {openNote("050021freeman"); addToVisited("050021freeman")}} activeAnnotationId={currentNoteId}><i>Freeman</i></Annotation>
+        sausages? Like that something. As he walked he took the folded <Annotation annotationId="050021freeman"><i>Freeman</i></Annotation>
         from his sidepocket, unfolded it, rolled it lengthwise in a baton and
         tapped it at each sauntering step against his trouserleg. Careless air:
         just drop in to see. Per second per second. Per second for every second
@@ -80,7 +80,7 @@ const LotusEaters = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         While the postmistress searched a pigeonhole he gazed at the recruiting
         poster with soldiers of all arms on parade: and held the tip of <span data-edition="ed1932" data-page="63"> </span>his
         baton against his nostrils, smelling freshprinted rag paper. No answer
-        probably. <Annotation annotationId="050003otherworld" visited={visitedNotes.has("050003otherworld")} annotationSelect={() => {openNote("050003otherworld"); addToVisited("050003otherworld")}} activeAnnotationId={currentNoteId}>Went too far last time.</Annotation>
+        probably. <Annotation annotationId="050003otherworld">Went too far last time.</Annotation>
       </p>
       <p>
         The postmistress handed him back through the grill his card with a
@@ -88,7 +88,7 @@ const LotusEaters = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <br/>
       <p style={{textIndent:"2in"}}>
-        <Annotation annotationId="050026henryflower" visited={visitedNotes.has("050026henryflower")} annotationSelect={() => {openNote("050026henryflower"); addToVisited("050026henryflower")}} activeAnnotationId={currentNoteId}>Henry Flower</Annotation>, Esq, 
+        <Annotation annotationId="050026henryflower">Henry Flower</Annotation>, Esq, 
       </p>
       <p style={{textIndent:"2.5in"}}>
         c/o P. O. Westland Row, 
@@ -100,19 +100,19 @@ const LotusEaters = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       <span data-edition="ed1922" data-page="69"> </span>
       <p>
         Answered anyhow. He slipped card and letter into his sidepocket,
-        reviewing again the soldiers on parade. Where's <Annotation annotationId="040018oldtweedy" visited={visitedNotes.has("040018oldtweedy")} annotationSelect={() => {openNote("040018oldtweedy"); addToVisited("040018oldtweedy")}} activeAnnotationId={currentNoteId}>old Tweedy's regiment</Annotation>?
+        reviewing again the soldiers on parade. Where's <Annotation annotationId="040018oldtweedy">old Tweedy's regiment</Annotation>?
         Castoff soldier. There: bearskin cap and hackle plume. No, he's a
-        grenadier. Pointed cuffs. There he is: <Annotation annotationId="030118royaldublins" visited={visitedNotes.has("030118royaldublins")} annotationSelect={() => {openNote("030118royaldublins"); addToVisited("030118royaldublins")}} activeAnnotationId={currentNoteId}>royal Dublin fusiliers. Redcoats.</Annotation>
+        grenadier. Pointed cuffs. There he is: <Annotation annotationId="030118royaldublins">royal Dublin fusiliers. Redcoats.</Annotation>
         Too showy. That must be why the women go after them. Uniform. Easier to
-        enlist and drill. <Annotation annotationId="050002maudgonne" visited={visitedNotes.has("050002maudgonne")} annotationSelect={() => {openNote("050002maudgonne"); addToVisited("050002maudgonne")}} activeAnnotationId={currentNoteId}>Maud Gonne's letter</Annotation> about taking them off <Annotation annotationId="060012liberatorsform" visited={visitedNotes.has("060012liberatorsform")} annotationSelect={() => {openNote("060012liberatorsform"); addToVisited("060012liberatorsform")}} activeAnnotationId={currentNoteId}>O'Connell
-        street</Annotation> at night: disgrace to our Irish capital. <Annotation annotationId="120010unitedirishman" visited={visitedNotes.has("120010unitedirishman")} annotationSelect={() => {openNote("120010unitedirishman"); addToVisited("120010unitedirishman")}} activeAnnotationId={currentNoteId}>Griffith's paper</Annotation> is <span data-edition="ed1961" data-page="72"> </span>on
-        the same tack now: <Annotation annotationId="050004venerealdisease" visited={visitedNotes.has("050004venerealdisease")} annotationSelect={() => {openNote("050004venerealdisease"); addToVisited("050004venerealdisease")}} activeAnnotationId={currentNoteId}>an army rotten with venereal disease</Annotation>: overseas or
+        enlist and drill. <Annotation annotationId="050002maudgonne">Maud Gonne's letter</Annotation> about taking them off <Annotation annotationId="060012liberatorsform">O'Connell
+        street</Annotation> at night: disgrace to our Irish capital. <Annotation annotationId="120010unitedirishman">Griffith's paper</Annotation> is <span data-edition="ed1961" data-page="72"> </span>on
+        the same tack now: <Annotation annotationId="050004venerealdisease">an army rotten with venereal disease</Annotation>: overseas or
         halfseasover empire. Half baked they look: hypnotised like. Eyes front.
-        <Annotation annotationId="040082highgradeha" visited={visitedNotes.has("040082highgradeha")} annotationSelect={() => {openNote("040082highgradeha"); addToVisited("040082highgradeha")}} activeAnnotationId={currentNoteId}>Mark time. Table: able. Bed: ed.</Annotation> The King's own. Never see him dressed
+        <Annotation annotationId="040082highgradeha">Mark time. Table: able. Bed: ed.</Annotation> The King's own. Never see him dressed
         up as a fireman or a bobby. A mason, yes.
       </p>
       <p>
-        He strolled out of the postoffice and <Annotation annotationId="050018totheright" visited={visitedNotes.has("050018totheright")} annotationSelect={() => {openNote("050018totheright"); addToVisited("050018totheright")}} activeAnnotationId={currentNoteId}>turned to the right</Annotation>. Talk: as if
+        He strolled out of the postoffice and <Annotation annotationId="050018totheright">turned to the right</Annotation>. Talk: as if
         that would mend matters. His hand went into his pocket and a forefinger
         felt its way under the flap of the envelope, ripping it open in jerks.
         Women will pay a lot of heed, I don't think. His fingers drew forth the
@@ -120,7 +120,7 @@ const LotusEaters = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         pinned on: photo perhaps. Hair? No.
       </p>
       <p>
-        <Annotation annotationId="040079mcoy" visited={visitedNotes.has("040079mcoy")} annotationSelect={() => {openNote("040079mcoy"); addToVisited("040079mcoy")}} activeAnnotationId={currentNoteId}>M'Coy</Annotation>. Get rid of him quickly. Take me out of my way. Hate company when
+        <Annotation annotationId="040079mcoy">M'Coy</Annotation>. Get rid of him quickly. Take me out of my way. Hate company when
         you.
       </p>
       <p>
@@ -145,7 +145,7 @@ const LotusEaters = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         —{" "}Is there any... no trouble I hope? I see you're...
       </p>
       <p>
-        —{" "}O, no, Mr Bloom said. <Annotation annotationId="040067poordignam" visited={visitedNotes.has("040067poordignam")} annotationSelect={() => {openNote("040067poordignam"); addToVisited("040067poordignam")}} activeAnnotationId={currentNoteId}>Poor Dignam</Annotation>, you know. The funeral is today.
+        —{" "}O, no, Mr Bloom said. <Annotation annotationId="040067poordignam">Poor Dignam</Annotation>, you know. The funeral is today.
       </p>
       <span data-edition="ed1939" data-page="56"> </span>
       <p>
@@ -160,20 +160,20 @@ const LotusEaters = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       <span data-edition="ed1932" data-page="64"> </span>
       <p>
         —{" "}I must try to get out there, M'Coy said. Eleven, is it? I only heard
-        it last night. Who was telling me? <Annotation annotationId="050028hoppy" visited={visitedNotes.has("050028hoppy")} annotationSelect={() => {openNote("050028hoppy"); addToVisited("050028hoppy")}} activeAnnotationId={currentNoteId}>Holohan. You know Hoppy?</Annotation>
+        it last night. Who was telling me? <Annotation annotationId="050028hoppy">Holohan. You know Hoppy?</Annotation>
       </p>
       <p>
         —{" "}I know.
       </p>
       <p>
-        Mr Bloom gazed across the road at <Annotation annotationId="050013jauntingcar" visited={visitedNotes.has("050013jauntingcar")} annotationSelect={() => {openNote("050013jauntingcar"); addToVisited("050013jauntingcar")}} activeAnnotationId={currentNoteId}>the outsider</Annotation> drawn up before the door
-        of <Annotation annotationId="050034grosvenor" visited={visitedNotes.has("050034grosvenor")} annotationSelect={() => {openNote("050034grosvenor"); addToVisited("050034grosvenor")}} activeAnnotationId={currentNoteId}>the Grosvenor</Annotation>. The porter hoisted the valise up on the well. She
+        Mr Bloom gazed across the road at <Annotation annotationId="050013jauntingcar">the outsider</Annotation> drawn up before the door
+        of <Annotation annotationId="050034grosvenor">the Grosvenor</Annotation>. The porter hoisted the valise up on the well. She
         stood still, waiting, while the man, husband, brother, like her,
         searched his pockets for change. Stylish kind of coat with that roll
         collar, warm for a day like this, looks like blanketcloth. Careless
         stand of her with her hands in those patch 
         <span data-edition="ed1922" data-page="70"> </span>
-        pockets. <Annotation annotationId="050043horseywomen" visited={visitedNotes.has("050043horseywomen")} annotationSelect={() => {openNote("050043horseywomen"); addToVisited("050043horseywomen")}} activeAnnotationId={currentNoteId}>Like that haughty
+        pockets. <Annotation annotationId="050043horseywomen">Like that haughty
         creature at the polo match. Women all for caste till you touch the spot.
         Handsome is and handsome does. Reserved about to yield. The honourable
         Mrs and Brutus is an honourable man. Possess her once take the starch
@@ -181,7 +181,7 @@ const LotusEaters = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <span data-edition="ed1961" data-page="73"> </span>
       <p>
-        —{" "}I was with <Annotation annotationId="050038bobdoran" visited={visitedNotes.has("050038bobdoran")} annotationSelect={() => {openNote("050038bobdoran"); addToVisited("050038bobdoran")}} activeAnnotationId={currentNoteId}>Bob Doran, he's on one of his periodical bends</Annotation>, and what do
+        —{" "}I was with <Annotation annotationId="050038bobdoran">Bob Doran, he's on one of his periodical bends</Annotation>, and what do
         you call him Bantam Lyons. Just down there in Conway's we were.
       </p>
       <p>
@@ -189,7 +189,7 @@ const LotusEaters = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         Hoppy. Having a wet. Drawing back his head and gazing far from beneath
         his vailed eyelids he saw the bright fawn skin shine in the glare, the
         braided drums. Clearly I can see today. Moisture about gives long sight
-        perhaps. Talking of one thing or another. Lady's hand. <Annotation annotationId="050013jauntingcar" visited={visitedNotes.has("050013jauntingcar")} annotationSelect={() => {openNote("050013jauntingcar"); addToVisited("050013jauntingcar")}} activeAnnotationId={currentNoteId}>Which side will
+        perhaps. Talking of one thing or another. Lady's hand. <Annotation annotationId="050013jauntingcar">Which side will
         she get up?</Annotation>
       </p>
       <p>
@@ -220,7 +220,7 @@ const LotusEaters = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         —{" "}<i>What's wrong with him</i>? He said. <i>He's dead</i>, he said. And, faith,
         he filled up. <i>Is it Paddy Dignam</i>? I said. I couldn't believe it when I
         heard it. I was with him no later than Friday last or Thursday was it in
-        <Annotation annotationId="050048pubs" visited={visitedNotes.has("050048pubs")} annotationSelect={() => {openNote("050048pubs"); addToVisited("050048pubs")}} activeAnnotationId={currentNoteId}>the Arch</Annotation>. <i>Yes,</i> he said. <i>He's gone. He died on Monday, poor fellow</i>.
+        <Annotation annotationId="050048pubs">the Arch</Annotation>. <i>Yes,</i> he said. <i>He's gone. He died on Monday, poor fellow</i>.
       </p>
       <p>
         Watch! Watch! Silk flash rich stockings white. Watch!
@@ -229,7 +229,7 @@ const LotusEaters = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         A heavy tramcar honking its gong slewed between.
       </p>
       <p>
-        Lost it. Curse your noisy pugnose. Feels locked out of it. <Annotation annotationId="050029peri" visited={visitedNotes.has("050029peri")} annotationSelect={() => {openNote("050029peri"); addToVisited("050029peri")}} activeAnnotationId={currentNoteId}>Paradise and
+        Lost it. Curse your noisy pugnose. Feels locked out of it. <Annotation annotationId="050029peri">Paradise and
         the peri.</Annotation> Always happening like that. The very moment. Girl in <span data-edition="ed1932" data-page="65"> </span>Eustace
         street hallway Monday was it settling her garter. Her friend covering
         the display of <i>esprit de corps</i>. Well, what are you gaping at?
@@ -241,7 +241,7 @@ const LotusEaters = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         —{" "}One of the best, M'Coy said.
       </p>
       <p>
-        The tram passed. They drove off towards <Annotation annotationId="050006looplinebridge" visited={visitedNotes.has("050006looplinebridge")} annotationSelect={() => {openNote("050006looplinebridge"); addToVisited("050006looplinebridge")}} activeAnnotationId={currentNoteId}>the Loop Line bridge</Annotation>, her rich
+        The tram passed. They drove off towards <Annotation annotationId="050006looplinebridge">the Loop Line bridge</Annotation>, her rich
         gloved hand on the steel grip. Flicker, flicker: the laceflare of her
         hat in the sun: flicker, flick.
       </p>
@@ -258,7 +258,7 @@ const LotusEaters = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       <span data-edition="ed1939" data-page="57"> </span>
       <span data-edition="ed1961" data-page="74"> </span>
       <p>
-        <Annotation annotationId="050016pottedmeat" visited={visitedNotes.has("050016pottedmeat")} annotationSelect={() => {openNote("050016pottedmeat"); addToVisited("050016pottedmeat")}} activeAnnotationId={currentNoteId}><i>What is home without<br/>
+        <Annotation annotationId="050016pottedmeat"><i>What is home without<br/>
         Plumtree's Potted Meat?<br/>
         Incomplete.<br/>
         With it an abode of bliss.</i></Annotation>
@@ -267,7 +267,7 @@ const LotusEaters = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         —{" "}My missus has just got an engagement. At least it's not settled yet.
       </p>
       <p>
-        <Annotation annotationId="040079mcoy" visited={visitedNotes.has("040079mcoy")} annotationSelect={() => {openNote("040079mcoy"); addToVisited("040079mcoy")}} activeAnnotationId={currentNoteId}>Valise tack again.</Annotation> By the way no harm. I'm off that, thanks.
+        <Annotation annotationId="040079mcoy">Valise tack again.</Annotation> By the way no harm. I'm off that, thanks.
       </p>
       <p>
         Mr Bloom turned his largelidded eyes with unhasty friendliness.
@@ -280,11 +280,11 @@ const LotusEaters = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         —{" "}That so? M'Coy said. Glad to hear that, old man. Who's getting it up?
       </p>
       <p>
-        Mrs Marion Bloom. Not up yet. <Annotation annotationId="040014singasong" visited={visitedNotes.has("040014singasong")} annotationSelect={() => {openNote("040014singasong"); addToVisited("040014singasong")}} activeAnnotationId={currentNoteId}>Queen was in her bedroom eating bread and.</Annotation>
-        No book. <Annotation annotationId="110002atfourshe" visited={visitedNotes.has("110002atfourshe")} annotationSelect={() => {openNote("110002atfourshe"); addToVisited("110002atfourshe")}} activeAnnotationId={currentNoteId}>Blackened court cards laid along her thigh by sevens. Dark lady
+        Mrs Marion Bloom. Not up yet. <Annotation annotationId="040014singasong">Queen was in her bedroom eating bread and.</Annotation>
+        No book. <Annotation annotationId="110002atfourshe">Blackened court cards laid along her thigh by sevens. Dark lady
         and fair man. Letter. Cat furry black ball.</Annotation> Torn strip of envelope.
       </p>
-      <p>     <Annotation annotationId="040035oldsweetsong" visited={visitedNotes.has("040035oldsweetsong")} annotationSelect={() => {openNote("040035oldsweetsong"); addToVisited("040035oldsweetsong")}} activeAnnotationId={currentNoteId}><i>Love's <br/>
+      <p>     <Annotation annotationId="040035oldsweetsong"><i>Love's <br/>
         Old <br/>
         Sweet <br/>
         Song <br/></i></Annotation><i>
@@ -313,8 +313,8 @@ const LotusEaters = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <p>
         —{" "}Tell you what, M'Coy said. You might put down my name at the <span data-edition="ed1932" data-page="66"> </span>funeral,
-        will you? I'd like to go but I mightn't be able, you see. <Annotation annotationId="010125hightide" visited={visitedNotes.has("010125hightide")} annotationSelect={() => {openNote("010125hightide"); addToVisited("010125hightide")}} activeAnnotationId={currentNoteId}>There's a
-        drowning case at Sandycove may turn up</Annotation> and then <Annotation annotationId="040079mcoy" visited={visitedNotes.has("040079mcoy")} annotationSelect={() => {openNote("040079mcoy"); addToVisited("040079mcoy")}} activeAnnotationId={currentNoteId}>the coroner and myself</Annotation>
+        will you? I'd like to go but I mightn't be able, you see. <Annotation annotationId="010125hightide">There's a
+        drowning case at Sandycove may turn up</Annotation> and then <Annotation annotationId="040079mcoy">the coroner and myself</Annotation>
         would have to go down if the body is found. You just shove in my name if
         I'm not there, will you?
       </p>
@@ -353,11 +353,11 @@ const LotusEaters = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <p>
         Mr Bloom stood at the corner, his eyes wandering over the multicoloured
-        hoardings. <Annotation annotationId="050030cantrellcochrane" visited={visitedNotes.has("050030cantrellcochrane")} annotationSelect={() => {openNote("050030cantrellcochrane"); addToVisited("050030cantrellcochrane")}} activeAnnotationId={currentNoteId}>Cantrell and Cochrane's Ginger Ale (Aromatic).</Annotation> Clery's Summer
-        Sale. No, he's going on straight. Hello. <Annotation annotationId="050032leah" visited={visitedNotes.has("050032leah")} annotationSelect={() => {openNote("050032leah"); addToVisited("050032leah")}} activeAnnotationId={currentNoteId}><i>Leah</i> tonight. Mrs Bandmann
+        hoardings. <Annotation annotationId="050030cantrellcochrane">Cantrell and Cochrane's Ginger Ale (Aromatic).</Annotation> Clery's Summer
+        Sale. No, he's going on straight. Hello. <Annotation annotationId="050032leah"><i>Leah</i> tonight. Mrs Bandmann
         Palmer. Like to see her again in that. <i>Hamlet</i> she played last night.</Annotation>
         Male impersonator. Perhaps he was a woman. Why Ophelia committed
-        suicide. Poor papa! <Annotation annotationId="050032leah" visited={visitedNotes.has("050032leah")} annotationSelect={() => {openNote("050032leah"); addToVisited("050032leah")}} activeAnnotationId={currentNoteId}>How he used to talk of Kate Bateman in that. Outside
+        suicide. Poor papa! <Annotation annotationId="050032leah">How he used to talk of Kate Bateman in that. Outside
         the Adelphi in London waited all the afternoon to get in. Year before
         I was born that was: sixtyfive. And Ristori in Vienna. What is this the
         right name is? By Mosenthal it is. Rachel, is it? No. The scene he was
@@ -379,7 +379,7 @@ const LotusEaters = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <span data-edition="ed1932" data-page="67"> </span><span data-edition="ed1986" data-page="62"> </span>
       <p>
-        Mr Bloom went round the corner and passed <Annotation annotationId="050012cabstands" visited={visitedNotes.has("050012cabstands")} annotationSelect={() => {openNote("050012cabstands"); addToVisited("050012cabstands")}} activeAnnotationId={currentNoteId}>the drooping nags of the
+        Mr Bloom went round the corner and passed <Annotation annotationId="050012cabstands">the drooping nags of the
         hazard</Annotation>. No use thinking of it any more. Nosebag time. Wish I hadn't met
         that M'Coy fellow.
       </p>
@@ -399,8 +399,8 @@ const LotusEaters = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         carried. Might just walk into her here. The lane is safer.
       </p>
       <p>
-        He passed <Annotation annotationId="050051shelter" visited={visitedNotes.has("050051shelter")} annotationSelect={() => {openNote("050051shelter"); addToVisited("050051shelter")}} activeAnnotationId={currentNoteId}>the cabman's shelter</Annotation>. Curious the life of drifting cabbies.
-        All weathers, all places, time or setdown, no will of their own. <Annotation annotationId="040025lacidarem" visited={visitedNotes.has("040025lacidarem")} annotationSelect={() => {openNote("040025lacidarem"); addToVisited("040025lacidarem")}} activeAnnotationId={currentNoteId}><i>Voglio
+        He passed <Annotation annotationId="050051shelter">the cabman's shelter</Annotation>. Curious the life of drifting cabbies.
+        All weathers, all places, time or setdown, no will of their own. <Annotation annotationId="040025lacidarem"><i>Voglio
         e non</i>.</Annotation> Like to give them an odd cigarette. Sociable. Shout a few flying
         syllables as they pass. He hummed:
       </p>
@@ -408,13 +408,13 @@ const LotusEaters = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         La la lala la la.
       </p>
       <p>
-        <Annotation annotationId="050018totheright" visited={visitedNotes.has("050018totheright")} annotationSelect={() => {openNote("050018totheright"); addToVisited("050018totheright")}} activeAnnotationId={currentNoteId}>He turned into Cumberland street</Annotation> and, going on some paces, halted in the
-        lee of the station wall. No-one. <Annotation annotationId="050050meades" visited={visitedNotes.has("050050meades")} annotationSelect={() => {openNote("050050meades"); addToVisited("050050meades")}} activeAnnotationId={currentNoteId}>Meade's timberyard. Piled balks.</Annotation> Ruins
+        <Annotation annotationId="050018totheright">He turned into Cumberland street</Annotation> and, going on some paces, halted in the
+        lee of the station wall. No-one. <Annotation annotationId="050050meades">Meade's timberyard. Piled balks.</Annotation> Ruins
         and tenements. With careful tread he passed over a hopscotch court with
         its forgotten pickeystone. Not a sinner. Near the timberyard a squatted
         child at marbles, alone, shooting the taw with a cunnythumb. A wise
         tabby, a blinking sphinx, watched from her warm sill. Pity to disturb
-        them. <Annotation annotationId="050040mohammed" visited={visitedNotes.has("050040mohammed")} annotationSelect={() => {openNote("050040mohammed"); addToVisited("050040mohammed")}} activeAnnotationId={currentNoteId}>Mohammed cut a piece out of his mantle not to wake her.</Annotation> Open it.
+        them. <Annotation annotationId="050040mohammed">Mohammed cut a piece out of his mantle not to wake her.</Annotation> Open it.
         And once I played marbles when I went to that old dame's school. She
         liked mignonette. Mrs Ellis's. And Mr? He opened the letter within the
         newspaper.
@@ -432,8 +432,8 @@ const LotusEaters = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       <p>
         I got your last letter to me and thank you very much for it. I am sorry
         you did not like my last letter. Why did you enclose the stamps? I am
-        awfully angry with you. <Annotation annotationId="040017seemtolikeit" visited={visitedNotes.has("040017seemtolikeit")} annotationSelect={() => {openNote("040017seemtolikeit"); addToVisited("040017seemtolikeit")}} activeAnnotationId={currentNoteId}>I do wish I could punish you for that.</Annotation> I called
-        you naughty boy because <Annotation annotationId="050003otherworld" visited={visitedNotes.has("050003otherworld")} annotationSelect={() => {openNote("050003otherworld"); addToVisited("050003otherworld")}} activeAnnotationId={currentNoteId}>I do not like that other world</Annotation>. Please tell me
+        awfully angry with you. <Annotation annotationId="040017seemtolikeit">I do wish I could punish you for that.</Annotation> I called
+        you naughty boy because <Annotation annotationId="050003otherworld">I do not like that other world</Annotation>. Please tell me
         what is the real 
         <span data-edition="ed1922" data-page="74"> </span>
         meaning of that word? Are you not happy in your home
@@ -454,7 +454,7 @@ const LotusEaters = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         <br/>
       </p>
       <p>
-        P. S. Do tell me <Annotation annotationId="050035opoponax" visited={visitedNotes.has("050035opoponax")} annotationSelect={() => {openNote("050035opoponax"); addToVisited("050035opoponax")}} activeAnnotationId={currentNoteId}>what kind of perfume does your wife use</Annotation>. I want to
+        P. S. Do tell me <Annotation annotationId="050035opoponax">what kind of perfume does your wife use</Annotation>. I want to
         know.<br/>
         <br/>
       </p>
@@ -474,7 +474,7 @@ const LotusEaters = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         write it herself. Doing the indignant: a girl of good family like me,
         respectable character. Could meet one Sunday after the rosary. Thank
         you: not having any. Usual love scrimmage. Then running round corners.
-        Bad as a row with Molly. <Annotation annotationId="100002tobacco" visited={visitedNotes.has("100002tobacco")} annotationSelect={() => {openNote("100002tobacco"); addToVisited("100002tobacco")}} activeAnnotationId={currentNoteId}>Cigar has a cooling effect. Narcotic.</Annotation> Go
+        Bad as a row with Molly. <Annotation annotationId="100002tobacco">Cigar has a cooling effect. Narcotic.</Annotation> Go
         further next time. Naughty boy: punish: afraid of words, of course.
         Brutal, why not? Try it anyhow. A bit at a time.
       </p>
@@ -485,7 +485,7 @@ const LotusEaters = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         without thorns.
       </p>
       <p>
-        Flat Dublin voices bawled in his head. Those two sluts that night in <Annotation annotationId="050014thecoombe" visited={visitedNotes.has("050014thecoombe")} annotationSelect={() => {openNote("050014thecoombe"); addToVisited("050014thecoombe")}} activeAnnotationId={currentNoteId}>the
+        Flat Dublin voices bawled in his head. Those two sluts that night in <Annotation annotationId="050014thecoombe">the
         Coombe</Annotation>, linked together in the rain.
       </p>
       <span data-edition="ed1922" data-page="75"> </span>
@@ -503,7 +503,7 @@ const LotusEaters = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       <p><i>To keep it up.</i></p>
       <span data-edition="ed1939" data-page="60"> </span>
       <p>
-        <Annotation annotationId="050027marthamary" visited={visitedNotes.has("050027marthamary")} annotationSelect={() => {openNote("050027marthamary"); addToVisited("050027marthamary")}} activeAnnotationId={currentNoteId}>Martha, Mary. I saw that picture somewhere I forget now old master or
+        <Annotation annotationId="050027marthamary">Martha, Mary. I saw that picture somewhere I forget now old master or
         faked for money. He is sitting in their house, talking. Mysterious.</Annotation> Also
         the two sluts in the Coombe would listen.
       </p>
@@ -519,7 +519,7 @@ const LotusEaters = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         more: all. Then a sigh: silence. Long long long rest.
       </p>
       <p>
-        <Annotation annotationId="050018totheright" visited={visitedNotes.has("050018totheright")} annotationSelect={() => {openNote("050018totheright"); addToVisited("050018totheright")}} activeAnnotationId={currentNoteId}>Going under the railway arch</Annotation> he took out the envelope, tore it swiftly
+        <Annotation annotationId="050018totheright">Going under the railway arch</Annotation> he took out the envelope, tore it swiftly
         in shreds and scattered them towards the road. The shreds fluttered
         away, sank in the dank air: a white flutter, then all sank.
       </p>
@@ -546,20 +546,20 @@ const LotusEaters = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <span data-edition="ed1922" data-page="76"> </span>
       <p>
-        He had reached the open <Annotation annotationId="050017allhallows" visited={visitedNotes.has("050017allhallows")} annotationSelect={() => {openNote("050017allhallows"); addToVisited("050017allhallows")}} activeAnnotationId={currentNoteId}>backdoor of All Hallows</Annotation>. Stepping into the porch
+        He had reached the open <Annotation annotationId="050017allhallows">backdoor of All Hallows</Annotation>. Stepping into the porch
         he doffed his hat, took the card from his pocket <span data-edition="ed1961" data-page="79"> </span>and tucked it again
         behind the leather headband. Damn it. I might have tried to work M'Coy
-        for a pass to <Annotation annotationId="010126mullingar" visited={visitedNotes.has("010126mullingar")} annotationSelect={() => {openNote("010126mullingar"); addToVisited("010126mullingar")}} activeAnnotationId={currentNoteId}>Mullingar</Annotation>.
+        for a pass to <Annotation annotationId="010126mullingar">Mullingar</Annotation>.
       </p>
       <p>
-        Same notice on the door. Sermon by the very reverend <Annotation annotationId="050052conmee" visited={visitedNotes.has("050052conmee")} annotationSelect={() => {openNote("050052conmee"); addToVisited("050052conmee")}} activeAnnotationId={currentNoteId}>John Conmee S.J.
+        Same notice on the door. Sermon by the very reverend <Annotation annotationId="050052conmee">John Conmee S.J.
         on saint Peter Claver and the African Mission</Annotation>. Save China's <span data-edition="ed1932" data-page="70"> </span>millions. Wonder how they explain it to the heathen Chinee. Prefer an ounce of opium. Celestials. Rank heresy for them. Prayers for the
         conversion of Gladstone they had too when he was almost unconscious. The
         protestants are the same. Convert Dr William J. Walsh D.D. to the true
-        religion.  <Annotation annotationId="050031buddhagod" visited={visitedNotes.has("050031buddhagod")} annotationSelect={() => {openNote("050031buddhagod"); addToVisited("050031buddhagod")}} activeAnnotationId={currentNoteId}>Buddha their god lying on his side in the museum. Taking it easy
-        with hand under his cheek. Josssticks burning.</Annotation> Not like <Annotation annotationId="050033eccehomo" visited={visitedNotes.has("050033eccehomo")} annotationSelect={() => {openNote("050033eccehomo"); addToVisited("050033eccehomo")}} activeAnnotationId={currentNoteId}>Ecce Homo. Crown
-        of thorns and cross.</Annotation> <Annotation annotationId="050036saintpatrick" visited={visitedNotes.has("050036saintpatrick")} annotationSelect={() => {openNote("050036saintpatrick"); addToVisited("050036saintpatrick")}} activeAnnotationId={currentNoteId}>Clever idea Saint Patrick the shamrock.</Annotation> Chopsticks?
-        Conmee: <Annotation annotationId="060034martincunningham" visited={visitedNotes.has("060034martincunningham")} annotationSelect={() => {openNote("060034martincunningham"); addToVisited("060034martincunningham")}} activeAnnotationId={currentNoteId}>Martin Cunningham</Annotation> knows him: distinguishedlooking. Sorry I
+        religion.  <Annotation annotationId="050031buddhagod">Buddha their god lying on his side in the museum. Taking it easy
+        with hand under his cheek. Josssticks burning.</Annotation> Not like <Annotation annotationId="050033eccehomo">Ecce Homo. Crown
+        of thorns and cross.</Annotation> <Annotation annotationId="050036saintpatrick">Clever idea Saint Patrick the shamrock.</Annotation> Chopsticks?
+        Conmee: <Annotation annotationId="060034martincunningham">Martin Cunningham</Annotation> knows him: distinguishedlooking. Sorry I
         didn't work him about getting Molly into the choir instead of that
         Father Farley who looked a fool but wasn't. They're taught that. He's
         not going out in bluey specs with the sweat rolling off him to baptise
@@ -574,7 +574,7 @@ const LotusEaters = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       <span data-edition="ed1939" data-page="61"> </span>
       <p>
         Something going on: some sodality. Pity so empty. Nice discreet place
-        to be next some girl. <Annotation annotationId="050045samaritan" visited={visitedNotes.has("050045samaritan")} annotationSelect={() => {openNote("050045samaritan"); addToVisited("050045samaritan")}} activeAnnotationId={currentNoteId}>Who is my neighbour?</Annotation> Jammed by the hour to slow
+        to be next some girl. <Annotation annotationId="050045samaritan">Who is my neighbour?</Annotation> Jammed by the hour to slow
         music. That woman at midnight mass. Seventh heaven. Women knelt in the
         benches with crimson halters round their necks, heads bowed. A batch
         knelt at the altarrails. The priest went along by them, murmuring,
@@ -599,31 +599,31 @@ const LotusEaters = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         sort of bread: unleavened shewbread. Look at them. Now I bet it makes
         them feel happy. Lollipop. It does. Yes, bread of angels it's called.
         There's a big idea behind it, kind of kingdom of God is within you feel.
-        First communicants. <Annotation annotationId="050047hokypoky" visited={visitedNotes.has("050047hokypoky")} annotationSelect={() => {openNote("050047hokypoky"); addToVisited("050047hokypoky")}} activeAnnotationId={currentNoteId}>Hokypoky penny a lump.</Annotation> Then feel all like one <span data-edition="ed1932" data-page="71"> </span>family
+        First communicants. <Annotation annotationId="050047hokypoky">Hokypoky penny a lump.</Annotation> Then feel all like one <span data-edition="ed1932" data-page="71"> </span>family
         party, same in the theatre, all in the same swim. They do. I'm sure of
         that. Not so lonely. In our confraternity. Then come out a bit spreeish.
         Let off steam. Thing is if you really believe in it. Lourdes cure,
         waters of oblivion, and the Knock apparition, statues bleeding. Old
         fellow asleep near that confessionbox. Hence those snores. Blind faith.
-        Safe in the arms of <Annotation annotationId="040077ourfather" visited={visitedNotes.has("040077ourfather")} annotationSelect={() => {openNote("040077ourfather"); addToVisited("040077ourfather")}} activeAnnotationId={currentNoteId}>kingdom come</Annotation>. Lulls all pain. Wake this time next
+        Safe in the arms of <Annotation annotationId="040077ourfather">kingdom come</Annotation>. Lulls all pain. Wake this time next
         year.
       </p>
       <p>
         He saw the priest stow the communion cup away, well in, and kneel an
         instant before it, showing a large grey bootsole from under the lace
         affair he had on. Suppose he lost the pin of his. He wouldn't know what
-        to do to. Bald spot behind. <Annotation annotationId="050033eccehomo" visited={visitedNotes.has("050033eccehomo")} annotationSelect={() => {openNote("050033eccehomo"); addToVisited("050033eccehomo")}} activeAnnotationId={currentNoteId}>Letters on his back: I.N.R.I? No: I.H.S.
+        to do to. Bald spot behind. <Annotation annotationId="050033eccehomo">Letters on his back: I.N.R.I? No: I.H.S.
         Molly told me one time I asked her. I have sinned: or no: I have
         suffered, it is. And the other one? Iron nails ran in.</Annotation>
       </p>
       <p>
         Meet one Sunday after the rosary. Do not deny my request. Turn up with
-        a veil and black bag. <Annotation annotationId="050039lightbehindher" visited={visitedNotes.has("050039lightbehindher")} annotationSelect={() => {openNote("050039lightbehindher"); addToVisited("050039lightbehindher")}} activeAnnotationId={currentNoteId}>Dusk and the light behind her.</Annotation> She might be here
+        a veil and black bag. <Annotation annotationId="050039lightbehindher">Dusk and the light behind her.</Annotation> She might be here
         with a ribbon round her neck and do the other thing all the same on the
-        sly. Their character. <Annotation annotationId="040089denzille" visited={visitedNotes.has("040089denzille")} annotationSelect={() => {openNote("040089denzille"); addToVisited("040089denzille")}} activeAnnotationId={currentNoteId}>That fellow that turned queen's evidence on the
+        sly. Their character. <Annotation annotationId="040089denzille">That fellow that turned queen's evidence on the
         invincibles he used to receive the, Carey was his name, the communion
         every morning. This very church. Peter Carey. No, Peter Claver I am
-        thinking of.</Annotation> <span data-edition="ed1986" data-page="66"> </span><Annotation annotationId="040089denzille" visited={visitedNotes.has("040089denzille")} annotationSelect={() => {openNote("040089denzille"); addToVisited("040089denzille")}} activeAnnotationId={currentNoteId}>Denis Carey. And just imagine that. Wife and six children
+        thinking of.</Annotation> <span data-edition="ed1986" data-page="66"> </span><Annotation annotationId="040089denzille">Denis Carey. And just imagine that. Wife and six children
         at home. And plotting that murder all the time.</Annotation> Those crawthumpers,
         now that's a good name for them, there's always something shiftylooking
         about them. They're not straight men of business either. O, no, she's
@@ -672,7 +672,7 @@ const LotusEaters = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <p>
         He saw the priest bend down and kiss the altar and then face about and
-        bless all the people. All <Annotation annotationId="010057crossed" visited={visitedNotes.has("010057crossed")} annotationSelect={() => {openNote("010057crossed"); addToVisited("010057crossed")}} activeAnnotationId={currentNoteId}>crossed themselves</Annotation> and stood up. Mr Bloom
+        bless all the people. All <Annotation annotationId="010057crossed">crossed themselves</Annotation> and stood up. Mr Bloom
         glanced about him and then stood up, looking over the risen hats. Stand
         up at the gospel of course. Then all settled down on their knees again
         and he sat back quietly in his bench. The priest came down from the
@@ -681,7 +681,7 @@ const LotusEaters = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         card:
       </p>
       <p>
-        —{" "}<Annotation annotationId="010088archangelmichael" visited={visitedNotes.has("010088archangelmichael")} annotationSelect={() => {openNote("010088archangelmichael"); addToVisited("010088archangelmichael")}} activeAnnotationId={currentNoteId}>O God, our refuge and our strength...</Annotation>
+        —{" "}<Annotation annotationId="010088archangelmichael">O God, our refuge and our strength...</Annotation>
       </p>
       <p>
         Mr Bloom put his face forward to catch the words. English. Throw them
@@ -692,7 +692,7 @@ const LotusEaters = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         to. Then I will tell you all. Penance. Punish me, please. Great weapon
         in their hands. More than doctor or solicitor. Woman dying to. And I
         schschschschschsch. And did you chachachachacha? And why did you? Look
-        down at her ring to find an excuse. <Annotation annotationId="050044whisperinggallery" visited={visitedNotes.has("050044whisperinggallery")} annotationSelect={() => {openNote("050044whisperinggallery"); addToVisited("050044whisperinggallery")}} activeAnnotationId={currentNoteId}>Whispering gallery walls have ears.</Annotation>
+        down at her ring to find an excuse. <Annotation annotationId="050044whisperinggallery">Whispering gallery walls have ears.</Annotation>
         Husband learn to his surprise. God's little joke. Then out she comes.
         Repentance skindeep. Lovely shame. Pray at an altar. 
         <span data-edition="ed1922" data-page="79"> </span>
@@ -713,7 +713,7 @@ const LotusEaters = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <span data-edition="ed1939" data-page="63"> </span>
       <p>
-        —{" "}<Annotation annotationId="010088archangelmichael" visited={visitedNotes.has("010088archangelmichael")} annotationSelect={() => {openNote("010088archangelmichael"); addToVisited("010088archangelmichael")}} activeAnnotationId={currentNoteId}>Blessed Michael, archangel, defend us in the hour of conflict. Be
+        —{" "}<Annotation annotationId="010088archangelmichael">Blessed Michael, archangel, defend us in the hour of conflict. Be
         our safeguard against the wickedness and snares of the devil (may God
         restrain him, we humbly pray!): and do thou, O prince of the heavenly
         host, by the power of God thrust Satan down to hell and with him those
@@ -734,14 +734,14 @@ const LotusEaters = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         Glimpses of the moon. Annoyed if you don't. Why didn't you tell me
         before. Still like you better untidy. Good job it wasn't farther south.
         He passed, discreetly buttoning, down the aisle and out through the main
-        door into the light. He stood a moment unseeing <Annotation annotationId="050023holywater" visited={visitedNotes.has("050023holywater")} annotationSelect={() => {openNote("050023holywater"); addToVisited("050023holywater")}} activeAnnotationId={currentNoteId}>by the cold black marble
+        door into the light. He stood a moment unseeing <Annotation annotationId="050023holywater">by the cold black marble
         bowl while before him and behind two worshippers dipped furtive hands in
         the low tide of holy water</Annotation>. Trams: a car of Prescott's dyeworks: a widow
         in her weeds. <span data-edition="ed1961" data-page="83"> </span>Notice because I'm in mourning myself. He covered himself.
         How goes the time? Quarter past. Time enough yet. Better get that lotion
         made up. Where is this? Ah yes, the last time. Sweny's in Lincoln place.
         Chemists rarely move. Their green and gold beaconjars too heavy to stir.
-        <Annotation annotationId="050001hamiltonlongs" visited={visitedNotes.has("050001hamiltonlongs")} annotationSelect={() => {openNote("050001hamiltonlongs"); addToVisited("050001hamiltonlongs")}} activeAnnotationId={currentNoteId}>Hamilton Long's, founded in the year of the flood.</Annotation> Huguenot churchyard
+        <Annotation annotationId="050001hamiltonlongs">Hamilton Long's, founded in the year of the flood.</Annotation> Huguenot churchyard
         near there. Visit some day.
       </p>
       <p>
@@ -750,7 +750,7 @@ const LotusEaters = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         O well, poor fellow, it's not his fault. When was it I got it made up
         last? Wait. 
         <span data-edition="ed1922" data-page="80"> </span><span data-edition="ed1986" data-page="68"> </span>
-        I changed a <Annotation annotationId="010019money" visited={visitedNotes.has("010019money")} annotationSelect={() => {openNote("010019money"); addToVisited("010019money")}} activeAnnotationId={currentNoteId}>sovereign</Annotation> I remember. First of the month it must
+        I changed a <Annotation annotationId="010019money">sovereign</Annotation> I remember. First of the month it must
         have been or the second. O, he can look it up in the prescriptions book.
       </p>
       <p>
@@ -800,7 +800,7 @@ const LotusEaters = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         one skin. Leopold, yes. Three we have. Warts, bunions and pimples to
         make it worse. But you want a perfume too. What perfume does your? <i>Peau
         d'Espagne</i>. That orangeflower water is so fresh. Nice smell these soaps
-        have. Pure curd soap. Time to get a bath round the corner. <Annotation annotationId="050010mosquebaths" visited={visitedNotes.has("050010mosquebaths")} annotationSelect={() => {openNote("050010mosquebaths"); addToVisited("050010mosquebaths")}} activeAnnotationId={currentNoteId}>Hammam.
+        have. Pure curd soap. Time to get a bath round the corner. <Annotation annotationId="050010mosquebaths">Hammam.
         Turkish. Massage.</Annotation> Dirt gets rolled up in your navel. Nicer if a nice
         girl did it. Also I think I. Yes I. Do it in the bath. Curious longing
         I. Water to water. Combine business with pleasure. Pity no time for
@@ -902,10 +902,10 @@ const LotusEaters = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         <span data-edition="ed1939" data-page="65"> </span>
         for threepence. Jack Fleming
         embezzling to gamble then smuggled off to America. Keeps a hotel now.
-        They never come back. <Annotation annotationId="030134fleshpots" visited={visitedNotes.has("030134fleshpots")} annotationSelect={() => {openNote("030134fleshpots"); addToVisited("030134fleshpots")}} activeAnnotationId={currentNoteId}>Fleshpots of Egypt.</Annotation>
+        They never come back. <Annotation annotationId="030134fleshpots">Fleshpots of Egypt.</Annotation>
       </p>
       <p>
-        He walked cheerfully towards <Annotation annotationId="050010mosquebaths" visited={visitedNotes.has("050010mosquebaths")} annotationSelect={() => {openNote("050010mosquebaths"); addToVisited("050010mosquebaths")}} activeAnnotationId={currentNoteId}>the mosque of the baths. Remind you of a
+        He walked cheerfully towards <Annotation annotationId="050010mosquebaths">the mosque of the baths. Remind you of a
         mosque, redbaked bricks, the minarets.</Annotation> College sports today I see. He
         eyed the horseshoe poster over the gate of college park: cyclist doubled
         up like a cod in a pot. Damn bad ad. Now if they had made it round
@@ -920,10 +920,10 @@ const LotusEaters = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <span data-edition="ed1986" data-page="70"> </span>
       <p>
-        Heavenly weather really. If life was always like that. <Annotation annotationId="050041cricket" visited={visitedNotes.has("050041cricket")} annotationSelect={() => {openNote("050041cricket"); addToVisited("050041cricket")}} activeAnnotationId={currentNoteId}>Cricket weather.
+        Heavenly weather really. If life was always like that. <Annotation annotationId="050041cricket">Cricket weather.
         Sit around under sunshades. Over after over. Out. They can't play it
-        here. Duck for six wickets. Still Captain Buller broke a window</Annotation> in <Annotation annotationId="050042kildareclub" visited={visitedNotes.has("050042kildareclub")} annotationSelect={() => {openNote("050042kildareclub"); addToVisited("050042kildareclub")}} activeAnnotationId={currentNoteId}>the
-        Kildare street club</Annotation> with a slog to square leg. <Annotation annotationId="050022donnybrook" visited={visitedNotes.has("050022donnybrook")} annotationSelect={() => {openNote("050022donnybrook"); addToVisited("050022donnybrook")}} activeAnnotationId={currentNoteId}>Donnybrook fair</Annotation> more
+        here. Duck for six wickets. Still Captain Buller broke a window</Annotation> in <Annotation annotationId="050042kildareclub">the
+        Kildare street club</Annotation> with a slog to square leg. <Annotation annotationId="050022donnybrook">Donnybrook fair</Annotation> more
         in their line. And the skulls we were acracking when M'Carthy took the
         floor. Heatwave. Won't last. Always passing, the stream of life, which
         in the stream of life we trace is dearer than them all.
@@ -933,11 +933,11 @@ const LotusEaters = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         stream. This is my body.
       </p>
       <p>
-        He foresaw his pale body reclined in it at full, <Annotation annotationId="050024nakedwomb" visited={visitedNotes.has("050024nakedwomb")} annotationSelect={() => {openNote("050024nakedwomb"); addToVisited("050024nakedwomb")}} activeAnnotationId={currentNoteId}>naked, in a womb of
+        He foresaw his pale body reclined in it at full, <Annotation annotationId="050024nakedwomb">naked, in a womb of
         warmth</Annotation>, oiled by scented melting soap, softly laved. He saw his
         trunk and limbs riprippled over and sustained, buoyed lightly upward,
         lemonyellow: his navel, bud of flesh: and saw the dark tangled curls of
-        his bush floating, floating hair of the stream around <Annotation annotationId="050008floatingflower" visited={visitedNotes.has("050008floatingflower")} annotationSelect={() => {openNote("050008floatingflower"); addToVisited("050008floatingflower")}} activeAnnotationId={currentNoteId}>the limp father of
+        his bush floating, floating hair of the stream around <Annotation annotationId="050008floatingflower">the limp father of
         thousands, a languid floating flower</Annotation>.
       </p>
       <br/><br/><br/>

--- a/src/content/chapters/Nausicaa.js
+++ b/src/content/chapters/Nausicaa.js
@@ -1,20 +1,20 @@
 import Annotation from "../../components/Annotation";
 
 
-const Nausicaa = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
+const Nausicaa = () => {
   return (
     <div>
       <p></p>
       <center><font size="+2">[13]</font></center>
       <br/>
       The summer evening had begun to fold the world in its mysterious
-      embrace. Far away in the west <Annotation annotationId="030072longestday" visited={visitedNotes.has("030072longestday")} annotationSelect={() => {openNote("030072longestday"); addToVisited("030072longestday")}} activeAnnotationId={currentNoteId}>the sun was setting</Annotation> and the last glow of
+      embrace. Far away in the west <Annotation annotationId="030072longestday">the sun was setting</Annotation> and the last glow of
       all too fleeting day lingered lovingly on sea and strand, on the proud
       promontory of dear old Howth guarding as ever the waters of the bay, on
-      the weedgrown rocks along <Annotation annotationId="030001sandymount" visited={visitedNotes.has("030001sandymount")} annotationSelect={() => {openNote("030001sandymount"); addToVisited("030001sandymount")}} activeAnnotationId={currentNoteId}>Sandymount shore</Annotation> and, last but not least, on
+      the weedgrown rocks along <Annotation annotationId="030001sandymount">Sandymount shore</Annotation> and, last but not least, on
       the quiet church whence there streamed forth at times upon the stillness
       the voice of prayer to her who is in her pure radiance a beacon ever to
-      the stormtossed heart of man, <Annotation annotationId="130002starofthesea" visited={visitedNotes.has("130002starofthesea")} annotationSelect={() => {openNote("130002starofthesea"); addToVisited("130002starofthesea")}} activeAnnotationId={currentNoteId}>Mary, star of the sea</Annotation>.
+      the stormtossed heart of man, <Annotation annotationId="130002starofthesea">Mary, star of the sea</Annotation>.
       <p></p>
       <p>
         The three girl friends were seated on the rocks, enjoying the evening
@@ -66,7 +66,7 @@ const Nausicaa = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         <span data-edition="ed1939" data-page="251"> </span>
         The apple of discord was a certain castle of sand
         which Master Jacky had built and Master Tommy would have it right go
-        wrong that it was to be architecturally improved by a frontdoor like <Annotation annotationId="070002sandymounttrams" visited={visitedNotes.has("070002sandymounttrams")} annotationSelect={() => {openNote("070002sandymounttrams"); addToVisited("070002sandymounttrams")}} activeAnnotationId={currentNoteId}>the
+        wrong that it was to be architecturally improved by a frontdoor like <Annotation annotationId="070002sandymounttrams">the
         Martello tower</Annotation> had. But if Master Tommy was headstrong Master Jacky was
         selfwilled too and, true to the maxim that every little Irishman's house
         is his castle, he fell upon his hated rival and to such purpose that the
@@ -194,7 +194,7 @@ const Nausicaa = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         and down in front of her window. Only now his father kept him in in the
         evenings studying hard to get an exhibition in the intermediate that was
         on and he was going to Trinity college to study for a doctor when
-        he left <Annotation annotationId="050020highschool" visited={visitedNotes.has("050020highschool")} annotationSelect={() => {openNote("050020highschool"); addToVisited("050020highschool")}} activeAnnotationId={currentNoteId}>the high school</Annotation> like his brother W. E. Wylie who was racing
+        he left <Annotation annotationId="050020highschool">the high school</Annotation> like his brother W. E. Wylie who was racing
         in the bicycle races in Trinity college university. Little recked he
         perhaps for what she felt, that dull aching void in her heart sometimes,
         piercing to the core. Yet he was young and perchance he might learn
@@ -352,7 +352,7 @@ const Nausicaa = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       <p>
         And she tickled tiny tot's two cheeks to make him forget and played here's 
         <span data-edition="ed1922" data-page="337"> </span>
-        <Annotation annotationId="060033corporation" visited={visitedNotes.has("060033corporation")} annotationSelect={() => {openNote("060033corporation"); addToVisited("060033corporation")}} activeAnnotationId={currentNoteId}>the lord mayor, here's his two horses, here's his gingerbread
+        <Annotation annotationId="060033corporation">the lord mayor, here's his two horses, here's his gingerbread
         carriage</Annotation> <span data-edition="ed1986" data-page="289"> </span>and here he walks in, chinchopper, chinchopper, chinchopper
         chin. But Edy got as cross as two sticks about him getting his own way
         like that from everyone always petting him.
@@ -402,7 +402,7 @@ const Nausicaa = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         reciting the litany of Our Lady of Loreto, beseeching her to intercede
         for them, the old familiar words, holy Mary, holy virgin of virgins. How
         sad to poor Gerty's ears! Had her father only avoided the clutches of
-        the demon drink, by <Annotation annotationId="060010fathermathew" visited={visitedNotes.has("060010fathermathew")} annotationSelect={() => {openNote("060010fathermathew"); addToVisited("060010fathermathew")}} activeAnnotationId={currentNoteId}>taking the pledge</Annotation> or those powders the drink habit
+        the demon drink, by <Annotation annotationId="060010fathermathew">taking the pledge</Annotation> or those powders the drink habit
         cured in Pearson's Weekly, she might now be rolling in her carriage,
         second to none. Over and over had she told herself that as she mused by
         the dying embers in a brown study without the lamp because she hated 
@@ -410,7 +410,7 @@ const Nausicaa = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         two lights or oftentimes gazing out of the window dreamily by the hour at
         the rain falling on the rusty bucket, thinking. But that vile decoction
         which has ruined so many hearths and homes had cast its shadow over her
-        childhood days. Nay, she had even witnessed in the home circle <Annotation annotationId="050049comehometoma" visited={visitedNotes.has("050049comehometoma")} annotationSelect={() => {openNote("050049comehometoma"); addToVisited("050049comehometoma")}} activeAnnotationId={currentNoteId}>deeds of
+        childhood days. Nay, she had even witnessed in the home circle <Annotation annotationId="050049comehometoma">deeds of
         violence caused by intemperance</Annotation> and had seen her own father, a prey to
         the fumes of intoxication, forget himself completely for if there was
         one thing of all things that Gerty knew 
@@ -424,7 +424,7 @@ const Nausicaa = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         And still the voices sang in supplication to the Virgin most powerful,
         Virgin most merciful. And Gerty, wrapt in thought, scarce saw or heard
         her companions or the twins at their boyish gambols or the gentleman
-        <Annotation annotationId="070002sandymounttrams" visited={visitedNotes.has("070002sandymounttrams")} annotationSelect={() => {openNote("070002sandymounttrams"); addToVisited("070002sandymounttrams")}} activeAnnotationId={currentNoteId}>off Sandymount green</Annotation> that Cissy Caffrey called the man that was so like
+        <Annotation annotationId="070002sandymounttrams">off Sandymount green</Annotation> that Cissy Caffrey called the man that was so like
         himself passing along the strand taking a short walk. You never saw him
         any way screwed but still and for all that she would not like him for a
         father because he was too old or something or on account of his face
@@ -432,7 +432,7 @@ const Nausicaa = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         pimples on it and his sandy moustache a bit white under his nose. Poor
         father! With all his faults she loved him still when he sang <i>Tell me,
         Mary, how to woo thee</i> or <i>My love and cottage near Rochelle</i> and they
-        had stewed <Annotation annotationId="030080cockles" visited={visitedNotes.has("030080cockles")} annotationSelect={() => {openNote("030080cockles"); addToVisited("030080cockles")}} activeAnnotationId={currentNoteId}>cockles</Annotation> and lettuce with Lazenby's salad dressing for
+        had stewed <Annotation annotationId="030080cockles">cockles</Annotation> and lettuce with Lazenby's salad dressing for
         supper and when he sang <i>The moon hath raised</i> with Mr Dignam that
         died suddenly and was buried, God have mercy on him, from a stroke. Her
         mother's birthday that was and Charley was home 
@@ -575,8 +575,8 @@ const Nausicaa = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         and through, read her very soul. Wonderful eyes they were, superbly
         expressive, but could you trust them? People were so queer. She could
         see at once by his dark eyes and his pale intellectual face that he
-        was a foreigner, the image of <Annotation annotationId="130003martinharvey" visited={visitedNotes.has("130003martinharvey")} annotationSelect={() => {openNote("130003martinharvey"); addToVisited("130003martinharvey")}} activeAnnotationId={currentNoteId}>the photo she had of Martin Harvey, the
-        matinee idol</Annotation>, only for <Annotation annotationId="040055moustachecup" visited={visitedNotes.has("040055moustachecup")} annotationSelect={() => {openNote("040055moustachecup"); addToVisited("040055moustachecup")}} activeAnnotationId={currentNoteId}>the moustache</Annotation> which she preferred because she
+        was a foreigner, the image of <Annotation annotationId="130003martinharvey">the photo she had of Martin Harvey, the
+        matinee idol</Annotation>, only for <Annotation annotationId="040055moustachecup">the moustache</Annotation> which she preferred because she
         wasn't stagestruck like Winny Rippingham that wanted they two to always
         dress the same on account of a play but she could not see whether he had
         an aquiline nose or a slightly <i>retroussé</i> from where he was sitting.
@@ -609,9 +609,9 @@ const Nausicaa = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         for the afflicted because of the seven dolours which transpierced
         her own heart. Gerty could picture the whole scene in the church, the
         stained glass windows lighted up, the candles, the flowers and the blue
-        banners of the blessed Virgin's sodality and <Annotation annotationId="040027conroy" visited={visitedNotes.has("040027conroy")} annotationSelect={() => {openNote("040027conroy"); addToVisited("040027conroy")}} activeAnnotationId={currentNoteId}>Father</Annotation> 
+        banners of the blessed Virgin's sodality and <Annotation annotationId="040027conroy">Father</Annotation> 
         <span data-edition="ed1922" data-page="342"> </span>
-        <Annotation annotationId="040027conroy" visited={visitedNotes.has("040027conroy")} annotationSelect={() => {openNote("040027conroy"); addToVisited("040027conroy")}} activeAnnotationId={currentNoteId}>Conroy</Annotation> was helping
+        <Annotation annotationId="040027conroy">Conroy</Annotation> was helping
         Canon O'Hanlon at the altar, carrying things in and out with his eyes
         cast down. He looked almost a saint and his confessionbox was so quiet
         and clean and dark and his hands were just like white wax and if ever
@@ -639,7 +639,7 @@ const Nausicaa = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         monkeys common as ditchwater. Someone ought to take them and give them
         a good hiding for themselves to keep them in their places, the both of
         them. And Cissy and Edy shouted after them to come back because they
-        were afraid  <Annotation annotationId="010125hightide" visited={visitedNotes.has("010125hightide")} annotationSelect={() => {openNote("010125hightide"); addToVisited("010125hightide")}} activeAnnotationId={currentNoteId}>the tide might come in on them and be drowned</Annotation>.
+        were afraid  <Annotation annotationId="010125hightide">the tide might come in on them and be drowned</Annotation>.
       </p>
       <p>
         —{" "}Jacky! Tommy!
@@ -854,7 +854,7 @@ const Nausicaa = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       <p>
         How moving the scene there in the gathering twilight, the last glimpse
         of Erin, the touching chime of those evening bells and at the same
-        time <Annotation annotationId="130004littleman" visited={visitedNotes.has("130004littleman")} annotationSelect={() => {openNote("130004littleman"); addToVisited("130004littleman")}} activeAnnotationId={currentNoteId}>a bat flew forth</Annotation> from the ivied belfry through the dusk, hither,
+        time <Annotation annotationId="130004littleman">a bat flew forth</Annotation> from the ivied belfry through the dusk, hither,
         thither, with a tiny lost cry. And she could see far away the lights of
         the lighthouses so picturesque she would have loved to do with a box of
         paints because it was easier than to make a man and soon <span data-edition="ed1932" data-page="328"> </span>the lamplighter
@@ -871,7 +871,7 @@ const Nausicaa = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         tortoiseshell combs, her child of Mary badge, the whiterose scent, the
         eyebrowleine, her alabaster pouncetbox and the ribbons to change
         when her things came home from the wash and there were some beautiful
-        thoughts written in it <Annotation annotationId="020080mauve" visited={visitedNotes.has("020080mauve")} annotationSelect={() => {openNote("020080mauve"); addToVisited("020080mauve")}} activeAnnotationId={currentNoteId}>in violet ink</Annotation> that she bought in Hely's 
+        thoughts written in it <Annotation annotationId="020080mauve">in violet ink</Annotation> that she bought in Hely's 
         <span data-edition="ed1922" data-page="347"> </span>
         of Dame Street for she felt that she too could write poetry if she could only
         express herself like that poem that appealed to her so deeply that
@@ -996,7 +996,7 @@ const Nausicaa = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         rocket sprang and bang shot blind blank and O! then the Roman candle
         burst and it was like a <span data-edition="ed1961" data-page="366"> </span>sigh of O! and everyone cried O! O! in raptures
         and it gushed out of it a stream of rain gold hair threads and they
-        shed and ah! they were <Annotation annotationId="180010dewy" visited={visitedNotes.has("180010dewy")} annotationSelect={() => {openNote("180010dewy"); addToVisited("180010dewy")}} activeAnnotationId={currentNoteId}>all greeny dewy stars falling with golden</Annotation>, O so
+        shed and ah! they were <Annotation annotationId="180010dewy">all greeny dewy stars falling with golden</Annotation>, O so
         lovely! O, so soft, sweet, soft!
       </p>
       <p>
@@ -1062,7 +1062,7 @@ const Nausicaa = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         menstruate at the same time with same moon, I mean? Depends on the
         time they were born I suppose. Or all start scratch then get out of
         step. Sometimes Molly and Milly together. Anyhow I got the best of that.
-        Damned glad I didn't <Annotation annotationId="050010mosquebaths" visited={visitedNotes.has("050010mosquebaths")} annotationSelect={() => {openNote("050010mosquebaths"); addToVisited("050010mosquebaths")}} activeAnnotationId={currentNoteId}>do it in the bath this morning</Annotation> over her silly I
+        Damned glad I didn't <Annotation annotationId="050010mosquebaths">do it in the bath this morning</Annotation> over her silly I
         will punish you letter. Made up for that tramdriver this morning. That
         gouger M'Coy stopping me to say nothing. And his wife engagement in the
         country valise, voice like a pickaxe. Thankful for small mercies.
@@ -1070,7 +1070,7 @@ const Nausicaa = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         natural craving. Shoals of them every evening poured out of offices.
         Reserve better. Don't want it they throw it at you. Catch em alive, O.
         Pity they can't see themselves. A dream of wellfilled hose. Where was
-        that? Ah, yes. <Annotation annotationId="150002applyeye" visited={visitedNotes.has("150002applyeye")} annotationSelect={() => {openNote("150002applyeye"); addToVisited("150002applyeye")}} activeAnnotationId={currentNoteId}>Mutoscope pictures</Annotation> in <Annotation annotationId="040043capelstreet" visited={visitedNotes.has("040043capelstreet")} annotationSelect={() => {openNote("040043capelstreet"); addToVisited("040043capelstreet")}} activeAnnotationId={currentNoteId}>Capel street</Annotation>: for men only. Peeping
+        that? Ah, yes. <Annotation annotationId="150002applyeye">Mutoscope pictures</Annotation> in <Annotation annotationId="040043capelstreet">Capel street</Annotation>: for men only. Peeping
         Tom. Willy's hat and what the girls did with it. Do they snapshot those
         girls or is <span data-edition="ed1986" data-page="301"> </span>it all a 
         <span data-edition="ed1922" data-page="351"> </span>
@@ -1078,13 +1078,13 @@ const Nausicaa = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         inside her <i>deshabillé.</i> Excites them also when they're. I'm all clean
         come and dirty me. And they like dressing one another for the sacrifice.
         Milly delighted with Molly's new blouse. At first. Put them all on to
-        take them all off. Molly. <Annotation annotationId="020080mauve" visited={visitedNotes.has("020080mauve")} annotationSelect={() => {openNote("020080mauve"); addToVisited("020080mauve")}} activeAnnotationId={currentNoteId}>Why I bought her the violet garters.</Annotation> Us too:
+        take them all off. Molly. <Annotation annotationId="020080mauve">Why I bought her the violet garters.</Annotation> Us too:
         the tie he wore, his lovely socks and turnedup trousers. He wore a pair
         of gaiters the night that first we met. His lovely shirt was shining
         beneath his what? of jet. Say a woman loses a charm with every pin she
         takes out. Pinned together. O, Mairy lost the pin of her. Dressed up to
         the nines for somebody. Fashion part of their charm. Just changes when
-        you're on the track of the secret. Except the east: <Annotation annotationId="050027marthamary" visited={visitedNotes.has("050027marthamary")} annotationSelect={() => {openNote("050027marthamary"); addToVisited("050027marthamary")}} activeAnnotationId={currentNoteId}>Mary, Martha</Annotation>: now as
+        you're on the track of the secret. Except the east: <Annotation annotationId="050027marthamary">Mary, Martha</Annotation>: now as
         then. No reasonable offer refused. She wasn't in a hurry either. Always
         off to a fellow when they are. <span data-edition="ed1961" data-page="368"> </span>They never forget an appointment. Out on
         spec probably. They believe in chance because like themselves. And the
@@ -1127,7 +1127,7 @@ const Nausicaa = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         beast. Besides I can't be so if Molly. Took off her hat to show her
         hair. Wide brim. Bought to hide her face, meeting someone might know
         her, bend down or carry a bunch of flowers to smell. Hair strong in rut.
-        <Annotation annotationId="010019money" visited={visitedNotes.has("010019money")} annotationSelect={() => {openNote("010019money"); addToVisited("010019money")}} activeAnnotationId={currentNoteId}>Ten bob</Annotation> I got for Molly's combings when we <span data-edition="ed1986" data-page="302"> </span>were on the rocks in Holles
+        <Annotation annotationId="010019money">Ten bob</Annotation> I got for Molly's combings when we <span data-edition="ed1986" data-page="302"> </span>were on the rocks in Holles
         street. Why not? Suppose he gave her money. Why not? All a prejudice.
         She's worth ten, fifteen, more, a pound. What? I think so. All that for
         nothing. Bold hand: Mrs Marion. Did I forget to write <span data-edition="ed1961" data-page="369"> </span>address on
@@ -1187,11 +1187,11 @@ const Nausicaa = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         she <span data-edition="ed1986" data-page="303"> </span>came to the use of reason, he, he and he. First kiss does the trick.
         The propitious moment. Something inside them goes pop. Mushy like, tell
         by their eye, on the sly. First thoughts are best. Remember that till
-        their dying day. Molly, <Annotation annotationId="170008precedingseries" visited={visitedNotes.has("170008precedingseries")} annotationSelect={() => {openNote("170008precedingseries"); addToVisited("170008precedingseries")}} activeAnnotationId={currentNoteId}>lieutenant Mulvey that kissed her</Annotation> under the
+        their dying day. Molly, <Annotation annotationId="170008precedingseries">lieutenant Mulvey that kissed her</Annotation> under the
         Moorish wall beside the gardens. Fifteen she told me. But her breasts
         were developed. Fell asleep then. After Glencree dinner that was when we
-        drove home <Annotation annotationId="010010mountains" visited={visitedNotes.has("010010mountains")} annotationSelect={() => {openNote("010010mountains"); addToVisited("010010mountains")}} activeAnnotationId={currentNoteId}>the featherbed mountain</Annotation>. Gnashing her teeth in sleep. <Annotation annotationId="060033corporation" visited={visitedNotes.has("060033corporation")} annotationSelect={() => {openNote("060033corporation"); addToVisited("060033corporation")}} activeAnnotationId={currentNoteId}>Lord mayor</Annotation>
-        <Annotation annotationId="170008precedingseries" visited={visitedNotes.has("170008precedingseries")} annotationSelect={() => {openNote("170008precedingseries"); addToVisited("170008precedingseries")}} activeAnnotationId={currentNoteId}>had his eye on her too. Val Dillon.</Annotation> Apoplectic.
+        drove home <Annotation annotationId="010010mountains">the featherbed mountain</Annotation>. Gnashing her teeth in sleep. <Annotation annotationId="060033corporation">Lord mayor</Annotation>
+        <Annotation annotationId="170008precedingseries">had his eye on her too. Val Dillon.</Annotation> Apoplectic.
       </p>
       <p>
         There she is with them down there for the fireworks. My fireworks. Up
@@ -1208,7 +1208,7 @@ const Nausicaa = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <p>
         Didn't look back when she was going down the strand. Wouldn't give that
-        satisfaction. <Annotation annotationId="040069seasidegirls" visited={visitedNotes.has("040069seasidegirls")} annotationSelect={() => {openNote("040069seasidegirls"); addToVisited("040069seasidegirls")}} activeAnnotationId={currentNoteId}>Those girls, those girls, those lovely seaside girls.</Annotation> Fine
+        satisfaction. <Annotation annotationId="040069seasidegirls">Those girls, those girls, those lovely seaside girls.</Annotation> Fine
         eyes she had, clear. It's the white of the eye brings that out not so
         much the pupil. Did she know what I? Course. Like a cat sitting beyond
         a dog's jump. Women never meet one like that Wilkins in the high school
@@ -1232,12 +1232,12 @@ const Nausicaa = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         like that. Holding up her hand, shaking it, to let the blood flow back
         when it was red. Who did you learn that from? Nobody. Something the
         nurse taught me. O, don't they know! Three years old she was in front of
-        Molly's dressingtable, just before we left <Annotation annotationId="040049pleasantoldtimes" visited={visitedNotes.has("040049pleasantoldtimes")} annotationSelect={() => {openNote("040049pleasantoldtimes"); addToVisited("040049pleasantoldtimes")}} activeAnnotationId={currentNoteId}>Lombard street west</Annotation>. Me have
-        a nice face. <Annotation annotationId="010126mullingar" visited={visitedNotes.has("010126mullingar")} annotationSelect={() => {openNote("010126mullingar"); addToVisited("010126mullingar")}} activeAnnotationId={currentNoteId}>Mullingar. Who knows? Ways of the world. Young student.</Annotation>
+        Molly's dressingtable, just before we left <Annotation annotationId="040049pleasantoldtimes">Lombard street west</Annotation>. Me have
+        a nice face. <Annotation annotationId="010126mullingar">Mullingar. Who knows? Ways of the world. Young student.</Annotation>
         Straight on her pins anyway not like the other. Still she was game.
         Lord, I am wet. Devil you are. Swell of her calf. Transparent <span data-edition="ed1986" data-page="304"> </span>stockings,
         stretched to breaking point. Not like that frump today. A. E. Rumpled
-        stockings. Or the one in Grafton street. White. Wow! <Annotation annotationId="040004beefheels" visited={visitedNotes.has("040004beefheels")} annotationSelect={() => {openNote("040004beefheels"); addToVisited("040004beefheels")}} activeAnnotationId={currentNoteId}>Beef to the heel</Annotation>.
+        stockings. Or the one in Grafton street. White. Wow! <Annotation annotationId="040004beefheels">Beef to the heel</Annotation>.
       </p>
       <p>
         A monkey puzzle rocket burst, spluttering in darting crackles. Zrads and
@@ -1253,15 +1253,15 @@ const Nausicaa = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         Did me good all the same. Off colour after Kiernan's, Dignam's. For
         this relief much thanks. In <i>Hamlet,</i> that is. Lord! It was all things
         combined. Excitement. When she leaned back, felt an ache at the butt
-        of my tongue. <Annotation annotationId="040069seasidegirls" visited={visitedNotes.has("040069seasidegirls")} annotationSelect={() => {openNote("040069seasidegirls"); addToVisited("040069seasidegirls")}} activeAnnotationId={currentNoteId}>Your head it simply swirls.</Annotation> He's right. Might have made a
+        of my tongue. <Annotation annotationId="040069seasidegirls">Your head it simply swirls.</Annotation> He's right. Might have made a
         worse fool of myself however. Instead of talking about nothing. Then
         I will tell you all. Still it was a kind of language between us. It
         couldn't be? No, Gerty they called her. Might be false name however like
-        my and <Annotation annotationId="040041dolphinsbarn" visited={visitedNotes.has("040041dolphinsbarn")} annotationSelect={() => {openNote("040041dolphinsbarn"); addToVisited("040041dolphinsbarn")}} activeAnnotationId={currentNoteId}>the address Dolphin's barn a blind</Annotation>.
+        my and <Annotation annotationId="040041dolphinsbarn">the address Dolphin's barn a blind</Annotation>.
       </p>
       <p>
         <i>Her maiden name was Jemima Brown <br/>
-        And she lived with her mother in <Annotation annotationId="030015irishtown" visited={visitedNotes.has("030015irishtown")} annotationSelect={() => {openNote("030015irishtown"); addToVisited("030015irishtown")}} activeAnnotationId={currentNoteId}>Irishtown</Annotation>.</i>
+        And she lived with her mother in <Annotation annotationId="030015irishtown">Irishtown</Annotation>.</i>
       </p>
       <span data-edition="ed1922" data-page="355"> </span>
       <p>
@@ -1280,7 +1280,7 @@ const Nausicaa = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         there still. She used to look over some nights when Molly was in the
         Coffee Palace. That young doctor O'Hare I noticed her brushing his coat.
         And Mrs Breen and Mrs Dignam once like that too, marriageable. Worst
-        of all at night Mrs Duggan told me in the <Annotation annotationId="020066cityarms" visited={visitedNotes.has("020066cityarms")} annotationSelect={() => {openNote("020066cityarms"); addToVisited("020066cityarms")}} activeAnnotationId={currentNoteId}>City Arms</Annotation>. <Annotation annotationId="050049comehometoma" visited={visitedNotes.has("050049comehometoma")} annotationSelect={() => {openNote("050049comehometoma"); addToVisited("050049comehometoma")}} activeAnnotationId={currentNoteId}>Husband rolling in
+        of all at night Mrs Duggan told me in the <Annotation annotationId="020066cityarms">City Arms</Annotation>. <Annotation annotationId="050049comehometoma">Husband rolling in
         drunk</Annotation>, stink of pub off him like a polecat. Have that in your nose in
         the dark, whiff of stale boose. Then ask in the morning: was I drunk
         last night? Bad policy however to fault the husband. Chickens come home
@@ -1295,10 +1295,10 @@ const Nausicaa = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         his wife. Still there's destiny in it, falling
         in love. Have their own secrets between them. Chaps that would go to the
         dogs if some woman didn't take them in hand. Then little chits of girls,
-        height of a shilling in coppers, with little hubbies. <Annotation annotationId="040065matcham" visited={visitedNotes.has("040065matcham")} annotationSelect={() => {openNote("040065matcham"); addToVisited("040065matcham")}} activeAnnotationId={currentNoteId}>As God made them
+        height of a shilling in coppers, with little hubbies. <Annotation annotationId="040065matcham">As God made them
         he matched them.</Annotation> Sometimes children turn out well enough. Twice nought
         makes one. Or old rich chap of seventy and blushing bride. Marry in May
-        and repent in December. This wet is very unpleasant. Stuck. Well <Annotation annotationId="040083hewasajew" visited={visitedNotes.has("040083hewasajew")} annotationSelect={() => {openNote("040083hewasajew"); addToVisited("040083hewasajew")}} activeAnnotationId={currentNoteId}>the
+        and repent in December. This wet is very unpleasant. Stuck. Well <Annotation annotationId="040083hewasajew">the
         foreskin</Annotation> is not back. Better detach.
       </p>
       <p>
@@ -1326,7 +1326,7 @@ const Nausicaa = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       <p>
         Wonder how is she feeling in that region. Shame all put on before third
         person. More put out about a hole in her stocking. Molly, her underjaw
-        stuck out, head back, <Annotation annotationId="170008precedingseries" visited={visitedNotes.has("170008precedingseries")} annotationSelect={() => {openNote("170008precedingseries"); addToVisited("170008precedingseries")}} activeAnnotationId={currentNoteId}>about the farmer in the ridingboots and spurs at
+        stuck out, head back, <Annotation annotationId="170008precedingseries">about the farmer in the ridingboots and spurs at
         the horse show</Annotation>. And when the painters were in Lombard street west.
         Fine voice that fellow had. How Giuglini began. Smell that I did. Like
         flowers. It was too. Violets. Came from the turpentine probably in the
@@ -1339,7 +1339,7 @@ const Nausicaa = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         Wait. Hm. Hm. Yes. That's her perfume. Why she waved her hand. I leave
         you this to think of me when I'm far away on the pillow. What is it?
         Heliotrope? No. Hyacinth? Hm. Roses, I think. She'd like scent of that
-        kind. Sweet and cheap: soon sour. <Annotation annotationId="050035opoponax" visited={visitedNotes.has("050035opoponax")} annotationSelect={() => {openNote("050035opoponax"); addToVisited("050035opoponax")}} activeAnnotationId={currentNoteId}>Why Molly likes opoponax. Suits her,
+        kind. Sweet and cheap: soon sour. <Annotation annotationId="050035opoponax">Why Molly likes opoponax. Suits her,
         with a little jessamine mixed. Her high notes and her low notes.</Annotation> At the
         dance night she met him, dance of the hours. Heat <span data-edition="ed1932" data-page="338"> </span>brought it out. She
         was wearing her black and it had the perfume of the time before. Good
@@ -1400,9 +1400,9 @@ const Nausicaa = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         good tuck in. Enjoying nature now. Grace after meals. After supper walk
         a mile. Sure he has a small bank balance somewhere, government sit. Walk
         after <span data-edition="ed1961" data-page="375"> </span>him now make him awkward like those newsboys me today. Still you
-        learn something. <Annotation annotationId="010052otherssee" visited={visitedNotes.has("010052otherssee")} annotationSelect={() => {openNote("010052otherssee"); addToVisited("010052otherssee")}} activeAnnotationId={currentNoteId}>See ourselves as others see us.</Annotation> So long as women don't
+        learn something. <Annotation annotationId="010052otherssee">See ourselves as others see us.</Annotation> So long as women don't
         mock what matter? That's the way to find out. Ask yourself who is he
-        now. <i>The Mystery Man on the Beach</i>, <Annotation annotationId="040019titbits" visited={visitedNotes.has("040019titbits")} annotationSelect={() => {openNote("040019titbits"); addToVisited("040019titbits")}} activeAnnotationId={currentNoteId}>prize titbit story</Annotation> by Mr Leopold
+        now. <i>The Mystery Man on the Beach</i>, <Annotation annotationId="040019titbits">prize titbit story</Annotation> by Mr Leopold
         Bloom. <span data-edition="ed1986" data-page="307"> </span>Payment at the rate of one guinea per column. And that fellow
         today at the graveside in the brown macintosh. Corns on his kismet
         however. Healthy perhaps absorb all the. Whistle brings rain they say.
@@ -1421,14 +1421,14 @@ const Nausicaa = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         you. Better now of course than long ago. Country roads. Run you through
         the small guts for nothing. Still two types there are you bob against.
         Scowl or smile. Pardon! Not at all. Best time to spray plants too in
-        the shade after the sun. Some light still. <Annotation annotationId="040013wonderisittrue" visited={visitedNotes.has("040013wonderisittrue")} annotationSelect={() => {openNote("040013wonderisittrue"); addToVisited("040013wonderisittrue")}} activeAnnotationId={currentNoteId}>Red rays are longest. Roygbiv
+        the shade after the sun. Some light still. <Annotation annotationId="040013wonderisittrue">Red rays are longest. Roygbiv
         Vance taught us: red, orange, yellow, green, blue, indigo, violet.</Annotation> A
         star I see. Venus? Can't tell yet. Two. When three it's night. Were
         those nightclouds there all the time? Looks like 
         <span data-edition="ed1939" data-page="271"> </span>
-        <Annotation annotationId="130006phantomship" visited={visitedNotes.has("130006phantomship")} annotationSelect={() => {openNote("130006phantomship"); addToVisited("130006phantomship")}} activeAnnotationId={currentNoteId}>a phantom ship. No.
+        <Annotation annotationId="130006phantomship">a phantom ship. No.
         Wait. Trees are they? An optical illusion. Mirage.</Annotation> Land of the setting
-        sun this. <Annotation annotationId="040006homerulesun" visited={visitedNotes.has("040006homerulesun")} annotationSelect={() => {openNote("040006homerulesun"); addToVisited("040006homerulesun")}} activeAnnotationId={currentNoteId}>Homerule sun setting in the southeast.</Annotation> My native land,
+        sun this. <Annotation annotationId="040006homerulesun">Homerule sun setting in the southeast.</Annotation> My native land,
         goodnight.
       </p>
       <p>
@@ -1440,7 +1440,7 @@ const Nausicaa = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         know how nice you looked. I begin to like them at that age. Green
         apples. Grab at all that offer. Suppose it's the only time we cross
         legs, seated. Also the library today: those girl graduates. Happy chairs
-        under them. But it's the evening influence. They feel all that. <Annotation annotationId="050026henryflower" visited={visitedNotes.has("050026henryflower")} annotationSelect={() => {openNote("050026henryflower"); addToVisited("050026henryflower")}} activeAnnotationId={currentNoteId}>Open
+        under them. But it's the evening influence. They feel all that. <Annotation annotationId="050026henryflower">Open
         like flowers</Annotation>, know their <span data-edition="ed1932" data-page="340"> </span>hours, sunflowers, Jerusalem artichokes, in
         ballrooms, chandeliers, avenues under the lamps. Nightstock in Mat
         Dillon's garden where I kissed her shoulder. Wish I had a full length
@@ -1463,22 +1463,22 @@ const Nausicaa = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         Or hers. Take the train there tomorrow. No. Returning not the
         same. Like kids your second visit to a house. The new I want. Nothing
         new under the sun. Care of P. O. Dolphin's Barn. Are you not happy in
-        your? <span data-edition="ed1986" data-page="308"> </span>Naughty darling. <Annotation annotationId="040041dolphinsbarn" visited={visitedNotes.has("040041dolphinsbarn")} annotationSelect={() => {openNote("040041dolphinsbarn"); addToVisited("040041dolphinsbarn")}} activeAnnotationId={currentNoteId}>At Dolphin's barn charades in Luke Doyle's house.</Annotation>
+        your? <span data-edition="ed1986" data-page="308"> </span>Naughty darling. <Annotation annotationId="040041dolphinsbarn">At Dolphin's barn charades in Luke Doyle's house.</Annotation>
         Mat Dillon and his bevy of daughters: Tiny, Atty, Floey, Maimy, Louy,
-        Hetty. Molly too. Eightyseven that was. Year before we. And <Annotation annotationId="040018oldtweedy" visited={visitedNotes.has("040018oldtweedy")} annotationSelect={() => {openNote("040018oldtweedy"); addToVisited("040018oldtweedy")}} activeAnnotationId={currentNoteId}>the old
+        Hetty. Molly too. Eightyseven that was. Year before we. And <Annotation annotationId="040018oldtweedy">the old
         major</Annotation>, partial to his drop of spirits. Curious she an only child, I an
         only child. So it returns. Think you're escaping and run into yourself.
         Longest way round is the shortest way home. And just when he and she.
         Circus horse walking in a ring. Rip van Winkle we played. Rip: tear in
-        Henny Doyle's overcoat. Van: breadvan delivering. Winkle: <Annotation annotationId="030080cockles" visited={visitedNotes.has("030080cockles")} annotationSelect={() => {openNote("030080cockles"); addToVisited("030080cockles")}} activeAnnotationId={currentNoteId}>cockles and
+        Henny Doyle's overcoat. Van: breadvan delivering. Winkle: <Annotation annotationId="030080cockles">cockles and
         periwinkles</Annotation>. Then I did Rip van Winkle coming back. She leaned on the
-        <Annotation annotationId="020027sideboard" visited={visitedNotes.has("020027sideboard")} annotationSelect={() => {openNote("020027sideboard"); addToVisited("020027sideboard")}} activeAnnotationId={currentNoteId}>sideboard</Annotation> watching. Moorish eyes. Twenty years asleep in Sleepy Hollow.
+        <Annotation annotationId="020027sideboard">sideboard</Annotation> watching. Moorish eyes. Twenty years asleep in Sleepy Hollow.
         All changed. Forgotten. The young are old. His gun rusty from the dew.
       </p>
       <p>
-        <Annotation annotationId="040082highgradeha" visited={visitedNotes.has("040082highgradeha")} annotationSelect={() => {openNote("040082highgradeha"); addToVisited("040082highgradeha")}} activeAnnotationId={currentNoteId}>Ba.</Annotation> What is that flying about? Swallow? Bat probably. Thinks I'm a tree,
-        so blind. Have birds no smell? <Annotation annotationId="030087pastlife" visited={visitedNotes.has("030087pastlife")} annotationSelect={() => {openNote("030087pastlife"); addToVisited("030087pastlife")}} activeAnnotationId={currentNoteId}>Metempsychosis.</Annotation> They believed you could
-        be changed into a tree from grief. Weeping willow. <Annotation annotationId="130004littleman" visited={visitedNotes.has("130004littleman")} annotationSelect={() => {openNote("130004littleman"); addToVisited("130004littleman")}} activeAnnotationId={currentNoteId}>Ba.</Annotation> There he goes.
+        <Annotation annotationId="040082highgradeha">Ba.</Annotation> What is that flying about? Swallow? Bat probably. Thinks I'm a tree,
+        so blind. Have birds no smell? <Annotation annotationId="030087pastlife">Metempsychosis.</Annotation> They believed you could
+        be changed into a tree from grief. Weeping willow. <Annotation annotationId="130004littleman">Ba.</Annotation> There he goes.
         Funny little beggar. Wonder where he lives. Belfry up there. Very
         likely. Hanging by his heels in the odour of sanctity. Bell scared him
         out, I suppose. Mass seems to be over. Could hear them all at it. Pray
@@ -1486,7 +1486,7 @@ const Nausicaa = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         thing with ads. Buy from us. And buy from us. Yes, there's the light in
         the priest's house. Their frugal meal. Remember about the mistake in the
         valuation when I was in Thom's. Twentyeight it is. Two houses they have.
-        <Annotation annotationId="040027conroy" visited={visitedNotes.has("040027conroy")} annotationSelect={() => {openNote("040027conroy"); addToVisited("040027conroy")}} activeAnnotationId={currentNoteId}>Gabriel Conroy's brother is curate.</Annotation> <Annotation annotationId="130004littleman" visited={visitedNotes.has("130004littleman")} annotationSelect={() => {openNote("130004littleman"); addToVisited("130004littleman")}} activeAnnotationId={currentNoteId}>Ba.</Annotation> Again. Wonder why they come out
+        <Annotation annotationId="040027conroy">Gabriel Conroy's brother is curate.</Annotation> <Annotation annotationId="130004littleman">Ba.</Annotation> Again. Wonder why they come out
         at night like mice. They're a mixed <span data-edition="ed1932" data-page="341"> </span>breed. Birds are like <span data-edition="ed1961" data-page="377"> </span>hopping mice.
         What frightens them, light or noise? Better sit still. All instinct
         like the bird in drouth got water out of the end of a jar by throwing
@@ -1498,18 +1498,18 @@ const Nausicaa = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         at a shoe see a blotch blob yellowish. Wants to stamp his trademark on
         everything. Instance, that cat this morning on the staircase. Colour of
         brown turf. Say you never see them with three colours. Not true. That
-        half tabbywhite tortoiseshell in the <Annotation annotationId="020066cityarms" visited={visitedNotes.has("020066cityarms")} annotationSelect={() => {openNote("020066cityarms"); addToVisited("020066cityarms")}} activeAnnotationId={currentNoteId}><i>City Arms</i></Annotation> with the letter em on
+        half tabbywhite tortoiseshell in the <Annotation annotationId="020066cityarms"><i>City Arms</i></Annotation> with the letter em on
         her forehead. Body fifty different colours. Howth a while ago amethyst.
         Glass flashing. That's how that wise man what's his name with the
         burning glass. Then the heather goes on fire. It can't be tourists'
         matches. What? Perhaps the sticks dry rub together in the 
         <span data-edition="ed1922" data-page="360"> </span>
         wind and
-        light. Or broken bottles <Annotation annotationId="120008gorse" visited={visitedNotes.has("120008gorse")} annotationSelect={() => {openNote("120008gorse"); addToVisited("120008gorse")}} activeAnnotationId={currentNoteId}>in the furze</Annotation> act as a burning glass in the sun.
+        light. Or broken bottles <Annotation annotationId="120008gorse">in the furze</Annotation> act as a burning glass in the sun.
         Archimedes. I have it! My memory's not so bad.
       </p>
       <p>
-        <Annotation annotationId="130004littleman" visited={visitedNotes.has("130004littleman")} annotationSelect={() => {openNote("130004littleman"); addToVisited("130004littleman")}} activeAnnotationId={currentNoteId}>Ba.</Annotation> Who knows what they're always flying for. Insects? That bee last
+        <Annotation annotationId="130004littleman">Ba.</Annotation> Who knows what they're always flying for. Insects? That bee last
         week got into the room playing with his shadow on the ceiling. Might
         be the one bit me, come back to see. Birds too never find out what
         they say. Like our small talk. And says she and says he. Nerve they have
@@ -1523,8 +1523,8 @@ const Nausicaa = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         they say. She has a good job if she minds it till Johnny comes marching
         home again. If ever he does. Smelling the tail end of ports. How can
         they like the sea? Yet they do. The anchor's weighed. Off he sails with
-        a <Annotation annotationId="040036scapulars" visited={visitedNotes.has("040036scapulars")} annotationSelect={() => {openNote("040036scapulars"); addToVisited("040036scapulars")}} activeAnnotationId={currentNoteId}>scapular</Annotation> or a medal on him for luck. Well. <Annotation annotationId="040047potato" visited={visitedNotes.has("040047potato")} annotationSelect={() => {openNote("040047potato"); addToVisited("040047potato")}} activeAnnotationId={currentNoteId}>And the tephilim no what's
-        this they call it poor papa's father had on his door to touch.</Annotation> <Annotation annotationId="060043passover" visited={visitedNotes.has("060043passover")} annotationSelect={() => {openNote("060043passover"); addToVisited("060043passover")}} activeAnnotationId={currentNoteId}>That
+        a <Annotation annotationId="040036scapulars">scapular</Annotation> or a medal on him for luck. Well. <Annotation annotationId="040047potato">And the tephilim no what's
+        this they call it poor papa's father had on his door to touch.</Annotation> <Annotation annotationId="060043passover">That
         brought us out of the land of Egypt and into the house of bondage.</Annotation>
         Something in all those superstitions because when you go out never know
         what dangers. Hanging on to a plank or astride of a beam for grim life,
@@ -1545,24 +1545,24 @@ const Nausicaa = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         postman, the glowworm's lamp at his belt gleaming here and there through
         the laurel hedges. And among the five young trees a hoisted lintstock
         lit the lamp at Leahy's terrace. By screens of lighted windows, by equal
-        gardens a shrill voice went crying, wailing: <Annotation annotationId="020064telegraph" visited={visitedNotes.has("020064telegraph")} annotationSelect={() => {openNote("020064telegraph"); addToVisited("020064telegraph")}} activeAnnotationId={currentNoteId}><i>Evening Telegraph, stop
+        gardens a shrill voice went crying, wailing: <Annotation annotationId="020064telegraph"><i>Evening Telegraph, stop
         press edition! Result of the Gold Cup race!</i></Annotation> and from the door of
         Dignam's house a boy ran out and called. Twittering the bat flew here,
         flew there. Far out over the sands the coming surf crept, grey. Howth
-        settled for slumber, tired of <Annotation annotationId="030072longestday" visited={visitedNotes.has("030072longestday")} annotationSelect={() => {openNote("030072longestday"); addToVisited("030072longestday")}} activeAnnotationId={currentNoteId}>long days</Annotation>, of yumyum rhododendrons (he was
+        settled for slumber, tired of <Annotation annotationId="030072longestday">long days</Annotation>, of yumyum rhododendrons (he was
         old) and felt 
         <span data-edition="ed1922" data-page="361"> </span>
         gladly the night breeze lift, ruffle his fell of ferns.
         He lay but opened a red eye unsleeping, deep and slowly breathing,
-        slumberous but awake. And far <Annotation annotationId="030013kishlightship" visited={visitedNotes.has("030013kishlightship")} annotationSelect={() => {openNote("030013kishlightship"); addToVisited("030013kishlightship")}} activeAnnotationId={currentNoteId}>on Kish bank the anchored lightship</Annotation>
+        slumberous but awake. And far <Annotation annotationId="030013kishlightship">on Kish bank the anchored lightship</Annotation>
         twinkled, winked at Mr Bloom.
       </p>
       <p>
-        Life those chaps out there must have, stuck in the same spot. <Annotation annotationId="130001irishlights" visited={visitedNotes.has("130001irishlights")} annotationSelect={() => {openNote("130001irishlights"); addToVisited("130001irishlights")}} activeAnnotationId={currentNoteId}>Irish
+        Life those chaps out there must have, stuck in the same spot. <Annotation annotationId="130001irishlights">Irish
         Lights board.</Annotation> Penance for their sins. Coastguards too. Rocket and
         breeches buoy and lifeboat. 
         <span data-edition="ed1939" data-page="273"> </span>
-        <Annotation annotationId="030013kishlightship" visited={visitedNotes.has("030013kishlightship")} annotationSelect={() => {openNote("030013kishlightship"); addToVisited("030013kishlightship")}} activeAnnotationId={currentNoteId}>Day we went out for the pleasure cruise in
+        <Annotation annotationId="030013kishlightship">Day we went out for the pleasure cruise in
         the Erin's King</Annotation>, throwing them the sack of old papers. Bears in the zoo.
         Filthy trip. Drunkards out to shake up their livers. Puking overboard
         to feed the herrings. Nausea. And the women, fear of God in their faces.
@@ -1593,10 +1593,10 @@ const Nausicaa = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <p>
         Better not stick here all night like a limpet. This weather makes you
-        dull. Must be getting on for nine by the light. Go home. <Annotation annotationId="050032leah" visited={visitedNotes.has("050032leah")} annotationSelect={() => {openNote("050032leah"); addToVisited("050032leah")}} activeAnnotationId={currentNoteId}>Too late for
+        dull. Must be getting on for nine by the light. Go home. <Annotation annotationId="050032leah">Too late for
         <i>Leah,</i></Annotation> <i>Lily of Killarney.</i> No. Might be still up. Call to the hospital
         to see. Hope she's over. Long day I've had. Martha, the bath, funeral,
-        house of keys, <Annotation annotationId="080005venus" visited={visitedNotes.has("080005venus")} annotationSelect={() => {openNote("080005venus"); addToVisited("080005venus")}} activeAnnotationId={currentNoteId}>museum with those goddesses</Annotation>, Dedalus' song. Then that
+        house of keys, <Annotation annotationId="080005venus">museum with those goddesses</Annotation>, Dedalus' song. Then that
         bawler in Barney Kiernan's. Got my own back there. Drunken ranters. What
         I said about his God made him wince. 
         <span data-edition="ed1922" data-page="362"> </span>
@@ -1610,31 +1610,31 @@ const Nausicaa = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         Borneo has just come to town. Imagine that in the early morning at close
         range. Everyone to his taste as Morris said when he kissed the cow. But
         Dignam's put the boots on it. Houses of mourning so depressing because
-        you never know. Anyhow she wants the money. <Annotation annotationId="130007scottishwidows" visited={visitedNotes.has("130007scottishwidows")} annotationSelect={() => {openNote("130007scottishwidows"); addToVisited("130007scottishwidows")}} activeAnnotationId={currentNoteId}>Must call to those Scottish
+        you never know. Anyhow she wants the money. <Annotation annotationId="130007scottishwidows">Must call to those Scottish
         Widows as I promised. Strange name.</Annotation> Takes it for granted we're going to
         pop off first. That widow on Monday was it outside Cramer's that
         looked at me. Buried the poor husband but progressing favourably on
         the premium. Her widow's mite. Well? What do you expect her to do? Must
         wheedle her <span data-edition="ed1961" data-page="380"> </span>way along. Widower I hate to see. Looks so forlorn. Poor man
-        O'Connor wife and five children poisoned by mussels here. <Annotation annotationId="030039sewage" visited={visitedNotes.has("030039sewage")} annotationSelect={() => {openNote("030039sewage"); addToVisited("030039sewage")}} activeAnnotationId={currentNoteId}>The sewage.</Annotation>
+        O'Connor wife and five children poisoned by mussels here. <Annotation annotationId="030039sewage">The sewage.</Annotation>
         Hopeless. Some good matronly woman in a porkpie hat to mother him. Take
         him in tow, platter face and a large apron. Ladies' grey flannelette
         bloomers, three shillings a pair, astonishing bargain. Plain and loved,
         <span data-edition="ed1939" data-page="274"> </span>
         loved for ever, they say. Ugly: no woman thinks she is. Love, lie and be
         handsome for tomorrow we die. See him sometimes walking about trying to
-        find out who played the trick. <Annotation annotationId="080010upup" visited={visitedNotes.has("080010upup")} annotationSelect={() => {openNote("080010upup"); addToVisited("080010upup")}} activeAnnotationId={currentNoteId}>U. p: up.</Annotation> Fate that is. He, not me. Also
+        find out who played the trick. <Annotation annotationId="080010upup">U. p: up.</Annotation> Fate that is. He, not me. Also
         a shop often noticed. Curse seems to dog it. Dreamt last night? Wait.
         Something confused. She had red slippers <span data-edition="ed1986" data-page="311"> </span>on. Turkish. Wore the breeches.
         Suppose she does. Would I like her in pyjamas? Damned hard to <span data-edition="ed1932" data-page="344"> </span>answer.
-        <Annotation annotationId="070019nannetti" visited={visitedNotes.has("070019nannetti")} annotationSelect={() => {openNote("070019nannetti"); addToVisited("070019nannetti")}} activeAnnotationId={currentNoteId}>Nannetti</Annotation>'s gone. <Annotation annotationId="010036mailboat" visited={visitedNotes.has("010036mailboat")} annotationSelect={() => {openNote("010036mailboat"); addToVisited("010036mailboat")}} activeAnnotationId={currentNoteId}>Mailboat. Near Holyhead by now.</Annotation> Must nail that ad
+        <Annotation annotationId="070019nannetti">Nannetti</Annotation>'s gone. <Annotation annotationId="010036mailboat">Mailboat. Near Holyhead by now.</Annotation> Must nail that ad
         of Keyes's. Work Hynes and Crawford. Petticoats for Molly. She has
         something to put in them. What's that? Might be money.
       </p>
       <p>
         Mr Bloom stooped and turned over a piece of paper on the strand. He
         brought it near his eyes and peered. Letter? No. Can't read. Better go.
-        Better. I'm tired to move. Page of an old copybook. <Annotation annotationId="030038pebbles" visited={visitedNotes.has("030038pebbles")} annotationSelect={() => {openNote("030038pebbles"); addToVisited("030038pebbles")}} activeAnnotationId={currentNoteId}>All those holes and
+        Better. I'm tired to move. Page of an old copybook. <Annotation annotationId="030038pebbles">All those holes and
         pebbles. Who could count them?</Annotation> Never know what you find. Bottle with
         story of a treasure in it, thrown from a wreck. Parcels post. Children
         always want to throw things in the sea. Trust? Bread cast on the waters.
@@ -1688,10 +1688,10 @@ const Nausicaa = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <p>
         O sweety all your little girlwhite up I saw dirty bracegirdle made me do
-        love sticky we two naughty Grace darling she him half past the bed <Annotation annotationId="030087pastlife" visited={visitedNotes.has("030087pastlife")} annotationSelect={() => {openNote("030087pastlife"); addToVisited("030087pastlife")}} activeAnnotationId={currentNoteId}>met
+        love sticky we two naughty Grace darling she him half past the bed <Annotation annotationId="030087pastlife">met
         him pike hoses</Annotation> frillies for Raoul to perfume your wife black hair heave
         under embon <i>señorita</i> young eyes Mulvey plump years dreams <span data-edition="ed1932" data-page="345"> </span>return 
-        tail end <Annotation annotationId="040061agendath" visited={visitedNotes.has("040061agendath")} annotationSelect={() => {openNote("040061agendath"); addToVisited("040061agendath")}} activeAnnotationId={currentNoteId}>Agendath</Annotation> swoony lovey showed me her next year in drawers return next 
+        tail end <Annotation annotationId="040061agendath">Agendath</Annotation> swoony lovey showed me her next year in drawers return next 
         in her next her next.
       </p>
       <span data-edition="ed1986" data-page="312"> </span>
@@ -1700,7 +1700,7 @@ const Nausicaa = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         with open mouth, his left boot sanded sideways, leaned, breathed. Just
         for a few
       </p>
-      <p><Annotation annotationId="130005cuckoo" visited={visitedNotes.has("130005cuckoo")} annotationSelect={() => {openNote("130005cuckoo"); addToVisited("130005cuckoo")}} activeAnnotationId={currentNoteId}>
+      <p><Annotation annotationId="130005cuckoo">
         <i>Cuckoo.<br/>
         Cuckoo.<br/>
         Cuckoo.</i></Annotation>

--- a/src/content/chapters/Nestor.js
+++ b/src/content/chapters/Nestor.js
@@ -1,13 +1,13 @@
 import Annotation from "../../components/Annotation";
 
 
-const Nestor = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
+const Nestor = () => {
   return (
     <div>
       <p></p>
-      <center><Annotation annotationId="020000nestor" visited={visitedNotes.has("020000nestor")} annotationSelect={() => {openNote("020000nestor"); addToVisited("020000nestor")}} activeAnnotationId={currentNoteId}><font size="+2">[2]</font></Annotation></center>
+      <center><Annotation annotationId="020000nestor"><font size="+2">[2]</font></Annotation></center>
       <br/>
-      —{" "}You, <Annotation annotationId="020001cochrane" visited={visitedNotes.has("020001cochrane")} annotationSelect={() => {openNote("020001cochrane"); addToVisited("020001cochrane")}} activeAnnotationId={currentNoteId}>Cochrane</Annotation>, <Annotation annotationId="020002pyrrhus" visited={visitedNotes.has("020002pyrrhus")} annotationSelect={() => {openNote("020002pyrrhus"); addToVisited("020002pyrrhus")}} activeAnnotationId={currentNoteId}>what city sent for him?</Annotation>
+      —{" "}You, <Annotation annotationId="020001cochrane">Cochrane</Annotation>, <Annotation annotationId="020002pyrrhus">what city sent for him?</Annotation>
       <p></p>
       <p>
         —{" "}Tarentum, sir.
@@ -25,8 +25,8 @@ const Nestor = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         The boy's blank face asked the blank window.
       </p>
       <p>
-        <Annotation annotationId="020003daughtersofmemory" visited={visitedNotes.has("020003daughtersofmemory")} annotationSelect={() => {openNote("020003daughtersofmemory"); addToVisited("020003daughtersofmemory")}} activeAnnotationId={currentNoteId}>Fabled by the daughters of memory.</Annotation> And yet it was in some way if not as
-        memory fabled it. A phrase, then, of impatience, <Annotation annotationId="020003daughtersofmemory" visited={visitedNotes.has("020003daughtersofmemory")} annotationSelect={() => {openNote("020003daughtersofmemory"); addToVisited("020003daughtersofmemory")}} activeAnnotationId={currentNoteId}>thud of Blake's wings
+        <Annotation annotationId="020003daughtersofmemory">Fabled by the daughters of memory.</Annotation> And yet it was in some way if not as
+        memory fabled it. A phrase, then, of impatience, <Annotation annotationId="020003daughtersofmemory">thud of Blake's wings
         of excess. I hear the ruin of all space, shattered glass and toppling
         masonry, and time one livid final flame.</Annotation> What's left us then?
       </p>
@@ -63,7 +63,7 @@ const Nestor = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         A bag of figrolls lay snugly in Armstrong's satchel. He curled them
         between his palms at whiles and swallowed them softly. Crumbs adhered to
         the tissue of his lips. A sweetened boy's breath. Welloff people, proud
-        that their eldest son was <Annotation annotationId="010058bloodyswindle" visited={visitedNotes.has("010058bloodyswindle")} annotationSelect={() => {openNote("010058bloodyswindle"); addToVisited("010058bloodyswindle")}} activeAnnotationId={currentNoteId}>in the navy</Annotation>. <Annotation annotationId="020004vicoroad" visited={visitedNotes.has("020004vicoroad")} annotationSelect={() => {openNote("020004vicoroad"); addToVisited("020004vicoroad")}} activeAnnotationId={currentNoteId}>Vico road, Dalkey</Annotation>.
+        that their eldest son was <Annotation annotationId="010058bloodyswindle">in the navy</Annotation>. <Annotation annotationId="020004vicoroad">Vico road, Dalkey</Annotation>.
       </p>
       <p>
         —{" "}Pyrrhus, sir? Pyrrhus, a pier.
@@ -80,7 +80,7 @@ const Nestor = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <p>
         —{" "}A pier, sir, Armstrong said. A thing out in the water. A kind of a
-        bridge. <Annotation annotationId="010037harbourmouth" visited={visitedNotes.has("010037harbourmouth")} annotationSelect={() => {openNote("010037harbourmouth"); addToVisited("010037harbourmouth")}} activeAnnotationId={currentNoteId}>Kingstown pier</Annotation>, sir.
+        bridge. <Annotation annotationId="010037harbourmouth">Kingstown pier</Annotation>, sir.
       </p>
       <p>
         Some laughed again: mirthless but with meaning. Two in the back bench
@@ -100,7 +100,7 @@ const Nestor = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         —{" "}How, sir? Comyn asked. A bridge is across a river.
       </p>
       <p>
-        <Annotation annotationId="020006chapbook" visited={visitedNotes.has("020006chapbook")} annotationSelect={() => {openNote("020006chapbook"); addToVisited("020006chapbook")}} activeAnnotationId={currentNoteId}>For Haines's chapbook. No-one here to hear. Tonight deftly amid wild
+        <Annotation annotationId="020006chapbook">For Haines's chapbook. No-one here to hear. Tonight deftly amid wild
         drink and talk, to pierce the polished mail of his mind. What then? A
         jester at the court of his master, indulged and disesteemed, winning a
         clement master's praise. Why had they chosen all that part? Not wholly
@@ -108,18 +108,18 @@ const Nestor = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         too often heard, their land a pawnshop.</Annotation>
       </p>
       <p>
-        Had Pyrrhus not fallen by a beldam's hand in Argos <Annotation annotationId="020007juliuscaesar" visited={visitedNotes.has("020007juliuscaesar")} annotationSelect={() => {openNote("020007juliuscaesar"); addToVisited("020007juliuscaesar")}} activeAnnotationId={currentNoteId}>or Julius Caesar not
+        Had Pyrrhus not fallen by a beldam's hand in Argos <Annotation annotationId="020007juliuscaesar">or Julius Caesar not
         been knifed to death</Annotation>. They are not to be thought away. Time has
-        branded them and fettered they are lodged in the room of <Annotation annotationId="020008infinitepossibilities" visited={visitedNotes.has("020008infinitepossibilities")} annotationSelect={() => {openNote("020008infinitepossibilities"); addToVisited("020008infinitepossibilities")}} activeAnnotationId={currentNoteId}>the infinite
+        branded them and fettered they are lodged in the room of <Annotation annotationId="020008infinitepossibilities">the infinite
         possibilities they have ousted</Annotation>. But can those have been possible seeing
         that they never were? Or was that only possible which came to pass?
-        Weave, <Annotation annotationId="010120weavewind" visited={visitedNotes.has("010120weavewind")} annotationSelect={() => {openNote("010120weavewind"); addToVisited("010120weavewind")}} activeAnnotationId={currentNoteId}>weaver of the wind</Annotation>.
+        Weave, <Annotation annotationId="010120weavewind">weaver of the wind</Annotation>.
       </p>
       <p>
         —{" "}Tell us a story, sir.
       </p>
       <p>
-        —{" "}O, do, sir. A <Annotation annotationId="020009ghoststory" visited={visitedNotes.has("020009ghoststory")} annotationSelect={() => {openNote("020009ghoststory"); addToVisited("020009ghoststory")}} activeAnnotationId={currentNoteId}>ghoststory</Annotation>.
+        —{" "}O, do, sir. A <Annotation annotationId="020009ghoststory">ghoststory</Annotation>.
       </p>
       <p>
         —{" "}Where do you begin in this? Stephen asked, opening another book.
@@ -142,19 +142,19 @@ const Nestor = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         of his satchel. He recited jerks of verse with odd glances at the text:
       </p>
       <span data-edition="ed1922" data-page="25"></span>
-      <p><i>—{" "}{" "}<Annotation annotationId="020010lycidas" visited={visitedNotes.has("020010lycidas")} annotationSelect={() => {openNote("020010lycidas"); addToVisited("020010lycidas")}} activeAnnotationId={currentNoteId}>Weep no more, woful shepherds, weep no more <br/>
+      <p><i>—{" "}{" "}<Annotation annotationId="020010lycidas">Weep no more, woful shepherds, weep no more <br/>
         For Lycidas, your sorrow, is not dead, <br/>
         Sunk though he be beneath the watery floor...</Annotation></i>
       </p>
       <p>
-        It must be <Annotation annotationId="020008infinitepossibilities" visited={visitedNotes.has("020008infinitepossibilities")} annotationSelect={() => {openNote("020008infinitepossibilities"); addToVisited("020008infinitepossibilities")}} activeAnnotationId={currentNoteId}>a movement then, an actuality of the possible as possible.</Annotation>
+        It must be <Annotation annotationId="020008infinitepossibilities">a movement then, an actuality of the possible as possible.</Annotation>
         Aristotle's phrase formed itself within the gabbled verses and floated
-        out into the studious silence of <Annotation annotationId="020011saintgenevieve" visited={visitedNotes.has("020011saintgenevieve")} annotationSelect={() => {openNote("020011saintgenevieve"); addToVisited("020011saintgenevieve")}} activeAnnotationId={currentNoteId}>the library of Saint Genevieve</Annotation> where he
+        out into the studious silence of <Annotation annotationId="020011saintgenevieve">the library of Saint Genevieve</Annotation> where he
         had read, sheltered from the sin of Paris, night by night. By his elbow
-        <Annotation annotationId="020012siamese" visited={visitedNotes.has("020012siamese")} annotationSelect={() => {openNote("020012siamese"); addToVisited("020012siamese")}} activeAnnotationId={currentNoteId}>a delicate Siamese conned a handbook of strategy</Annotation>. Fed and feeding brains
+        <Annotation annotationId="020012siamese">a delicate Siamese conned a handbook of strategy</Annotation>. Fed and feeding brains
         about me: under glowlamps, impaled, with faintly beating feelers: <span data-edition="ed1961" data-page="25"></span>and
-        <Annotation annotationId="020023darkness" visited={visitedNotes.has("020023darkness")} annotationSelect={() => {openNote("020023darkness"); addToVisited("020023darkness")}} activeAnnotationId={currentNoteId}>in my mind's darkness a sloth of the underworld, reluctant, shy of
-        brightness, shifting her dragon scaly folds.</Annotation> <Annotation annotationId="020013candescent" visited={visitedNotes.has("020013candescent")} annotationSelect={() => {openNote("020013candescent"); addToVisited("020013candescent")}} activeAnnotationId={currentNoteId}>Thought is the thought of
+        <Annotation annotationId="020023darkness">in my mind's darkness a sloth of the underworld, reluctant, shy of
+        brightness, shifting her dragon scaly folds.</Annotation> <Annotation annotationId="020013candescent">Thought is the thought of
         thought. Tranquil brightness. The soul is in a manner all that is: the
         soul is the form of forms. Tranquility sudden, vast, candescent: form of
         forms.</Annotation>
@@ -176,12 +176,12 @@ const Nestor = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         His hand turned the page over. He leaned back and went on again, having
         just remembered. Of him that walked the waves. Here also over these
         craven hearts his shadow lies and on the scoffer's heart and lips and
-        on mine. It lies upon their eager faces who offered him <Annotation annotationId="020014coinoftribute" visited={visitedNotes.has("020014coinoftribute")} annotationSelect={() => {openNote("020014coinoftribute"); addToVisited("020014coinoftribute")}} activeAnnotationId={currentNoteId}>a coin of the
+        on mine. It lies upon their eager faces who offered him <Annotation annotationId="020014coinoftribute">a coin of the
         tribute. To Caesar what is Caesar's, to </Annotation> 
         <span data-edition="ed1939" data-page="21"> </span>
-        <Annotation annotationId="020014coinoftribute" visited={visitedNotes.has("020014coinoftribute")} annotationSelect={() => {openNote("020014coinoftribute"); addToVisited("020014coinoftribute")}} activeAnnotationId={currentNoteId}>God what is God's. </Annotation> A long look from dark eyes, a riddling sentence to be woven and <Annotation annotationId="010120weavewind" visited={visitedNotes.has("010120weavewind")} annotationSelect={() => {openNote("010120weavewind"); addToVisited("010120weavewind")}} activeAnnotationId={currentNoteId}>woven on the church's looms</Annotation>. Ay.
+        <Annotation annotationId="020014coinoftribute">God what is God's. </Annotation> A long look from dark eyes, a riddling sentence to be woven and <Annotation annotationId="010120weavewind">woven on the church's looms</Annotation>. Ay.
       </p>
-      <p><i><Annotation annotationId="020015riddleme" visited={visitedNotes.has("020015riddleme")} annotationSelect={() => {openNote("020015riddleme"); addToVisited("020015riddleme")}} activeAnnotationId={currentNoteId}>Riddle me, riddle me, randy ro. <br/>
+      <p><i><Annotation annotationId="020015riddleme">Riddle me, riddle me, randy ro. <br/>
         My father gave me seeds to sow.</Annotation></i>
       </p>
       <p>
@@ -191,7 +191,7 @@ const Nestor = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         —{" "}Have I heard all? Stephen asked.
       </p>
       <p>
-        —{" "}Yes, sir. <Annotation annotationId="020016hockey" visited={visitedNotes.has("020016hockey")} annotationSelect={() => {openNote("020016hockey"); addToVisited("020016hockey")}} activeAnnotationId={currentNoteId}>Hockey</Annotation> <Annotation annotationId="020000nestor" visited={visitedNotes.has("020000nestor")} annotationSelect={() => {openNote("020000nestor"); addToVisited("020000nestor")}} activeAnnotationId={currentNoteId}>at ten</Annotation>, sir.
+        —{" "}Yes, sir. <Annotation annotationId="020016hockey">Hockey</Annotation> <Annotation annotationId="020000nestor">at ten</Annotation>, sir.
       </p>
       <p>
         —{" "}Half day, sir. Thursday.
@@ -245,7 +245,7 @@ const Nestor = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         Stephen, his throat itching, answered:
       </p>
       <p>
-        —{" "}<Annotation annotationId="020009ghoststory" visited={visitedNotes.has("020009ghoststory")} annotationSelect={() => {openNote("020009ghoststory"); addToVisited("020009ghoststory")}} activeAnnotationId={currentNoteId}>The fox burying his grandmother under a hollybush.</Annotation>
+        —{" "}<Annotation annotationId="020009ghoststory">The fox burying his grandmother under a hollybush.</Annotation>
       </p>
       <p>
         He stood up and gave a shout of nervous laughter to which their cries
@@ -277,7 +277,7 @@ const Nestor = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <span data-edition="ed1939" data-page="22"></span>
       <p>
-        —{" "}<Annotation annotationId="020017deasy" visited={visitedNotes.has("020017deasy")} annotationSelect={() => {openNote("020017deasy"); addToVisited("020017deasy")}} activeAnnotationId={currentNoteId}>Mr Deasy</Annotation> told me to write them out all again, he said, and show them
+        —{" "}<Annotation annotationId="020017deasy">Mr Deasy</Annotation> told me to write them out all again, he said, and show them
         to you, sir.
       </p>
       <p>
@@ -301,28 +301,28 @@ const Nestor = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       <p>
         Ugly and futile: lean neck and tangled hair and a stain of ink, a snail's
         bed. Yet someone had loved him, borne him in her arms and in her heart.
-        But for her the race of the world would have <Annotation annotationId="020053squashedsnail" visited={visitedNotes.has("020053squashedsnail")} annotationSelect={() => {openNote("020053squashedsnail"); addToVisited("020053squashedsnail")}} activeAnnotationId={currentNoteId}>trampled him underfoot, a squashed boneless snail</Annotation>. She had loved his weak watery blood drained from her own. <Annotation annotationId="020024amormatris" visited={visitedNotes.has("020024amormatris")} annotationSelect={() => {openNote("020024amormatris"); addToVisited("020024amormatris")}} activeAnnotationId={currentNoteId}>Was that then real? The only true thing in life?</Annotation> His
-        mother's prostrate body <Annotation annotationId="020018columbanus" visited={visitedNotes.has("020018columbanus")} annotationSelect={() => {openNote("020018columbanus"); addToVisited("020018columbanus")}} activeAnnotationId={currentNoteId}>the fiery Columbanus</Annotation> in holy zeal bestrode.
+        But for her the race of the world would have <Annotation annotationId="020053squashedsnail">trampled him underfoot, a squashed boneless snail</Annotation>. She had loved his weak watery blood drained from her own. <Annotation annotationId="020024amormatris">Was that then real? The only true thing in life?</Annotation> His
+        mother's prostrate body <Annotation annotationId="020018columbanus">the fiery Columbanus</Annotation> in holy zeal bestrode.
         She was no more: the trembling skeleton of a twig burnt in the fire,
-        an odour of <Annotation annotationId="010045waxandrosewood" visited={visitedNotes.has("010045waxandrosewood")} annotationSelect={() => {openNote("010045waxandrosewood"); addToVisited("010045waxandrosewood")}} activeAnnotationId={currentNoteId}>rosewood and wetted ashes</Annotation>. She <span data-edition="ed1961" data-page="27"></span>had saved him from being
+        an odour of <Annotation annotationId="010045waxandrosewood">rosewood and wetted ashes</Annotation>. She <span data-edition="ed1961" data-page="27"></span>had saved him from being
         trampled underfoot and had gone, scarcely having been. A poor soul
         gone to heaven: and on a heath beneath winking stars a fox, red reek
         of rapine in his fur, with merciless bright eyes scraped in the earth,
         listened, scraped up the earth, listened, scraped and scraped.
       </p>
       <p>
-        Sitting at his side Stephen solved out the problem. <Annotation annotationId="010139hearhim" visited={visitedNotes.has("010139hearhim")} annotationSelect={() => {openNote("010139hearhim"); addToVisited("010139hearhim")}} activeAnnotationId={currentNoteId}>He proves by algebra
+        Sitting at his side Stephen solved out the problem. <Annotation annotationId="010139hearhim">He proves by algebra
         that Shakespeare's ghost is Hamlet's grandfather.</Annotation> Sargent peered askance
         through his slanted glasses. Hockeysticks rattled in the lumberroom: the
         hollow knock of a ball and calls from the field.
       </p>
       <p>
-        Across the page <Annotation annotationId="020020morrice" visited={visitedNotes.has("020020morrice")} annotationSelect={() => {openNote("020020morrice"); addToVisited("020020morrice")}} activeAnnotationId={currentNoteId}>the symbols moved in grave morrice, in the mummery of
+        Across the page <Annotation annotationId="020020morrice">the symbols moved in grave morrice, in the mummery of
         their letters, wearing quaint caps of squares and cubes.</Annotation> Give hands,
         traverse, bow to partner: so: imps of fancy of the Moors. Gone too from
-        the world, <Annotation annotationId="020021averromonides" visited={visitedNotes.has("020021averromonides")} annotationSelect={() => {openNote("020021averromonides"); addToVisited("020021averromonides")}} activeAnnotationId={currentNoteId}>Averroes and Moses Maimonides</Annotation>, dark men in mien and movement,
-        flashing in their mocking mirrors the obscure <Annotation annotationId="020022animamundi" visited={visitedNotes.has("020022animamundi")} annotationSelect={() => {openNote("020022animamundi"); addToVisited("020022animamundi")}} activeAnnotationId={currentNoteId}>soul of the world</Annotation>, a
-        <Annotation annotationId="020023darkness" visited={visitedNotes.has("020023darkness")} annotationSelect={() => {openNote("020023darkness"); addToVisited("020023darkness")}} activeAnnotationId={currentNoteId}>darkness shining in brightness</Annotation> which brightness could not comprehend.
+        the world, <Annotation annotationId="020021averromonides">Averroes and Moses Maimonides</Annotation>, dark men in mien and movement,
+        flashing in their mocking mirrors the obscure <Annotation annotationId="020022animamundi">soul of the world</Annotation>, a
+        <Annotation annotationId="020023darkness">darkness shining in brightness</Annotation> which brightness could not comprehend.
       </p>
       <p>
         —{" "}Do you understand now? Can you work the second for yourself?
@@ -333,7 +333,7 @@ const Nestor = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       <p>
         In long shaky strokes Sargent copied the data. Waiting always for a word
         of help his hand moved faithfully the unsteady symbols, a faint hue of
-        shame flickering behind his dull skin. <Annotation annotationId="020024amormatris" visited={visitedNotes.has("020024amormatris")} annotationSelect={() => {openNote("020024amormatris"); addToVisited("020024amormatris")}} activeAnnotationId={currentNoteId}><i>Amor matris:</i> subjective and
+        shame flickering behind his dull skin. <Annotation annotationId="020024amormatris"><i>Amor matris:</i> subjective and
         objective genitive.</Annotation> With her weak blood and wheysour milk she had fed
         him and hid from sight of others his swaddling bands.
       </p>
@@ -342,7 +342,7 @@ const Nestor = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         Like him was I, these sloping shoulders, this gracelessness. My
         childhood bends beside me. Too far for me to lay a hand there once or
         lightly. Mine is far and his secret as our eyes. Secrets, silent, stony
-        sit in the <Annotation annotationId="020023darkness" visited={visitedNotes.has("020023darkness")} annotationSelect={() => {openNote("020023darkness"); addToVisited("020023darkness")}} activeAnnotationId={currentNoteId}>dark palaces of both
+        sit in the <Annotation annotationId="020023darkness">dark palaces of both
         <span data-edition="ed1922" data-page="28"></span>our hearts</Annotation>: secrets weary of their tyranny: tyrants, willing to be dethroned.
       </p>
       <p>
@@ -391,7 +391,7 @@ const Nestor = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         —{" "}Cochrane and Halliday are on the same side, sir, Stephen said.
       </p>
       <p>
-        —{" "}Will you wait in <Annotation annotationId="020075samewisdom" visited={visitedNotes.has("020075samewisdom")} annotationSelect={() => {openNote("020075samewisdom"); addToVisited("020075samewisdom")}} activeAnnotationId={currentNoteId}>my study</Annotation> for a moment, Mr Deasy said, till I restore
+        —{" "}Will you wait in <Annotation annotationId="020075samewisdom">my study</Annotation> for a moment, Mr Deasy said, till I restore
         order here.
       </p>
       <p>
@@ -409,9 +409,9 @@ const Nestor = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         Stale smoky air hung in the study with the smell of drab abraded leather
         of its chairs. As on the first day he bargained with me here. 
       </p>
-      <p><Annotation annotationId="020025asitwas" visited={visitedNotes.has("020025asitwas")} annotationSelect={() => {openNote("020025asitwas"); addToVisited("020025asitwas")}} activeAnnotationId={currentNoteId}>As it was
-        in the beginning,</Annotation> is now. On the <Annotation annotationId="020027sideboard" visited={visitedNotes.has("020027sideboard")} annotationSelect={() => {openNote("020027sideboard"); addToVisited("020027sideboard")}} activeAnnotationId={currentNoteId}>sideboard</Annotation> the tray of <Annotation annotationId="020026stuartcoins" visited={visitedNotes.has("020026stuartcoins")} annotationSelect={() => {openNote("020026stuartcoins"); addToVisited("020026stuartcoins")}} activeAnnotationId={currentNoteId}>Stuart coins</Annotation>,
-        base treasure of <Annotation annotationId="060036bogs" visited={visitedNotes.has("060036bogs")} annotationSelect={() => {openNote("060036bogs"); addToVisited("060036bogs")}} activeAnnotationId={currentNoteId}>a bog</Annotation>: and ever shall be. And <Annotation annotationId="020028twelveapostles" visited={visitedNotes.has("020028twelveapostles")} annotationSelect={() => {openNote("020028twelveapostles"); addToVisited("020028twelveapostles")}} activeAnnotationId={currentNoteId}>snug in their spooncase</Annotation> of <Annotation annotationId="020080mauve" visited={visitedNotes.has("020080mauve")} annotationSelect={() => {openNote("020080mauve"); addToVisited("020080mauve")}} activeAnnotationId={currentNoteId}>purple plush</Annotation>, faded, the twelve apostles having preached to all the
+      <p><Annotation annotationId="020025asitwas">As it was
+        in the beginning,</Annotation> is now. On the <Annotation annotationId="020027sideboard">sideboard</Annotation> the tray of <Annotation annotationId="020026stuartcoins">Stuart coins</Annotation>,
+        base treasure of <Annotation annotationId="060036bogs">a bog</Annotation>: and ever shall be. And <Annotation annotationId="020028twelveapostles">snug in their spooncase</Annotation> of <Annotation annotationId="020080mauve">purple plush</Annotation>, faded, the twelve apostles having preached to all the
         gentiles: world without end. 
       </p>
       <p>
@@ -432,24 +432,24 @@ const Nestor = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <span data-edition="ed1986" data-page="24"> </span>
       <p>
-        And now his <Annotation annotationId="020075samewisdom" visited={visitedNotes.has("020075samewisdom")} annotationSelect={() => {openNote("020075samewisdom"); addToVisited("020075samewisdom")}} activeAnnotationId={currentNoteId}>strongroom</Annotation> for the gold. Stephen's embarrassed hand moved
+        And now his <Annotation annotationId="020075samewisdom">strongroom</Annotation> for the gold. Stephen's embarrassed hand moved
         over the shells heaped in the cold stone mortar: whelks and <span data-edition="ed1932" data-page="27"></span>money
         cowries and leopard shells: and this, whorled as an emir's turban, and
-        this, <Annotation annotationId="020030shellmoney" visited={visitedNotes.has("020030shellmoney")} annotationSelect={() => {openNote("020030shellmoney"); addToVisited("020030shellmoney")}} activeAnnotationId={currentNoteId}>the scallop of saint James. An old pilgrim's hoard</Annotation>, dead treasure, hollow shells.
+        this, <Annotation annotationId="020030shellmoney">the scallop of saint James. An old pilgrim's hoard</Annotation>, dead treasure, hollow shells.
       </p>
       <p>
         A sovereign fell, bright and new, on the soft pile of the tablecloth.
       </p>
       <span data-edition="ed1961" data-page="29"></span>
       <p>
-        —{" "}Three, Mr Deasy said, turning his <Annotation annotationId="020029savingsbox" visited={visitedNotes.has("020029savingsbox")} annotationSelect={() => {openNote("020029savingsbox"); addToVisited("020029savingsbox")}} activeAnnotationId={currentNoteId}>little savingsbox</Annotation> about in his hand. These are handy things to have. See. This is for sovereigns. This is for
+        —{" "}Three, Mr Deasy said, turning his <Annotation annotationId="020029savingsbox">little savingsbox</Annotation> about in his hand. These are handy things to have. See. This is for sovereigns. This is for
         shillings. Sixpences, halfcrowns. And here crowns. See.
       </p>
       <p>
         He shot from it two crowns and two shillings.
       </p>
       <p>
-        —{" "}<Annotation annotationId="010019money" visited={visitedNotes.has("010019money")} annotationSelect={() => {openNote("010019money"); addToVisited("010019money")}} activeAnnotationId={currentNoteId}>Three twelve</Annotation>, he said. I think you'll find that's right.
+        —{" "}<Annotation annotationId="010019money">Three twelve</Annotation>, he said. I think you'll find that's right.
       </p>
       <p>
         —{" "}Thank you, sir, Stephen said, gathering the money together with shy
@@ -476,36 +476,36 @@ const Nestor = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         —{" "}Mine would be often empty, Stephen said.
       </p>
       <p>
-        The same room and hour, the <Annotation annotationId="020075samewisdom" visited={visitedNotes.has("020075samewisdom")} annotationSelect={() => {openNote("020075samewisdom"); addToVisited("020075samewisdom")}} activeAnnotationId={currentNoteId}>same wisdom</Annotation>: and I the same. <Annotation annotationId="020025asitwas" visited={visitedNotes.has("020025asitwas")} annotationSelect={() => {openNote("020025asitwas"); addToVisited("020025asitwas")}} activeAnnotationId={currentNoteId}>Three times
+        The same room and hour, the <Annotation annotationId="020075samewisdom">same wisdom</Annotation>: and I the same. <Annotation annotationId="020025asitwas">Three times
         now. Three nooses round me here.</Annotation> Well? I can break them in this instant
         if I will.
       </p>
       <p>
-        —{" "}<Annotation annotationId="160001priestpoverty" visited={visitedNotes.has("160001priestpoverty")} annotationSelect={() => {openNote("160001priestpoverty"); addToVisited("160001priestpoverty")}} activeAnnotationId={currentNoteId}>Because you don't save, Mr Deasy said, pointing his finger. You don't
+        —{" "}<Annotation annotationId="160001priestpoverty">Because you don't save, Mr Deasy said, pointing his finger. You don't
         know yet what money is. Money is power.</Annotation> When you have lived as long as I
-        have. I know, I know. <Annotation annotationId="020033mademoney" visited={visitedNotes.has("020033mademoney")} annotationSelect={() => {openNote("020033mademoney"); addToVisited("020033mademoney")}} activeAnnotationId={currentNoteId}>If youth but knew. But what does Shakespeare say? <i>Put but money in thy purse.</i></Annotation> 
+        have. I know, I know. <Annotation annotationId="020033mademoney">If youth but knew. But what does Shakespeare say? <i>Put but money in thy purse.</i></Annotation> 
       </p>
       <p>
-        <Annotation annotationId="020033mademoney" visited={visitedNotes.has("020033mademoney")} annotationSelect={() => {openNote("020033mademoney"); addToVisited("020033mademoney")}} activeAnnotationId={currentNoteId}>—{" "}Iago, Stephen murmured.</Annotation>
+        <Annotation annotationId="020033mademoney">—{" "}Iago, Stephen murmured.</Annotation>
       </p>
-      <p><Annotation annotationId="020033mademoney" visited={visitedNotes.has("020033mademoney")} annotationSelect={() => {openNote("020033mademoney"); addToVisited("020033mademoney")}} activeAnnotationId={currentNoteId}>
+      <p><Annotation annotationId="020033mademoney">
         He lifted his gaze from the idle shells to the old man's stare.</Annotation>
       </p>
       <p>
-        <Annotation annotationId="020033mademoney" visited={visitedNotes.has("020033mademoney")} annotationSelect={() => {openNote("020033mademoney"); addToVisited("020033mademoney")}} activeAnnotationId={currentNoteId}>—{" "}He knew what money was, Mr Deasy said. He made money. A poet, yes, but
+        <Annotation annotationId="020033mademoney">—{" "}He knew what money was, Mr Deasy said. He made money. A poet, yes, but
         an Englishman too.</Annotation> Do you know what is the pride of the English? Do you
         know what is the proudest word you will ever hear from an Englishman's
         mouth?
       </p>
       <p>
-        <Annotation annotationId="010107seasruler" visited={visitedNotes.has("010107seasruler")} annotationSelect={() => {openNote("010107seasruler"); addToVisited("010107seasruler")}} activeAnnotationId={currentNoteId}>The seas' ruler.</Annotation> His seacold eyes looked on the empty bay: <Annotation annotationId="010141blamehistory" visited={visitedNotes.has("010141blamehistory")} annotationSelect={() => {openNote("010141blamehistory"); addToVisited("010141blamehistory")}} activeAnnotationId={currentNoteId}>history is to blame</Annotation>: on me and on my words, <Annotation annotationId="010038greateyes" visited={visitedNotes.has("010038greateyes")} annotationSelect={() => {openNote("010038greateyes"); addToVisited("010038greateyes")}} activeAnnotationId={currentNoteId}>unhating</Annotation>.
+        <Annotation annotationId="010107seasruler">The seas' ruler.</Annotation> His seacold eyes looked on the empty bay: <Annotation annotationId="010141blamehistory">history is to blame</Annotation>: on me and on my words, <Annotation annotationId="010038greateyes">unhating</Annotation>.
       </p>
       <p>
         —{" "}That on his empire, Stephen said, the sun never sets. 
       </p>
       <span data-edition="ed1922" data-page="30"></span>
       <p>
-        —{" "}Ba! Mr Deasy cried. That's not English. <Annotation annotationId="020034frenchcelt" visited={visitedNotes.has("020034frenchcelt")} annotationSelect={() => {openNote("020034frenchcelt"); addToVisited("020034frenchcelt")}} activeAnnotationId={currentNoteId}>A French Celt said that.</Annotation> He
+        —{" "}Ba! Mr Deasy cried. That's not English. <Annotation annotationId="020034frenchcelt">A French Celt said that.</Annotation> He
         tapped his savingsbox against his thumbnail. 
       </p>
       <p>
@@ -517,13 +517,13 @@ const Nestor = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         Good man, good man.
       </p>
       <p>
-        <i>—{" "}I paid my way. I never borrowed a shilling in my life.</i> <Annotation annotationId="020035owenothing" visited={visitedNotes.has("020035owenothing")} annotationSelect={() => {openNote("020035owenothing"); addToVisited("020035owenothing")}} activeAnnotationId={currentNoteId}>Can you feel
+        <i>—{" "}I paid my way. I never borrowed a shilling in my life.</i> <Annotation annotationId="020035owenothing">Can you feel
         that? <i>I owe nothing.</i> Can you?</Annotation>
       </p>
       <span data-edition="ed1961" data-page="30"></span>
       <p>
-        Mulligan, nine pounds, three pairs of socks, one pair <Annotation annotationId="020076brogues" visited={visitedNotes.has("020076brogues")} annotationSelect={() => {openNote("020076brogues"); addToVisited("020076brogues")}} activeAnnotationId={currentNoteId}>brogues</Annotation>, ties.
-        Curran, ten <Annotation annotationId="010019money" visited={visitedNotes.has("010019money")} annotationSelect={() => {openNote("010019money"); addToVisited("010019money")}} activeAnnotationId={currentNoteId}>guineas</Annotation>. McCann, one guinea. Fred Ryan, two shillings.
+        Mulligan, nine pounds, three pairs of socks, one pair <Annotation annotationId="020076brogues">brogues</Annotation>, ties.
+        Curran, ten <Annotation annotationId="010019money">guineas</Annotation>. McCann, one guinea. Fred Ryan, two shillings.
         <span data-edition="ed1986" data-page="25"> </span>Temple, two lunches. Russell, one guinea, Cousins, ten shillings, Bob
         Reynolds, half a guinea, Koehler, three guineas, Mrs MacKernan, five
         weeks' board. The lump I have is useless.
@@ -539,22 +539,22 @@ const Nestor = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         We are a generous people but we must also be just.
       </p>
       <p>
-        —{" "}<Annotation annotationId="030037griffith" visited={visitedNotes.has("030037griffith")} annotationSelect={() => {openNote("030037griffith"); addToVisited("030037griffith")}} activeAnnotationId={currentNoteId}>I fear those big words, Stephen said, which make us so unhappy</Annotation>.
+        —{" "}<Annotation annotationId="030037griffith">I fear those big words, Stephen said, which make us so unhappy</Annotation>.
       </p>
       <p>
         Mr Deasy stared sternly for some moments over the mantelpiece at the
-        shapely bulk of a man in <Annotation annotationId="020036filibegs" visited={visitedNotes.has("020036filibegs")} annotationSelect={() => {openNote("020036filibegs"); addToVisited("020036filibegs")}} activeAnnotationId={currentNoteId}>tartan filibegs</Annotation>: <Annotation annotationId="020079kingedward" visited={visitedNotes.has("020079kingedward")} annotationSelect={() => {openNote("020079kingedward"); addToVisited("020079kingedward")}} activeAnnotationId={currentNoteId}>Albert Edward, prince of
+        shapely bulk of a man in <Annotation annotationId="020036filibegs">tartan filibegs</Annotation>: <Annotation annotationId="020079kingedward">Albert Edward, prince of
         Wales</Annotation>.
       </p>
       <p>
-        —{" "}You think me an old fogey and an old <Annotation annotationId="020037oldtory" visited={visitedNotes.has("020037oldtory")} annotationSelect={() => {openNote("020037oldtory"); addToVisited("020037oldtory")}} activeAnnotationId={currentNoteId}>tory</Annotation>, his thoughtful voice said. <Annotation annotationId="020075samewisdom" visited={visitedNotes.has("020075samewisdom")} annotationSelect={() => {openNote("020075samewisdom"); addToVisited("020075samewisdom")}} activeAnnotationId={currentNoteId}>I saw three generations</Annotation> since <Annotation annotationId="020038oconnell" visited={visitedNotes.has("020038oconnell")} annotationSelect={() => {openNote("020038oconnell"); addToVisited("020038oconnell")}} activeAnnotationId={currentNoteId}>O'Connell</Annotation>'s time. I remember <Annotation annotationId="020039famine" visited={visitedNotes.has("020039famine")} annotationSelect={() => {openNote("020039famine"); addToVisited("020039famine")}} activeAnnotationId={currentNoteId}>the famine in '46</Annotation>. Do you know that <Annotation annotationId="020040orangelodges" visited={visitedNotes.has("020040orangelodges")} annotationSelect={() => {openNote("020040orangelodges"); addToVisited("020040orangelodges")}} activeAnnotationId={currentNoteId}>the orange lodges</Annotation> agitated for repeal of <Annotation annotationId="020032theunion" visited={visitedNotes.has("020032theunion")} annotationSelect={() => {openNote("020032theunion"); addToVisited("020032theunion")}} activeAnnotationId={currentNoteId}> the
-        union</Annotation> twenty years before O'Connell did or before <Annotation annotationId="020041prelates" visited={visitedNotes.has("020041prelates")} annotationSelect={() => {openNote("020041prelates"); addToVisited("020041prelates")}} activeAnnotationId={currentNoteId}>the prelates of your
-        communion denounced him</Annotation> as a demagogue? You <Annotation annotationId="020073fenians" visited={visitedNotes.has("020073fenians")} annotationSelect={() => {openNote("020073fenians"); addToVisited("020073fenians")}} activeAnnotationId={currentNoteId}>fenians</Annotation> forget some things.
+        —{" "}You think me an old fogey and an old <Annotation annotationId="020037oldtory">tory</Annotation>, his thoughtful voice said. <Annotation annotationId="020075samewisdom">I saw three generations</Annotation> since <Annotation annotationId="020038oconnell">O'Connell</Annotation>'s time. I remember <Annotation annotationId="020039famine">the famine in '46</Annotation>. Do you know that <Annotation annotationId="020040orangelodges">the orange lodges</Annotation> agitated for repeal of <Annotation annotationId="020032theunion"> the
+        union</Annotation> twenty years before O'Connell did or before <Annotation annotationId="020041prelates">the prelates of your
+        communion denounced him</Annotation> as a demagogue? You <Annotation annotationId="020073fenians">fenians</Annotation> forget some things.
       </p>
       <p>
-        <Annotation annotationId="020042immortalmemory" visited={visitedNotes.has("020042immortalmemory")} annotationSelect={() => {openNote("020042immortalmemory"); addToVisited("020042immortalmemory")}} activeAnnotationId={currentNoteId}>Glorious, pious and immortal memory.</Annotation> The <Annotation annotationId="020043corpses" visited={visitedNotes.has("020043corpses")} annotationSelect={() => {openNote("020043corpses"); addToVisited("020043corpses")}} activeAnnotationId={currentNoteId}>lodge of Diamond in Armagh the
+        <Annotation annotationId="020042immortalmemory">Glorious, pious and immortal memory.</Annotation> The <Annotation annotationId="020043corpses">lodge of Diamond in Armagh the
         splendid behung with corpses of papishes</Annotation>. Hoarse, masked and armed, the
-        <Annotation annotationId="020044covenant" visited={visitedNotes.has("020044covenant")} annotationSelect={() => {openNote("020044covenant"); addToVisited("020044covenant")}} activeAnnotationId={currentNoteId}>planters' covenant</Annotation>. The <Annotation annotationId="020045blackandblue" visited={visitedNotes.has("020045blackandblue")} annotationSelect={() => {openNote("020045blackandblue"); addToVisited("020045blackandblue")}} activeAnnotationId={currentNoteId}>black north and true blue</Annotation> bible. <Annotation annotationId="020046croppiesdown" visited={visitedNotes.has("020046croppiesdown")} annotationSelect={() => {openNote("020046croppiesdown"); addToVisited("020046croppiesdown")}} activeAnnotationId={currentNoteId}>Croppies lie
+        <Annotation annotationId="020044covenant">planters' covenant</Annotation>. The <Annotation annotationId="020045blackandblue">black north and true blue</Annotation> bible. <Annotation annotationId="020046croppiesdown">Croppies lie
         down.</Annotation>
       </p>
       <p>
@@ -562,22 +562,22 @@ const Nestor = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <p>
         —{" "}I have rebel blood in me too, Mr Deasy said. On the spindle side. But
-        I am descended from <Annotation annotationId="020047johnblackwood" visited={visitedNotes.has("020047johnblackwood")} annotationSelect={() => {openNote("020047johnblackwood"); addToVisited("020047johnblackwood")}} activeAnnotationId={currentNoteId}>sir John Blackwood who voted for the union</Annotation>. We are
-        all Irish, <Annotation annotationId="020078kingssons" visited={visitedNotes.has("020078kingssons")} annotationSelect={() => {openNote("020078kingssons"); addToVisited("020078kingssons")}} activeAnnotationId={currentNoteId}>all kings' sons</Annotation>.
+        I am descended from <Annotation annotationId="020047johnblackwood">sir John Blackwood who voted for the union</Annotation>. We are
+        all Irish, <Annotation annotationId="020078kingssons">all kings' sons</Annotation>.
       </p>
       <p>
         —{" "}Alas, Stephen said.
       </p>
       <p>
-        —{" "}<Annotation annotationId="020047johnblackwood" visited={visitedNotes.has("020047johnblackwood")} annotationSelect={() => {openNote("020047johnblackwood"); addToVisited("020047johnblackwood")}} activeAnnotationId={currentNoteId}><i>Per vias rectas</i>, Mr Deasy said firmly, was his motto. He voted for it and put on his topboots to ride to Dublin from the Ards of Down to do so.</Annotation>
+        —{" "}<Annotation annotationId="020047johnblackwood"><i>Per vias rectas</i>, Mr Deasy said firmly, was his motto. He voted for it and put on his topboots to ride to Dublin from the Ards of Down to do so.</Annotation>
       </p>
       <span data-edition="ed1939" data-page="25"> </span>
       <p><i>Lal the ral the ra <br/>
-        <Annotation annotationId="020048rockyroad" visited={visitedNotes.has("020048rockyroad")} annotationSelect={() => {openNote("020048rockyroad"); addToVisited("020048rockyroad")}} activeAnnotationId={currentNoteId}>The rocky road to Dublin.</Annotation></i>
+        <Annotation annotationId="020048rockyroad">The rocky road to Dublin.</Annotation></i>
       </p>
       <span data-edition="ed1922" data-page="31"></span>
       <p>
-        A gruff squire on horseback with shiny topboots. <Annotation annotationId="020049softday" visited={visitedNotes.has("020049softday")} annotationSelect={() => {openNote("020049softday"); addToVisited("020049softday")}} activeAnnotationId={currentNoteId}>Soft day</Annotation>, sir John!
+        A gruff squire on horseback with shiny topboots. <Annotation annotationId="020049softday">Soft day</Annotation>, sir John!
         Soft day, your honour!... Day!... Day!... Two topboots jog dangling
         on to Dublin. Lal the ral the ra. Lal the ral the raddy.
       </p>
@@ -601,8 +601,8 @@ const Nestor = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         sometimes blowing as he screwed up the drum to erase an error.
       </p>
       <p>
-        <Annotation annotationId="020050vanishedhorses" visited={visitedNotes.has("020050vanishedhorses")} annotationSelect={() => {openNote("020050vanishedhorses"); addToVisited("020050vanishedhorses")}} activeAnnotationId={currentNoteId}>Stephen seated himself noiselessly before the princely presence. Framed
-        around the walls images of vanished horses stood in homage, their</Annotation> <span data-edition="ed1986" data-page="26"> </span><Annotation annotationId="020050vanishedhorses" visited={visitedNotes.has("020050vanishedhorses")} annotationSelect={() => {openNote("020050vanishedhorses"); addToVisited("020050vanishedhorses")}} activeAnnotationId={currentNoteId}>meek
+        <Annotation annotationId="020050vanishedhorses">Stephen seated himself noiselessly before the princely presence. Framed
+        around the walls images of vanished horses stood in homage, their</Annotation> <span data-edition="ed1986" data-page="26"> </span><Annotation annotationId="020050vanishedhorses">meek
         heads poised in air: lord Hastings' Repulse, the duke of Westminster's
         Shotover, the duke of Beaufort's Ceylon, <i>prix de Paris</i>, 1866. Elfin
         riders sat them,  watchful of a sign. He saw their speeds, backing king's
@@ -614,7 +614,7 @@ const Nestor = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         allimportant question...
       </p>
       <p>
-        <Annotation annotationId="020051evenmoney" visited={visitedNotes.has("020051evenmoney")} annotationSelect={() => {openNote("020051evenmoney"); addToVisited("020051evenmoney")}} activeAnnotationId={currentNoteId}>Where Cranly led me to get rich quick, hunting his winners among the
+        <Annotation annotationId="020051evenmoney">Where Cranly led me to get rich quick, hunting his winners among the
         mudsplashed brakes, amid bawls of bookies on their pitches and reek
         of the canteen, over the motley slush. Even
         money Fair Rebel: ten to one the field. Dicers and thimbleriggers
@@ -629,7 +629,7 @@ const Nestor = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         Again: a goal. I am among them, among their battling bodies in a medley,
         the joust of life. You mean that knockkneed mother's darling who seems
         to be slightly crawsick? Jousts. Time shocked rebounds, shock by shock.
-        <Annotation annotationId="020052battlingbodies" visited={visitedNotes.has("020052battlingbodies")} annotationSelect={() => {openNote("020052battlingbodies"); addToVisited("020052battlingbodies")}} activeAnnotationId={currentNoteId}> Jousts, slush and uproar of battles, the frozen deathspew of the slain,
+        <Annotation annotationId="020052battlingbodies"> Jousts, slush and uproar of battles, the frozen deathspew of the slain,
         a shout of spearspikes baited with men's bloodied guts.</Annotation>
       </p>
       <p>
@@ -639,39 +639,39 @@ const Nestor = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         He came to the table, pinning together his sheets. Stephen stood up.
       </p>
       <p>
-        —{" "}I have put the matter into <Annotation annotationId="020056nutshell" visited={visitedNotes.has("020056nutshell")} annotationSelect={() => {openNote("020056nutshell"); addToVisited("020056nutshell")}} activeAnnotationId={currentNoteId}>a nutshell</Annotation>, Mr Deasy said. It's about
-        the <Annotation annotationId="020054footandmouth" visited={visitedNotes.has("020054footandmouth")} annotationSelect={() => {openNote("020054footandmouth"); addToVisited("020054footandmouth")}} activeAnnotationId={currentNoteId}>foot and mouth disease</Annotation>. Just look through it. There can be no two
+        —{" "}I have put the matter into <Annotation annotationId="020056nutshell">a nutshell</Annotation>, Mr Deasy said. It's about
+        the <Annotation annotationId="020054footandmouth">foot and mouth disease</Annotation>. Just look through it. There can be no two
         opinions on the matter.
       </p>
       <span data-edition="ed1922" data-page="32"></span>
       <span data-edition="ed1961" data-page="32"></span>
       <p>
-        May I trespass on your valuable space. <Annotation annotationId="020057ourhistory" visited={visitedNotes.has("020057ourhistory")} annotationSelect={() => {openNote("020057ourhistory"); addToVisited("020057ourhistory")}} activeAnnotationId={currentNoteId}>That doctrine of <i>laissez faire</i>
+        May I trespass on your valuable space. <Annotation annotationId="020057ourhistory">That doctrine of <i>laissez faire</i>
         which so often in our history. Our cattle trade. The way of all our old
         industries. Liverpool ring which jockeyed the Galway harbour scheme.
         European conflagration. Grain supplies through the narrow waters of
-        </Annotation><span data-edition="ed1932" data-page="30"></span><Annotation annotationId="020057ourhistory" visited={visitedNotes.has("020057ourhistory")} annotationSelect={() => {openNote("020057ourhistory"); addToVisited("020057ourhistory")}} activeAnnotationId={currentNoteId}>the channel. The pluterperfect imperturbability of the department of
-        agriculture.</Annotation> Pardoned a classical allusion. <Annotation annotationId="020058cassandra" visited={visitedNotes.has("020058cassandra")} annotationSelect={() => {openNote("020058cassandra"); addToVisited("020058cassandra")}} activeAnnotationId={currentNoteId}>Cassandra. By a woman who
+        </Annotation><span data-edition="ed1932" data-page="30"></span><Annotation annotationId="020057ourhistory">the channel. The pluterperfect imperturbability of the department of
+        agriculture.</Annotation> Pardoned a classical allusion. <Annotation annotationId="020058cassandra">Cassandra. By a woman who
         was no better than she should be.</Annotation> To come to the point at issue.
       </p>
       <p>
-        —{" "}<Annotation annotationId="020056nutshell" visited={visitedNotes.has("020056nutshell")} annotationSelect={() => {openNote("020056nutshell"); addToVisited("020056nutshell")}} activeAnnotationId={currentNoteId}>I don't mince words, do I?</Annotation> Mr Deasy asked as Stephen read on.
+        —{" "}<Annotation annotationId="020056nutshell">I don't mince words, do I?</Annotation> Mr Deasy asked as Stephen read on.
       </p>
       <span data-edition="ed1939" data-page="26"> </span>
       <p>
-        <Annotation annotationId="020055serumandvirus" visited={visitedNotes.has("020055serumandvirus")} annotationSelect={() => {openNote("020055serumandvirus"); addToVisited("020055serumandvirus")}} activeAnnotationId={currentNoteId}>Foot and mouth disease. Known as Koch's preparation. Serum and virus.
+        <Annotation annotationId="020055serumandvirus">Foot and mouth disease. Known as Koch's preparation. Serum and virus.
         Percentage of salted horses. Rinderpest. Emperor's horses at Murzsteg,
-        lower Austria. Veterinary surgeons.</Annotation> <Annotation annotationId="020074blackwoodprice" visited={visitedNotes.has("020074blackwoodprice")} annotationSelect={() => {openNote("020074blackwoodprice"); addToVisited("020074blackwoodprice")}} activeAnnotationId={currentNoteId}>Mr Henry Blackwood Price.</Annotation> Courteous
+        lower Austria. Veterinary surgeons.</Annotation> <Annotation annotationId="020074blackwoodprice">Mr Henry Blackwood Price.</Annotation> Courteous
         offer a fair trial. Dictates of common sense. Allimportant question. In
         every sense of the word take the bull by the horns. Thanking you for the
         hospitality of your columns.
       </p>
       <p>
         —{" "}I want that to be printed and read, Mr Deasy said. You will see at the
-        next outbreak they will put an <Annotation annotationId="020054footandmouth" visited={visitedNotes.has("020054footandmouth")} annotationSelect={() => {openNote("020054footandmouth"); addToVisited("020054footandmouth")}} activeAnnotationId={currentNoteId}>embargo on Irish cattle</Annotation>. And it can
-        be cured. It is cured. My cousin, Blackwood Price, writes to me it is <Annotation annotationId="020055serumandvirus" visited={visitedNotes.has("020055serumandvirus")} annotationSelect={() => {openNote("020055serumandvirus"); addToVisited("020055serumandvirus")}} activeAnnotationId={currentNoteId}>regularly treated and cured in Austria by cattledoctors</Annotation> there. They
+        next outbreak they will put an <Annotation annotationId="020054footandmouth">embargo on Irish cattle</Annotation>. And it can
+        be cured. It is cured. My cousin, Blackwood Price, writes to me it is <Annotation annotationId="020055serumandvirus">regularly treated and cured in Austria by cattledoctors</Annotation> there. They
         offer to come over here. I am trying to work up influence with
-        <Annotation annotationId="020057ourhistory" visited={visitedNotes.has("020057ourhistory")} annotationSelect={() => {openNote("020057ourhistory"); addToVisited("020057ourhistory")}} activeAnnotationId={currentNoteId}>the department.</Annotation> Now I'm going to try publicity. I am surrounded by
+        <Annotation annotationId="020057ourhistory">the department.</Annotation> Now I'm going to try publicity. I am surrounded by
         difficulties, by... intrigues by... backstairs influence by...
       </p>
       <span data-edition="ed1986" data-page="27"> </span>
@@ -679,11 +679,11 @@ const Nestor = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         He raised his forefinger and beat the air oldly before his voice spoke.
       </p>
       <p>
-        —{" "}Mark my words, Mr Dedalus, he said. <Annotation annotationId="010122germanjews" visited={visitedNotes.has("010122germanjews")} annotationSelect={() => {openNote("010122germanjews"); addToVisited("010122germanjews")}} activeAnnotationId={currentNoteId}>England is in the hands of the
+        —{" "}Mark my words, Mr Dedalus, he said. <Annotation annotationId="010122germanjews">England is in the hands of the
         jews. In all the highest places: her finance, her press.</Annotation> And they are
         the signs of a nation's decay. Wherever they gather they eat up the
         nation's vital strength. I have seen it coming these years. As sure
-        as we are standing here the <Annotation annotationId="020060jewmerchants" visited={visitedNotes.has("020060jewmerchants")} annotationSelect={() => {openNote("020060jewmerchants"); addToVisited("020060jewmerchants")}} activeAnnotationId={currentNoteId}>jew merchants</Annotation> are already at their work of
+        as we are standing here the <Annotation annotationId="020060jewmerchants">jew merchants</Annotation> are already at their work of
         destruction. Old England is dying.
       </p>
       <p>
@@ -693,7 +693,7 @@ const Nestor = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       <p>
         —{" "}Dying, he said, if not dead by now.
       </p>
-      <p><Annotation annotationId="020059oldengland" visited={visitedNotes.has("020059oldengland")} annotationSelect={() => {openNote("020059oldengland"); addToVisited("020059oldengland")}} activeAnnotationId={currentNoteId}><i>The harlot's cry from street to street <br/>
+      <p><Annotation annotationId="020059oldengland"><i>The harlot's cry from street to street <br/>
         Shall weave old England's windingsheet.</i></Annotation>
       </p>
       <p>
@@ -707,11 +707,11 @@ const Nestor = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         gentile, is he not?
       </p>
       <p>
-        —{" "}<Annotation annotationId="020060jewmerchants" visited={visitedNotes.has("020060jewmerchants")} annotationSelect={() => {openNote("020060jewmerchants"); addToVisited("020060jewmerchants")}} activeAnnotationId={currentNoteId}>They sinned against the light</Annotation>, Mr Deasy said gravely. And you can see
-        <Annotation annotationId="020023darkness" visited={visitedNotes.has("020023darkness")} annotationSelect={() => {openNote("020023darkness"); addToVisited("020023darkness")}} activeAnnotationId={currentNoteId}>the darkness in their eyes</Annotation>. And that is why they are <Annotation annotationId="020061wanderers" visited={visitedNotes.has("020061wanderers")} annotationSelect={() => {openNote("020061wanderers"); addToVisited("020061wanderers")}} activeAnnotationId={currentNoteId}>wanderers on the earth to this day.</Annotation>
+        —{" "}<Annotation annotationId="020060jewmerchants">They sinned against the light</Annotation>, Mr Deasy said gravely. And you can see
+        <Annotation annotationId="020023darkness">the darkness in their eyes</Annotation>. And that is why they are <Annotation annotationId="020061wanderers">wanderers on the earth to this day.</Annotation>
       </p>
       <p>
-        <Annotation annotationId="020062stockexchange" visited={visitedNotes.has("020062stockexchange")} annotationSelect={() => {openNote("020062stockexchange"); addToVisited("020062stockexchange")}} activeAnnotationId={currentNoteId}>On the steps of the Paris stock exchange</Annotation> the goldskinned men quoting
+        <Annotation annotationId="020062stockexchange">On the steps of the Paris stock exchange</Annotation> the goldskinned men quoting
         prices on their gemmed fingers. Gabble of geese. They swarmed loud,
         uncouth about the temple, their heads thickplotting under maladroit silk
         <span data-edition="ed1932" data-page="31"></span>hats. Not theirs: these clothes, this speech, these gestures. Their full
@@ -732,14 +732,14 @@ const Nestor = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         sideways open uncertainly. Is this old wisdom? He waits to hear from me.
       </p>
       <p>
-        —{" "}History, Stephen said, is <Annotation annotationId="020063niare" visited={visitedNotes.has("020063niare")} annotationSelect={() => {openNote("020063niare"); addToVisited("020063niare")}} activeAnnotationId={currentNoteId}>a niare from which I am trying to awake.</Annotation>
+        —{" "}History, Stephen said, is <Annotation annotationId="020063niare">a niare from which I am trying to awake.</Annotation>
       </p>
       <p>
         From the playfield the boys raised a shout. A whirring whistle: goal.
         What if that niare gave you a back kick?
       </p>
       <p>
-        —{" "}The ways of the Creator are not our ways, Mr Deasy said. <Annotation annotationId="020067onegreatgoal" visited={visitedNotes.has("020067onegreatgoal")} annotationSelect={() => {openNote("020067onegreatgoal"); addToVisited("020067onegreatgoal")}} activeAnnotationId={currentNoteId}>All human
+        —{" "}The ways of the Creator are not our ways, Mr Deasy said. <Annotation annotationId="020067onegreatgoal">All human
         history moves towards one great goal, the manifestation of God.</Annotation>
       </p>
       <p>
@@ -756,7 +756,7 @@ const Nestor = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         —{" "}What? Mr Deasy asked.
       </p>
       <p>
-        —{" "}<Annotation annotationId="020069streetshout" visited={visitedNotes.has("020069streetshout")} annotationSelect={() => {openNote("020069streetshout"); addToVisited("020069streetshout")}} activeAnnotationId={currentNoteId}>A shout in the street</Annotation>, Stephen answered, shrugging his shoulders.
+        —{" "}<Annotation annotationId="020069streetshout">A shout in the street</Annotation>, Stephen answered, shrugging his shoulders.
       </p>
       <p>
         Mr Deasy looked down and held for awhile the wings of his nose tweaked
@@ -765,17 +765,17 @@ const Nestor = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       <span data-edition="ed1986" data-page="28"> </span>
       <p>
         —{" "}I am happier than you are, he said. We have committed many errors and
-        many sins. <Annotation annotationId="020070womansin" visited={visitedNotes.has("020070womansin")} annotationSelect={() => {openNote("020070womansin"); addToVisited("020070womansin")}} activeAnnotationId={currentNoteId}>A woman brought sin into the world. For a woman who was no
+        many sins. <Annotation annotationId="020070womansin">A woman brought sin into the world. For a woman who was no
         better than she should be, Helen, the runaway wife of Menelaus, ten
         years the Greeks made war on Troy. A faithless wife first brought the
-        strangers</Annotation> <span data-edition="ed1961" data-page="34"></span><Annotation annotationId="020070womansin" visited={visitedNotes.has("020070womansin")} annotationSelect={() => {openNote("020070womansin"); addToVisited("020070womansin")}} activeAnnotationId={currentNoteId}>to our shore here, MacMurrough's wife and her leman, O'Rourke,
+        strangers</Annotation> <span data-edition="ed1961" data-page="34"></span><Annotation annotationId="020070womansin">to our shore here, MacMurrough's wife and her leman, O'Rourke,
         prince of Breffni. A woman too brought Parnell low.</Annotation> Many errors, many
         failures but 
         <span data-edition="ed1922" data-page="34"></span>
         not the one sin. I am a struggler now at the end of my
         days. But I will fight for the right till the end.
       </p>
-      <p><Annotation annotationId="020071ulsterfight" visited={visitedNotes.has("020071ulsterfight")} annotationSelect={() => {openNote("020071ulsterfight"); addToVisited("020071ulsterfight")}} activeAnnotationId={currentNoteId}><i>For Ulster will fight <br/>
+      <p><Annotation annotationId="020071ulsterfight"><i>For Ulster will fight <br/>
         And Ulster will be right.</i></Annotation>
       </p>
       <p>
@@ -814,7 +814,7 @@ const Nestor = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         published at once.
       </p>
       <p>
-        <i>Telegraph. <Annotation annotationId="020077homestead" visited={visitedNotes.has("020077homestead")} annotationSelect={() => {openNote("020077homestead"); addToVisited("020077homestead")}} activeAnnotationId={currentNoteId}>Irish Homestead.</Annotation></i>
+        <i>Telegraph. <Annotation annotationId="020077homestead">Irish Homestead.</Annotation></i>
       </p>
       <p>
         —{" "}I will try, Stephen said, and let you know tomorrow. I know two
@@ -822,12 +822,12 @@ const Nestor = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <p>
         —{" "}That will do, Mr Deasy said briskly. I wrote last night to Mr Field,
-        M.P. There is a meeting of the cattletraders' association today at <Annotation annotationId="020066cityarms" visited={visitedNotes.has("020066cityarms")} annotationSelect={() => {openNote("020066cityarms"); addToVisited("020066cityarms")}} activeAnnotationId={currentNoteId}>the
+        M.P. There is a meeting of the cattletraders' association today at <Annotation annotationId="020066cityarms">the
         City Arms hotel.</Annotation> I asked him to lay my letter before the meeting. You
         see if you can get it into your two papers. What are they?
       </p>
       <p>
-        —{" "} <Annotation annotationId="020064telegraph" visited={visitedNotes.has("020064telegraph")} annotationSelect={() => {openNote("020064telegraph"); addToVisited("020064telegraph")}} activeAnnotationId={currentNoteId}><i>The Evening Telegraph</i></Annotation>...
+        —{" "} <Annotation annotationId="020064telegraph"><i>The Evening Telegraph</i></Annotation>...
       </p>
       <p>
         —{" "}That will do, Mr Deasy said. There is no time to lose. Now I have to
@@ -845,13 +845,13 @@ const Nestor = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         —{" "}Good morning, sir, Stephen said again, bowing to his bent back.
       </p>
       <p>
-        He went out by the open porch and <Annotation annotationId="020072gravelpath" visited={visitedNotes.has("020072gravelpath")} annotationSelect={() => {openNote("020072gravelpath"); addToVisited("020072gravelpath")}} activeAnnotationId={currentNoteId}>down the gravel path under the trees,
+        He went out by the open porch and <Annotation annotationId="020072gravelpath">down the gravel path under the trees,
         hearing the cries of voices and crack of sticks from the playfield.
         The lions couchant on the pillars</Annotation> as he <span data-edition="ed1961" data-page="35"></span>passed out through the gate:
         toothless
         <span data-edition="ed1922" data-page="35"></span>
         terrors. Still I will help him in his fight. Mulligan will dub
-        me a new name: <Annotation annotationId="020065bullockbefriending" visited={visitedNotes.has("020065bullockbefriending")} annotationSelect={() => {openNote("020065bullockbefriending"); addToVisited("020065bullockbefriending")}} activeAnnotationId={currentNoteId}>the bullockbefriending bard</Annotation>.
+        me a new name: <Annotation annotationId="020065bullockbefriending">the bullockbefriending bard</Annotation>.
       </p>
       <span data-edition="ed1986" data-page="29"> </span>
       <p>
@@ -872,7 +872,7 @@ const Nestor = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <p>
         —{" "}I just wanted to say, he said. Ireland, they say, has the honour of
-        being <Annotation annotationId="020068letthemin" visited={visitedNotes.has("020068letthemin")} annotationSelect={() => {openNote("020068letthemin"); addToVisited("020068letthemin")}} activeAnnotationId={currentNoteId}>the only country which never persecuted the jews.</Annotation> Do you know
+        being <Annotation annotationId="020068letthemin">the only country which never persecuted the jews.</Annotation> Do you know
         that? No. And do you know why?
       </p>
       <p>
@@ -882,7 +882,7 @@ const Nestor = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         —{" "}Why, sir? Stephen asked, beginning to smile.
       </p>
       <p>
-        —{" "}Because <Annotation annotationId="020068letthemin" visited={visitedNotes.has("020068letthemin")} annotationSelect={() => {openNote("020068letthemin"); addToVisited("020068letthemin")}} activeAnnotationId={currentNoteId}>she never let them in</Annotation>, Mr Deasy said solemnly.<span data-edition="ed1932" data-page="33"></span>
+        —{" "}Because <Annotation annotationId="020068letthemin">she never let them in</Annotation>, Mr Deasy said solemnly.<span data-edition="ed1932" data-page="33"></span>
       </p>
       <p>A coughball of laughter leaped from his throat dragging after it a
         rattling chain of phlegm. He turned back quickly, coughing, laughing,

--- a/src/content/chapters/OxenOfTheSun.js
+++ b/src/content/chapters/OxenOfTheSun.js
@@ -1,24 +1,24 @@
 import Annotation from "../../components/Annotation";
 
 
-const OxenOfTheSun = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
+const OxenOfTheSun = () => {
   return (
     <div>
       <p></p>
       <center><font size="+2">[14]</font></center>
       <br/>
-      <Annotation annotationId="140032deshileamus" visited={visitedNotes.has("140032deshileamus")} annotationSelect={() => {openNote("140032deshileamus"); addToVisited("140032deshileamus")}} activeAnnotationId={currentNoteId}>Deshil Holles Eamus.</Annotation> Deshil <Annotation annotationId="140035holles" visited={visitedNotes.has("140035holles")} annotationSelect={() => {openNote("140035holles"); addToVisited("140035holles")}} activeAnnotationId={currentNoteId}>Holles</Annotation> Eamus. Deshil Holles Eamus.
+      <Annotation annotationId="140032deshileamus">Deshil Holles Eamus.</Annotation> Deshil <Annotation annotationId="140035holles">Holles</Annotation> Eamus. Deshil Holles Eamus.
       <p></p>
       <p>
-        Send us <Annotation annotationId="140037brightone" visited={visitedNotes.has("140037brightone")} annotationSelect={() => {openNote("140037brightone"); addToVisited("140037brightone")}} activeAnnotationId={currentNoteId}>bright one, light one, Horhorn</Annotation>, quickening and wombfruit. Send
+        Send us <Annotation annotationId="140037brightone">bright one, light one, Horhorn</Annotation>, quickening and wombfruit. Send
         us bright one, light one, Horhorn, quickening and wombfruit. Send us
         bright one, light one, Horhorn, quickening and wombfruit.
       </p>
       <p>
-        <Annotation annotationId="140036hoopsaboyaboy" visited={visitedNotes.has("140036hoopsaboyaboy")} annotationSelect={() => {openNote("140036hoopsaboyaboy"); addToVisited("140036hoopsaboyaboy")}} activeAnnotationId={currentNoteId}>Hoopsa boyaboy hoopsa!</Annotation> Hoopsa boyaboy hoopsa! Hoopsa boyaboy hoopsa!
+        <Annotation annotationId="140036hoopsaboyaboy">Hoopsa boyaboy hoopsa!</Annotation> Hoopsa boyaboy hoopsa! Hoopsa boyaboy hoopsa!
       </p>
       <p>
-        <Annotation annotationId="140033universally" visited={visitedNotes.has("140033universally")} annotationSelect={() => {openNote("140033universally"); addToVisited("140033universally")}} activeAnnotationId={currentNoteId}>Universally that person's acumen is esteemed very little perceptive</Annotation>
+        <Annotation annotationId="140033universally">Universally that person's acumen is esteemed very little perceptive</Annotation>
         concerning whatsoever matters are being held as most profitably by
         mortals with sapience endowed to be studied who is ignorant of that
         which the most in doctrine erudite and certainly by reason of that in
@@ -33,7 +33,7 @@ const OxenOfTheSun = ({openNote, currentNoteId, visitedNotes, addToVisited}) => 
         apprehended but is conscious that that exterior splendour may be the
         surface of a downwardtending lutulent reality or on the contrary anyone
         so is there inilluminated as not to perceive that as no nature's boon
-        can contend against <Annotation annotationId="080028multiply" visited={visitedNotes.has("080028multiply")} annotationSelect={() => {openNote("080028multiply"); addToVisited("080028multiply")}} activeAnnotationId={currentNoteId}> the bounty of increase</Annotation> so it behoves every most just
+        can contend against <Annotation annotationId="080028multiply"> the bounty of increase</Annotation> so it behoves every most just
         citizen to become the exhortator and admonisher of his semblables and
         to tremble lest what had in the past been by the nation excellently
         commenced might be in the future not with similar excellence
@@ -48,7 +48,7 @@ const OxenOfTheSun = ({openNote, currentNoteId, visitedNotes, addToVisited}) => 
         function ever irrevocably enjoined?
       </p>
       <p>
-        <Annotation annotationId="140031historians" visited={visitedNotes.has("140031historians")} annotationSelect={() => {openNote("140031historians"); addToVisited("140031historians")}} activeAnnotationId={currentNoteId}>It is not why therefore we shall wonder if, as the best historians
+        <Annotation annotationId="140031historians">It is not why therefore we shall wonder if, as the best historians
         relate,</Annotation> among the Celts, who nothing that was not in its nature
         admirable admired, the art of medicine shall have <span data-edition="ed1961" data-page="383"> </span>been highly honoured.
         Not to speak of <span data-edition="ed1986" data-page="314"> </span>hostels, leperyards, sweating chambers, plaguegraves,
@@ -83,7 +83,7 @@ const OxenOfTheSun = ({openNote, currentNoteId, visitedNotes, addToVisited}) => 
         to be about to be cherished had been begun she felt!
       </p>
       <p>
-        <Annotation annotationId="140040beforeborn" visited={visitedNotes.has("140040beforeborn")} annotationSelect={() => {openNote("140040beforeborn"); addToVisited("140040beforeborn")}} activeAnnotationId={currentNoteId}>Before born bliss babe had. Within womb won he worship.</Annotation> Whatever in that
+        <Annotation annotationId="140040beforeborn">Before born bliss babe had. Within womb won he worship.</Annotation> Whatever in that
         one case done commodiously done was. A couch by midwives attended with
         wholesome food reposeful, cleanest swaddles as though forthbringing were
         now done and by wise foresight set: but to this no less of what drugs
@@ -98,15 +98,15 @@ const OxenOfTheSun = ({openNote, currentNoteId, visitedNotes, addToVisited}) => 
         thereto to lie in, her term up.
       </p>
       <p>
-        Some man that wayfaring was stood by housedoor at night's oncoming. <Annotation annotationId="020061wanderers" visited={visitedNotes.has("020061wanderers")} annotationSelect={() => {openNote("020061wanderers"); addToVisited("020061wanderers")}} activeAnnotationId={currentNoteId}>Of
+        Some man that wayfaring was stood by housedoor at night's oncoming. <Annotation annotationId="020061wanderers">Of
         Israel's folk was that man that on earth wandering far had fared.</Annotation> Stark
         ruth of man his errand that him lone led till that house.
       </p>
       <p>
-        Of that house <Annotation annotationId="140038drhorne" visited={visitedNotes.has("140038drhorne")} annotationSelect={() => {openNote("140038drhorne"); addToVisited("140038drhorne")}} activeAnnotationId={currentNoteId}>A. Horne</Annotation> is lord. <Annotation annotationId="140035holles" visited={visitedNotes.has("140035holles")} annotationSelect={() => {openNote("140035holles"); addToVisited("140035holles")}} activeAnnotationId={currentNoteId}>Seventy beds</Annotation> keeps he there teeming
+        Of that house <Annotation annotationId="140038drhorne">A. Horne</Annotation> is lord. <Annotation annotationId="140035holles">Seventy beds</Annotation> keeps he there teeming
         mothers are wont that they lie for to thole and bring forth bairns hale
         so God's angel to Mary quoth. Watchers twey there walk, white sisters
-        in ward sleepless. Smarts they still, sickness soothing: <Annotation annotationId="140035holles" visited={visitedNotes.has("140035holles")} annotationSelect={() => {openNote("140035holles"); addToVisited("140035holles")}} activeAnnotationId={currentNoteId}>in twelve moons
+        in ward sleepless. Smarts they still, sickness soothing: <Annotation annotationId="140035holles">in twelve moons
         thrice an hundred</Annotation>. Truest bedthanes they twain are, for Horne holding
         wariest ward.
       </p>
@@ -147,7 +147,7 @@ const OxenOfTheSun = ({openNote, currentNoteId, visitedNotes, addToVisited}) => 
         wanhope sorrowing one with other.
       </p>
       <p>
-        <Annotation annotationId="140030everyman" visited={visitedNotes.has("140030everyman")} annotationSelect={() => {openNote("140030everyman"); addToVisited("140030everyman")}} activeAnnotationId={currentNoteId}>Therefore, everyman, look to that last end that is thy death</Annotation> and the dust 
+        <Annotation annotationId="140030everyman">Therefore, everyman, look to that last end that is thy death</Annotation> and the dust 
         <span data-edition="ed1922" data-page="368"> </span>
         that gripeth on every man that is born of woman for as he came
         naked forth from his mother's womb so naked shall he wend him at the
@@ -168,13 +168,13 @@ const OxenOfTheSun = ({openNote, currentNoteId, visitedNotes, addToVisited}) => 
         twelve bloodflows chiding her childless.
       </p>
       <p>
-        <Annotation annotationId="140029thecastle" visited={visitedNotes.has("140029thecastle")} annotationSelect={() => {openNote("140029thecastle"); addToVisited("140029thecastle")}} activeAnnotationId={currentNoteId}>And whiles they spake the door of the castle was opened</Annotation> and there nighed
+        <Annotation annotationId="140029thecastle">And whiles they spake the door of the castle was opened</Annotation> and there nighed
         them a mickle noise as of many that sat there at meat. And there <span data-edition="ed1986" data-page="316"> </span>came
         against the place as they stood a young learningknight yclept Dixon. And
         the traveller Leopold was couth to him sithen it had happed that they
-        had had ado each with other in <Annotation annotationId="010068themater" visited={visitedNotes.has("010068themater")} annotationSelect={() => {openNote("010068themater"); addToVisited("010068themater")}} activeAnnotationId={currentNoteId}>the house of misericord</Annotation> where this
+        had had ado each with other in <Annotation annotationId="010068themater">the house of misericord</Annotation> where this
         learningknight lay by cause the traveller Leopold came there to be
-        <span data-edition="ed1932" data-page="349"> </span>healed for <Annotation annotationId="040040bluebottle" visited={visitedNotes.has("040040bluebottle")} annotationSelect={() => {openNote("040040bluebottle"); addToVisited("040040bluebottle")}} activeAnnotationId={currentNoteId}>he was sore wounded in his breast by a spear wherewith a
+        <span data-edition="ed1932" data-page="349"> </span>healed for <Annotation annotationId="040040bluebottle">he was sore wounded in his breast by a spear wherewith a
         horrible and dreadful dragon was smitten him</Annotation> for which he did do make
         a salve of volatile salt and chrism as much as he might suffice. And he
         said now that he should go into that castle for to make merry with
@@ -202,13 +202,13 @@ const OxenOfTheSun = ({openNote, currentNoteId, visitedNotes, addToVisited}) => 
         his breath that he
         blares into them like to bubbles. And full fair cheer and rich was on
         the board that no wight could devise a fuller ne richer. And there was
-        a vat of silver that was moved by craft to open in the which lay <Annotation annotationId="180008sardines" visited={visitedNotes.has("180008sardines")} annotationSelect={() => {openNote("180008sardines"); addToVisited("180008sardines")}} activeAnnotationId={currentNoteId}>strange
+        a vat of silver that was moved by craft to open in the which lay <Annotation annotationId="180008sardines">strange
         fishes withouten heads</Annotation> though misbelieving men nie that this be possible
         thing without they see it natheless they are so. And these fishes lie
         in an oily water brought there from Portugal land because of the fatness
         that therein is like to the juices of the olivepress. And also it was
         a marvel to see in that castle how by magic they make a compost out of
-        fecund <Annotation annotationId="030019kidneysofwheat" visited={visitedNotes.has("030019kidneysofwheat")} annotationSelect={() => {openNote("030019kidneysofwheat"); addToVisited("030019kidneysofwheat")}} activeAnnotationId={currentNoteId}>wheatkidneys</Annotation> out of Chaldee that by aid of certain angry spirits
+        fecund <Annotation annotationId="030019kidneysofwheat">wheatkidneys</Annotation> out of Chaldee that by aid of certain angry spirits
         that they do into it swells up wondrously like to a vast mountain. And
         they teach the serpents there to entwine themselves up on long sticks
         out of the ground and of the scales of these serpents they brew out a
@@ -225,7 +225,7 @@ const OxenOfTheSun = ({openNote, currentNoteId, visitedNotes, addToVisited}) => 
       </p>
       <span data-edition="ed1932" data-page="350"> </span>
       <p>
-        <Annotation annotationId="140028goodsister" visited={visitedNotes.has("140028goodsister")} annotationSelect={() => {openNote("140028goodsister"); addToVisited("140028goodsister")}} activeAnnotationId={currentNoteId}>This meanwhile this good sister stood by the door</Annotation> and begged them at the
+        <Annotation annotationId="140028goodsister">This meanwhile this good sister stood by the door</Annotation> and begged them at the
         reverence of Jesu our alther liege Lord to leave their wassailing for
         there was above one quick with child, a gentle dame, whose time hied
         fast. Sir <span data-edition="ed1986" data-page="317"> </span>Leopold heard on the upfloor cry on high and he wondered what
@@ -254,7 +254,7 @@ const OxenOfTheSun = ({openNote, currentNoteId, visitedNotes, addToVisited}) => 
         the board, that is to wit, Dixon yclept junior of saint Mary Merciable's
         with other his fellows Lynch and Madden, scholars of medicine, and the
         franklin that hight Lenehan and one from Alba Longa, one Crotthers, and
-        young Stephen that had <Annotation annotationId="010097latinquarterhat" visited={visitedNotes.has("010097latinquarterhat")} annotationSelect={() => {openNote("010097latinquarterhat"); addToVisited("010097latinquarterhat")}} activeAnnotationId={currentNoteId}>mien of a frere</Annotation> that was at head of the board
+        young Stephen that had <Annotation annotationId="010097latinquarterhat">mien of a frere</Annotation> that was at head of the board
         and Costello that men clepen Punch Costello all long of a mastery of
         him erewhile gested (and of all them, reserved young Stephen, he was the
         most drunken that demanded still of more mead) and beside the meek sir
@@ -295,7 +295,7 @@ const OxenOfTheSun = ({openNote, currentNoteId, visitedNotes, addToVisited}) => 
         had these words following:
         Murmur, sirs, is eke oft among lay folk. Both babe and parent now
         glorify their Maker, the one in limbo gloom, the other in purgefire.
-        But, gramercy, what of <Annotation annotationId="020008infinitepossibilities" visited={visitedNotes.has("020008infinitepossibilities")} annotationSelect={() => {openNote("020008infinitepossibilities"); addToVisited("020008infinitepossibilities")}} activeAnnotationId={currentNoteId}>those Godpossibled souls that we nightly
+        But, gramercy, what of <Annotation annotationId="020008infinitepossibilities">those Godpossibled souls that we nightly
         impossibilise</Annotation>, which is the sin against the Holy Ghost, Very God, Lord
         and Giver of Life? For, sirs, he said, our lust is brief. We are means
         to those small creatures within us and nature has other ends than we.
@@ -314,7 +314,7 @@ const OxenOfTheSun = ({openNote, currentNoteId, visitedNotes, addToVisited}) => 
         be or wheresoever. Then spoke young Stephen orgulous of mother Church
         that <span data-edition="ed1961" data-page="389"> </span>would cast him out of her bosom, of law of canons, of Lilith,
         patron of abortions, <span data-edition="ed1932" data-page="352"> </span>of bigness wrought by wind of seeds of brightness
-        or by <Annotation annotationId="030149vampire" visited={visitedNotes.has("030149vampire")} annotationSelect={() => {openNote("030149vampire"); addToVisited("030149vampire")}} activeAnnotationId={currentNoteId}>potency of vampires</Annotation> <Annotation annotationId="090003hyde" visited={visitedNotes.has("090003hyde")} annotationSelect={() => {openNote("090003hyde"); addToVisited("090003hyde")}} activeAnnotationId={currentNoteId}>mouth to mouth</Annotation> or, as Virgilius saith, by the
+        or by <Annotation annotationId="030149vampire">potency of vampires</Annotation> <Annotation annotationId="090003hyde">mouth to mouth</Annotation> or, as Virgilius saith, by the
         influence of the occident or by the reek of moonflower or an she lie
         with a woman which her man has but lain with, <i>effectu secuto</i>, or
         peradventure in her bath according to the opinions of Averroes and Moses
@@ -334,10 +334,10 @@ const OxenOfTheSun = ({openNote, currentNoteId, visitedNotes, addToVisited}) => 
         Church belike at one blow had birth and death pence and in such sort
         deliverly he scaped their questions. That is truth, pardy, said Dixon,
         and, or I err, a pregnant word. <span data-edition="ed1986" data-page="319"> </span>Which hearing young Stephen was a
-        marvellous glad man and he averred that <Annotation annotationId="010129ubermensch" visited={visitedNotes.has("010129ubermensch")} annotationSelect={() => {openNote("010129ubermensch"); addToVisited("010129ubermensch")}} activeAnnotationId={currentNoteId}>he who stealeth from the poor
+        marvellous glad man and he averred that <Annotation annotationId="010129ubermensch">he who stealeth from the poor
         lendeth</Annotation> 
         <span data-edition="ed1922" data-page="372"> </span>
-        <Annotation annotationId="010129ubermensch" visited={visitedNotes.has("010129ubermensch")} annotationSelect={() => {openNote("010129ubermensch"); addToVisited("010129ubermensch")}} activeAnnotationId={currentNoteId}>to the Lord</Annotation> for he was of a wild manner when he was drunken and
+        <Annotation annotationId="010129ubermensch">to the Lord</Annotation> for he was of a wild manner when he was drunken and
         that he was now in that taking it appeared eftsoons.
       </p>
       <p>
@@ -346,7 +346,7 @@ const OxenOfTheSun = ({openNote, currentNoteId, visitedNotes, addToVisited}) => 
         and as he was minded of his good lady Marion that had borne him an only
         manchild which on his eleventh day on live had died and no man of art
         could save so dark is destiny. And she was wondrous stricken of heart
-        for that evil hap and for his burial did him on a fair <Annotation annotationId="030091ruddywool" visited={visitedNotes.has("030091ruddywool")} annotationSelect={() => {openNote("030091ruddywool"); addToVisited("030091ruddywool")}} activeAnnotationId={currentNoteId}>corselet of
+        for that evil hap and for his burial did him on a fair <Annotation annotationId="030091ruddywool">corselet of
         lamb's wool</Annotation>, the flower of the flock, lest he might perish utterly and
         lie akeled (for it was then about the midst of the winter) and now Sir
         Leopold that had of his body no manchild for an heir looked upon him his
@@ -362,11 +362,11 @@ const OxenOfTheSun = ({openNote, currentNoteId, visitedNotes, addToVisited}) => 
         their approach from him that still plied it very busily who, praying for
         the intentions of the sovereign pontiff, he gave them for a<span data-edition="ed1932" data-page="353"> </span>pledge the
         vicar of Christ which also as he said is vicar of Bray. Now drink we,
-        quod he, of this mazer and quaff ye this mead which is <Annotation annotationId="010106sacredpint" visited={visitedNotes.has("010106sacredpint")} annotationSelect={() => {openNote("010106sacredpint"); addToVisited("010106sacredpint")}} activeAnnotationId={currentNoteId}>not indeed parcel
+        quod he, of this mazer and quaff ye this mead which is <Annotation annotationId="010106sacredpint">not indeed parcel
         of my body but my soul's bodiment. Leave ye fraction of bread to them
         that live by bread alone.</Annotation> Be not afeard neither for any want for this
         will comfort more than the other will dismay. See ye here. And he showed
-        them glistering <Annotation annotationId="020014coinoftribute" visited={visitedNotes.has("020014coinoftribute")} annotationSelect={() => {openNote("020014coinoftribute"); addToVisited("020014coinoftribute")}} activeAnnotationId={currentNoteId}>coins of the tribute</Annotation> and goldsmiths' <Annotation annotationId="020035owenothing" visited={visitedNotes.has("020035owenothing")} annotationSelect={() => {openNote("020035owenothing"); addToVisited("020035owenothing")}} activeAnnotationId={currentNoteId}>notes the worth of
+        them glistering <Annotation annotationId="020014coinoftribute">coins of the tribute</Annotation> and goldsmiths' <Annotation annotationId="020035owenothing">notes the worth of
         two pound nineteen shilling that he had, he said, for a song which he
         writ</Annotation>. They all admired to see the foresaid riches in such dearth of
         money as was herebefore. His words were then these as followeth: Know
@@ -375,27 +375,27 @@ const OxenOfTheSun = ({openNote, currentNoteId, visitedNotes, addToVisited}) => 
         bramblebush to be a rose upon the rood of time. Mark me now. In woman's
         womb word is made flesh but in the spirit of the maker all flesh
         that passes becomes the word that shall not pass away. This is the
-        postcreation. <Annotation annotationId="030102viditdeus" visited={visitedNotes.has("030102viditdeus")} annotationSelect={() => {openNote("030102viditdeus"); addToVisited("030102viditdeus")}} activeAnnotationId={currentNoteId}><i>Omnis caro ad te veniet</i>.</Annotation> No question but her name is
+        postcreation. <Annotation annotationId="030102viditdeus"><i>Omnis caro ad te veniet</i>.</Annotation> No question but her name is
         puissant who aventried the dear corse of our Agenbuyer, Healer and Herd,
         our mighty mother and mother most venerable and Bernardus saith aptly
         that She hath an <i>omnipotentiam deiparae supplicem</i>, that is to wit, an
         almightiness of petition because she is the second Eve and she won
         us, saith Augustine too, whereas that other, our grandam, which we are linked
         <span data-edition="ed1922" data-page="373"> </span>
-        up with by successive <Annotation annotationId="140004anastomosis" visited={visitedNotes.has("140004anastomosis")} annotationSelect={() => {openNote("140004anastomosis"); addToVisited("140004anastomosis")}} activeAnnotationId={currentNoteId}>anastomosis of navelcords</Annotation> sold us all,
+        up with by successive <Annotation annotationId="140004anastomosis">anastomosis of navelcords</Annotation> sold us all,
         seed, breed and generation, for a penny pippin. But here is the matter
         now. Or she knew him, 
         <span data-edition="ed1939" data-page="282"> </span>
         that second I say, and was but creature of her
         creature, <i>vergine madre figlia di tuo figlio</i> or she knew him not and
-        then stands she in the one denial or ignorancy with <Annotation annotationId="140039jackbuilt" visited={visitedNotes.has("140039jackbuilt")} annotationSelect={() => {openNote("140039jackbuilt"); addToVisited("140039jackbuilt")}} activeAnnotationId={currentNoteId}>Peter Piscator who
-        lives in the house</Annotation> <span data-edition="ed1986" data-page="320"> </span><Annotation annotationId="140039jackbuilt" visited={visitedNotes.has("140039jackbuilt")} annotationSelect={() => {openNote("140039jackbuilt"); addToVisited("140039jackbuilt")}} activeAnnotationId={currentNoteId}>that Jack built</Annotation> and with Joseph the joiner patron of
-        the happy demise of all unhappy marriages, <i><Annotation annotationId="010150fatherbird" visited={visitedNotes.has("010150fatherbird")} annotationSelect={() => {openNote("010150fatherbird"); addToVisited("010150fatherbird")}} activeAnnotationId={currentNoteId}>parceque M. Léo Taxil nous
+        then stands she in the one denial or ignorancy with <Annotation annotationId="140039jackbuilt">Peter Piscator who
+        lives in the house</Annotation> <span data-edition="ed1986" data-page="320"> </span><Annotation annotationId="140039jackbuilt">that Jack built</Annotation> and with Joseph the joiner patron of
+        the happy demise of all unhappy marriages, <i><Annotation annotationId="010150fatherbird">parceque M. Léo Taxil nous
         a dit que qui l'avait mise dans cette fichue position c'était le
         sacré pigeon</Annotation></i>, <i>ventre de Dieu! Entweder</i> transubstantiality <i>oder</i>
         consubstantiality but in no case subsubstantiality. And all cried out
         upon it for a very scurvy word. A pregnancy without joy, <span data-edition="ed1961" data-page="391"> </span>he said, a
-        birth without pangs, <Annotation annotationId="030083nakedeve" visited={visitedNotes.has("030083nakedeve")} annotationSelect={() => {openNote("030083nakedeve"); addToVisited("030083nakedeve")}} activeAnnotationId={currentNoteId}>a body without blemish, a belly without bigness</Annotation>.
+        birth without pangs, <Annotation annotationId="030083nakedeve">a body without blemish, a belly without bigness</Annotation>.
         Let the lewd with faith and fervour worship. With will will we
         withstand, withsay.
       </p>
@@ -455,14 +455,14 @@ const OxenOfTheSun = ({openNote, currentNoteId, visitedNotes, addToVisited}) => 
         very high in those days and the custom of the country approved with it.
         Greater love than this, he said, no man hath that a man lay down his
         wife for his friend. Go thou and do likewise. Thus, or words to that
-        effect, saith <Annotation annotationId="010129ubermensch" visited={visitedNotes.has("010129ubermensch")} annotationSelect={() => {openNote("010129ubermensch"); addToVisited("010129ubermensch")}} activeAnnotationId={currentNoteId}>Zarathustra, sometime regius professor of French letters</Annotation>
+        effect, saith <Annotation annotationId="010129ubermensch">Zarathustra, sometime regius professor of French letters</Annotation>
         to the university of Oxtail nor breathed there ever that man to whom
         mankind was more beholden. Bring a stranger within thy tower it will
         go hard but thou wilt have the secondbest bed. <i>Orate, fratres, pro
         memetipso</i>. And all the people shall say, Amen. Remember, Erin, thy
         generations and thy days of old, how thou settedst little by me and by
         my word and broughtest in a stranger to my gates to commit fornication
-        in my sight and to wax fat and kick like Jeshurum. <Annotation annotationId="020060jewmerchants" visited={visitedNotes.has("020060jewmerchants")} annotationSelect={() => {openNote("020060jewmerchants"); addToVisited("020060jewmerchants")}} activeAnnotationId={currentNoteId}>Therefore hast thou
+        in my sight and to wax fat and kick like Jeshurum. <Annotation annotationId="020060jewmerchants">Therefore hast thou
         sinned against the light</Annotation> and hast made me, thy lord, to be the slave of
         servants. Return, return, Clan Milly: forget me not, O Milesian. Why
         hast thou done this abomination before me that thou didst spurn me for
@@ -487,13 +487,13 @@ const OxenOfTheSun = ({openNote, currentNoteId, visitedNotes, addToVisited}) => 
         originals, that same multiplicit concordance which leads forth growth
         from birth accomplishing by a retrogressive metamorphosis that minishing
         and ablation towards the final which is agreeable unto nature so is it
-        with our subsolar being. <Annotation annotationId="030093twomaries" visited={visitedNotes.has("030093twomaries")} annotationSelect={() => {openNote("030093twomaries"); addToVisited("030093twomaries")}} activeAnnotationId={currentNoteId}>The aged sisters draw us into life: we wail,
+        with our subsolar being. <Annotation annotationId="030093twomaries">The aged sisters draw us into life: we wail,
         batten, sport, clip, clasp, sunder, dwindle, die: over us dead they
         bend. First, saved from water of old Nile, among bulrushes, a bed
-        of fasciated</Annotation> <span data-edition="ed1986" data-page="322"> </span><Annotation annotationId="030093twomaries" visited={visitedNotes.has("030093twomaries")} annotationSelect={() => {openNote("030093twomaries"); addToVisited("030093twomaries")}} activeAnnotationId={currentNoteId}>wattles: at last the cavity of a mountain</Annotation>, an occulted
+        of fasciated</Annotation> <span data-edition="ed1986" data-page="322"> </span><Annotation annotationId="030093twomaries">wattles: at last the cavity of a mountain</Annotation>, an occulted
         sepulchre amid the conclamation of the hillcat and the ossifrage. And as
         no man <span data-edition="ed1932" data-page="356"> </span>knows the ubicity of his tumulus nor to what processes we shall
-        thereby be ushered nor whether to Tophet or to <Annotation annotationId="030008edenville" visited={visitedNotes.has("030008edenville")} annotationSelect={() => {openNote("030008edenville"); addToVisited("030008edenville")}} activeAnnotationId={currentNoteId}>Edenville</Annotation> in the like way
+        thereby be ushered nor whether to Tophet or to <Annotation annotationId="030008edenville">Edenville</Annotation> in the like way
         is all hidden when we would backward see from what region of remoteness
         the whatness of our whoness hath fetched his whenceness.
       </p>
@@ -509,7 +509,7 @@ const OxenOfTheSun = ({openNote, currentNoteId, visitedNotes, addToVisited}) => 
       </p>
       <span data-edition="ed1939" data-page="284"> </span>
       <p>
-        A black crack of <Annotation annotationId="020069streetshout" visited={visitedNotes.has("020069streetshout")} annotationSelect={() => {openNote("020069streetshout"); addToVisited("020069streetshout")}} activeAnnotationId={currentNoteId}>noise in the street</Annotation> here, alack, bawled back. Loud on
+        A black crack of <Annotation annotationId="020069streetshout">noise in the street</Annotation> here, alack, bawled back. Loud on
         left Thor thundered: in anger awful the hammerhurler. Came now the storm
         that hist his heart. And Master Lynch bade him have a care to flout and
         witwanton as the god self was angered for his hellprate and paganry. And
@@ -523,7 +523,7 @@ const OxenOfTheSun = ({openNote, currentNoteId, visitedNotes, addToVisited}) => 
         Lenehan vowed he would do after and he was indeed but a word and
         a blow on any the least colour. But the braggart boaster cried that an
         old Nobodaddy was in his cups it was muchwhat indifferent and he would
-        not lag behind his lead. But this was only to dye his desperation <Annotation annotationId="030153crouched" visited={visitedNotes.has("030153crouched")} annotationSelect={() => {openNote("030153crouched"); addToVisited("030153crouched")}} activeAnnotationId={currentNoteId}>as
+        not lag behind his lead. But this was only to dye his desperation <Annotation annotationId="030153crouched">as
         cowed he crouched</Annotation> in Horne's hall. He drank indeed at one draught to
         pluck up a heart of any grace for it thundered long rumblingly over all
         the heavens so that Master Madden, being godly certain whiles, knocked
@@ -542,7 +542,7 @@ const OxenOfTheSun = ({openNote, currentNoteId, visitedNotes, addToVisited}) => 
         bottle Holiness that then he lived withal? Indeed not for <span data-edition="ed1932" data-page="357"> </span>Grace was not
         there to find that bottle. Heard he then in that clap the voice of the
         god Bringforth or, what Calmer said, a hubbub of Phenomenon? Heard?
-        Why, he could not but hear unless he had plugged up <Annotation annotationId="140004anastomosis" visited={visitedNotes.has("140004anastomosis")} annotationSelect={() => {openNote("140004anastomosis"); addToVisited("140004anastomosis")}} activeAnnotationId={currentNoteId}>the tube
+        Why, he could not but hear unless he had plugged up <Annotation annotationId="140004anastomosis">the tube
         Understanding</Annotation> (which he had not done). For through that tube he saw that
         he was in the land of Phenomenon where he must for a certain one day die
         as he was like <span data-edition="ed1986" data-page="323"> </span>the rest too a passing show. And would he not accept to
@@ -588,7 +588,7 @@ const OxenOfTheSun = ({openNote, currentNoteId, visitedNotes, addToVisited}) => 
       </p>
       <span data-edition="ed1932" data-page="358"> </span>
       <p>
-        So Thursday sixteenth June Patk. Dignam laid in clay <Annotation annotationId="040067poordignam" visited={visitedNotes.has("040067poordignam")} annotationSelect={() => {openNote("040067poordignam"); addToVisited("040067poordignam")}} activeAnnotationId={currentNoteId}>of an apoplexy</Annotation> and
+        So Thursday sixteenth June Patk. Dignam laid in clay <Annotation annotationId="040067poordignam">of an apoplexy</Annotation> and
         after hard drought, please God, rained, a bargeman coming in by water a
         fifty mile or thereabout with turf saying the seed won't sprout, fields
         athirst, very sadcoloured and stunk mightily, the quags and tofts too.
@@ -596,7 +596,7 @@ const OxenOfTheSun = ({openNote, currentNoteId, visitedNotes, addToVisited}) => 
         this long while back as no man remembered to be without. The rosy buds
         all gone brown and spread out blobs and on the hills nought but dry flag
         and faggots that would catch at first fire. All the world saying, for
-        aught they knew, <Annotation annotationId="010064dundrum" visited={visitedNotes.has("010064dundrum")} annotationSelect={() => {openNote("010064dundrum"); addToVisited("010064dundrum")}} activeAnnotationId={currentNoteId}>the big wind of last February</Annotation> a year that did havoc the
+        aught they knew, <Annotation annotationId="010064dundrum">the big wind of last February</Annotation> a year that did havoc the
         land so pitifully a small thing beside this barrenness. But by and
         by, as said, this evening after sundown, the wind sitting in the
         west, biggish swollen clouds <span data-edition="ed1986" data-page="324"> </span>to be seen as the night increased and the
@@ -605,7 +605,7 @@ const OxenOfTheSun = ({openNote, currentNoteId, visitedNotes, addToVisited}) => 
         in a brace of shakes all scamper pellmell within door for the smoking
         shower, the men making shelter for their straws with a clout or
         kerchief, womenfolk skipping off with kirtles catched up soon as the
-        pour came. <Annotation annotationId="140035holles" visited={visitedNotes.has("140035holles")} annotationSelect={() => {openNote("140035holles"); addToVisited("140035holles")}} activeAnnotationId={currentNoteId}>In Ely place, Baggot street, Duke's lawn, thence through
+        pour came. <Annotation annotationId="140035holles">In Ely place, Baggot street, Duke's lawn, thence through
         Merrion green up to Holles street</Annotation> a swash of water running that was
         before bonedry and not one chair or coach or fiacre seen about but
         no more crack after that first. Over against the Rt. Hon. Mr Justice
@@ -619,7 +619,7 @@ const OxenOfTheSun = ({openNote, currentNoteId, visitedNotes, addToVisited}) => 
         month yet till Saint Swithin and asks what in the earth he does there,
         he bound home and he to Andrew Horne's being stayed for to crush a cup
         of wine, so he said, but would tell him of a skittish heifer, big of
-        her age and <Annotation annotationId="040004beefheels" visited={visitedNotes.has("040004beefheels")} annotationSelect={() => {openNote("040004beefheels"); addToVisited("040004beefheels")}} activeAnnotationId={currentNoteId}>beef to the heel</Annotation>, and all this while poured with rain and
+        her age and <Annotation annotationId="040004beefheels">beef to the heel</Annotation>, and all this while poured with rain and
         so both together on to Horne's. There Leop. Bloom of Crawford's journal
         sitting snug with a covey of wags, likely brangling fellows, Dixon jun.,
         scholar of my lady of Mercy, Vin. Lynch, a Scots fellow, Will. Madden,
@@ -638,7 +638,7 @@ const OxenOfTheSun = ({openNote, currentNoteId, visitedNotes, addToVisited}) => 
         her last chick's nails that was then a twelvemonth and with other three
         all breastfed that died written out in a fair hand in the king's bible.
         Her hub fifty odd and a methodist but takes the sacrament and is to
-        be seen any fair sabbath with a pair of his boys off <Annotation annotationId="010135bullockharbour" visited={visitedNotes.has("010135bullockharbour")} annotationSelect={() => {openNote("010135bullockharbour"); addToVisited("010135bullockharbour")}} activeAnnotationId={currentNoteId}>Bullock harbour</Annotation>
+        be seen any fair sabbath with a pair of his boys off <Annotation annotationId="010135bullockharbour">Bullock harbour</Annotation>
         dapping on the sound with a heavybraked reel or in a punt he has
         trailing <span data-edition="ed1961" data-page="397"> </span>for flounder and pollock and catches a fine bag, I hear. In sum
         an infinite great fall of rain and all refreshed and will much increase
@@ -651,7 +651,7 @@ const OxenOfTheSun = ({openNote, currentNoteId, visitedNotes, addToVisited}) => 
       </p>
       <span data-edition="ed1986" data-page="325"> </span>
       <p>
-        With this came up Lenehan to the feet of the table to say how <Annotation annotationId="020064telegraph" visited={visitedNotes.has("020064telegraph")} annotationSelect={() => {openNote("020064telegraph"); addToVisited("020064telegraph")}} activeAnnotationId={currentNoteId}>the letter
+        With this came up Lenehan to the feet of the table to say how <Annotation annotationId="020064telegraph">the letter
         was in that night's gazette</Annotation> and he made a show to find it about him
         (for he swore with an oath that he had been at pains about it) but on
         Stephen's persuasion he gave over the search and was bidden to sit near
@@ -671,7 +671,7 @@ const OxenOfTheSun = ({openNote, currentNoteId, visitedNotes, addToVisited}) => 
         some randy quip he had from a punk or whatnot that every mother's son of
         them would burst their sides. The other, Costello that is, hearing this
         talk asked was it poetry or a tale. Faith, no, he says, Frank (that was
-        his name), 'tis all about <Annotation annotationId="020054footandmouth" visited={visitedNotes.has("020054footandmouth")} annotationSelect={() => {openNote("020054footandmouth"); addToVisited("020054footandmouth")}} activeAnnotationId={currentNoteId}>Kerry cows that are to be butchered along of
+        his name), 'tis all about <Annotation annotationId="020054footandmouth">Kerry cows that are to be butchered along of
         the plague</Annotation>. But they can go hang, says he with a wink, for me with their
         bully beef, a pox on it. There's as good fish in this tin as ever came
         out of it and very friendly he offered to take of some salty sprats that
@@ -687,7 +687,7 @@ const OxenOfTheSun = ({openNote, currentNoteId, visitedNotes, addToVisited}) => 
         parish beadle than with his volumes. One time he would be a playactor,
         then a sutler or a welsher, then nought would keep him from the bearpit
         and the cocking main, then he was for the ocean sea or to foot it on
-        the roads with <Annotation annotationId="030078tinkers" visited={visitedNotes.has("030078tinkers")} annotationSelect={() => {openNote("030078tinkers"); addToVisited("030078tinkers")}} activeAnnotationId={currentNoteId}>the Romany folk</Annotation>, kidnapping a squire's heir by favour of
+        the roads with <Annotation annotationId="030078tinkers">the Romany folk</Annotation>, kidnapping a squire's heir by favour of
         moonlight or fecking maids' linen or choking chickens behind a hedge. He
         had been off as many times as a cat has lives and back again with naked
         pockets as many more to his father the headborough who shed 
@@ -705,7 +705,7 @@ const OxenOfTheSun = ({openNote, currentNoteId, visitedNotes, addToVisited}) => 
         <span data-edition="ed1922" data-page="380"> </span>
         like 'tis the hoose or the timber tongue. Mr
         <span data-edition="ed1986" data-page="326"> </span>Stephen, a little moved but very handsomely told him no such matter and
-        that <Annotation annotationId="020055serumandvirus" visited={visitedNotes.has("020055serumandvirus")} annotationSelect={() => {openNote("020055serumandvirus"); addToVisited("020055serumandvirus")}} activeAnnotationId={currentNoteId}>he had dispatches from the emperor's chief tailtickler thanking
+        that <Annotation annotationId="020055serumandvirus">he had dispatches from the emperor's chief tailtickler thanking
         him for the hospitality, that was sending over Doctor Rinderpest, the
         bestquoted cowcatcher in all Muscovy, with a bolus or two of physic</Annotation> to
         take the bull by the horns. Come, come, says Mr Vincent, plain dealing.
@@ -713,7 +713,7 @@ const OxenOfTheSun = ({openNote, currentNoteId, visitedNotes, addToVisited}) => 
         bull that's Irish, says he. Irish by name and irish by nature, says Mr
         Stephen, and he sent the ale purling about, an Irish bull in an English
         chinashop. I conceive you, says Mr Dixon. It is that same bull that was
-        <Annotation annotationId="010142greenstone" visited={visitedNotes.has("010142greenstone")} annotationSelect={() => {openNote("010142greenstone"); addToVisited("010142greenstone")}} activeAnnotationId={currentNoteId}>sent to our island by farmer Nicholas, the bravest cattlebreeder of them
+        <Annotation annotationId="010142greenstone">sent to our island by farmer Nicholas, the bravest cattlebreeder of them
         all, with an emerald ring in his nose</Annotation>. True for you, says Mr Vincent
         cross the table, and a bullseye into the bargain, says he, and a plumper
         and a portlier bull, says he, never shit on shamrock. He had horns
@@ -727,7 +727,7 @@ const OxenOfTheSun = ({openNote, currentNoteId, visitedNotes, addToVisited}) => 
         with that he slapped his posteriors very soundly. But the slap and the
         blessing stood him friend, says Mr Vincent, for to make up he taught him
         a trick worth two of the other so that maid, wife, abbess and widow to
-        this day affirm that they would rather any time of the month <Annotation annotationId="010020ancientgreek" visited={visitedNotes.has("010020ancientgreek")} annotationSelect={() => {openNote("010020ancientgreek"); addToVisited("010020ancientgreek")}} activeAnnotationId={currentNoteId}>whisper
+        this day affirm that they would rather any time of the month <Annotation annotationId="010020ancientgreek">whisper
         in his ear in the dark of a cowhouse</Annotation> or get a lick on the nape from his
         long holy tongue than lie with the finest strapping young ravisher in
         the four fields of all Ireland. Another then put in his word: And they
@@ -749,7 +749,7 @@ const OxenOfTheSun = ({openNote, currentNoteId, visitedNotes, addToVisited}) => 
         island with a printed notice, saying:
         By the Lord Harry, Green is the grass that grows on the ground. And,
         says Mr Dixon, if ever he got scent of a cattleraider in Roscommon or
-        <Annotation annotationId="170019localities" visited={visitedNotes.has("170019localities")} annotationSelect={() => {openNote("170019localities"); addToVisited("170019localities")}} activeAnnotationId={currentNoteId}>the wilds of Connemara</Annotation> or a husbandman in Sligo that was sowing as much
+        <Annotation annotationId="170019localities">the wilds of Connemara</Annotation> or a husbandman in Sligo that was sowing as much
         as a handful of mustard or a bag of rapeseed out he run amok over half
         the countryside rooting 
         <span data-edition="ed1939" data-page="288"> </span>
@@ -826,15 +826,15 @@ const OxenOfTheSun = ({openNote, currentNoteId, visitedNotes, addToVisited}) => 
         females with rich jointures, a prey for the vilest bonzes, who hide their
         flambeau under a bushel in an uncongenial cloister or lose their womanly
         bloom in the embraces of some unaccountable muskin when they might
-        <Annotation annotationId="080028multiply" visited={visitedNotes.has("080028multiply")} annotationSelect={() => {openNote("080028multiply"); addToVisited("080028multiply")}} activeAnnotationId={currentNoteId}>multiply the inlets of happiness</Annotation>, sacrificing the inestimable jewel of
+        <Annotation annotationId="080028multiply">multiply the inlets of happiness</Annotation>, sacrificing the inestimable jewel of
         their sex when a hundred pretty fellows were at hand to caress, this, he
         assured them, made his heart weep. To curb this inconvenient (which
         he concluded due to a suppression of latent heat), having advised with
         certain counsellors of worth and inspected into this matter, he had
         resolved to purchase in fee simple for ever the freehold of Lambay
-        island from its holder, <Annotation annotationId="030150malahide" visited={visitedNotes.has("030150malahide")} annotationSelect={() => {openNote("030150malahide"); addToVisited("030150malahide")}} activeAnnotationId={currentNoteId}>lord Talbot de Malahide, a Tory gentleman of
+        island from its holder, <Annotation annotationId="030150malahide">lord Talbot de Malahide, a Tory gentleman of
         note much in favour with our ascendancy party</Annotation>. He proposed to set up
-        there a national fertilising farm to be named <Annotation annotationId="010065omphalos" visited={visitedNotes.has("010065omphalos")} annotationSelect={() => {openNote("010065omphalos"); addToVisited("010065omphalos")}} activeAnnotationId={currentNoteId}><i>Omphalos</i></Annotation> with an obelisk
+        there a national fertilising farm to be named <Annotation annotationId="010065omphalos"><i>Omphalos</i></Annotation> with an obelisk
         hewn and erected after the fashion of Egypt and to offer his dutiful
         yeoman services for the fecundation of any female of what grade of life
         soever who should there direct to him with the desire of fulfilling the
@@ -891,7 +891,7 @@ const OxenOfTheSun = ({openNote, currentNoteId, visitedNotes, addToVisited}) => 
         <span data-edition="ed1922" data-page="384"> </span>
         smalls, smote
         himself bravely below the diaphragm, exclaiming with an admirable droll
-        mimic of <Annotation annotationId="010134mothergrogan" visited={visitedNotes.has("010134mothergrogan")} annotationSelect={() => {openNote("010134mothergrogan"); addToVisited("010134mothergrogan")}} activeAnnotationId={currentNoteId}>Mother Grogan</Annotation> (the most excellent creature of her sex though
+        mimic of <Annotation annotationId="010134mothergrogan">Mother Grogan</Annotation> (the most excellent creature of her sex though
         'tis pity she's a trollop): There's a belly that never bore a bastard.
         This was so happy a conceit that it renewed the storms of mirth and threw
         the whole room into the most violent agitations of delight. The spry
@@ -981,11 +981,11 @@ const OxenOfTheSun = ({openNote, currentNoteId, visitedNotes, addToVisited}) => 
         you. What, you dog? Have you a way with them? Gad's bud, immensely
         so, said Mr Lynch. The bedside manner it 
         <span data-edition="ed1922" data-page="386"> </span>
-        is that they use in <Annotation annotationId="010068themater" visited={visitedNotes.has("010068themater")} annotationSelect={() => {openNote("010068themater"); addToVisited("010068themater")}} activeAnnotationId={currentNoteId}>the Mater
+        is that they use in <Annotation annotationId="010068themater">the Mater
         hospice</Annotation>. Demme, does not Doctor O'Gargle chuck the nuns there under the
         chin. As I look to be saved I had it from my Kitty who has been wardmaid
         there any time these seven months. Lawksamercy, doctor, cried the young
-        blood in the <Annotation annotationId="010103waistcoat" visited={visitedNotes.has("010103waistcoat")} annotationSelect={() => {openNote("010103waistcoat"); addToVisited("010103waistcoat")}} activeAnnotationId={currentNoteId}>primrose vest</Annotation>, feigning a womanish simper and immodest
+        blood in the <Annotation annotationId="010103waistcoat">primrose vest</Annotation>, feigning a womanish simper and immodest
         squirmings of his body, how you do tease a body! Drat the man! Bless
         me, I'm all of a wibbly wobbly. Why, you're as bad as dear little Father
         Cantekissem, that you are! May this pot of four half choke me, cried
@@ -1086,7 +1086,7 @@ const OxenOfTheSun = ({openNote, currentNoteId, visitedNotes, addToVisited}) => 
         been the man in the gap, a clerk in orders, a linkboy (virtuous) or
         an itinerant vendor of articles needed in every household. Singular,
         communed the guest with himself, the wonderfully unequal faculty of
-        <span data-edition="ed1932" data-page="369"> </span><Annotation annotationId="030087pastlife" visited={visitedNotes.has("030087pastlife")} annotationSelect={() => {openNote("030087pastlife"); addToVisited("030087pastlife")}} activeAnnotationId={currentNoteId}>metempsychosis</Annotation> possessed by them, that the puerperal dormitory and the
+        <span data-edition="ed1932" data-page="369"> </span><Annotation annotationId="030087pastlife">metempsychosis</Annotation> possessed by them, that the puerperal dormitory and the
         dissecting theatre should be the seminaries of such frivolity, that the
         mere acquisition of academic titles should suffice to transform in a
         pinch of time these votaries of levity into exemplary practitioners of
@@ -1108,7 +1108,7 @@ const OxenOfTheSun = ({openNote, currentNoteId, visitedNotes, addToVisited}) => 
         being a deluder of others he has become at last his own dupe as he is,
         if report belie him not, his own and his only enjoyer? Far be it from
         candour to violate the bedchamber of a respectable lady, the daughter of
-        <Annotation annotationId="030118royaldublins" visited={visitedNotes.has("030118royaldublins")} annotationSelect={() => {openNote("030118royaldublins"); addToVisited("030118royaldublins")}} activeAnnotationId={currentNoteId}>a gallant major</Annotation>, or to cast the most distant reflections upon her
+        <Annotation annotationId="030118royaldublins">a gallant major</Annotation>, or to cast the most distant reflections upon her
         virtue but if he challenges attention there (as it was indeed highly his
         interest not to have done) then be it so. Unhappy woman, she has been
         too long and too persistently denied her legitimate prerogative to
@@ -1128,7 +1128,7 @@ const OxenOfTheSun = ({openNote, currentNoteId, visitedNotes, addToVisited}) => 
         becomes him to preach that gospel. Has he not nearer home a seedfield
         that lies fallow for the want of a ploughshare? A habit reprehensible
         at puberty is second nature and an opprobrium in middle life. If he must
-        dispense his <Annotation annotationId="140003balmofgilead" visited={visitedNotes.has("140003balmofgilead")} annotationSelect={() => {openNote("140003balmofgilead"); addToVisited("140003balmofgilead")}} activeAnnotationId={currentNoteId}>balm of Gilead</Annotation> in <span data-edition="ed1986" data-page="334"> </span>nostrums and apothegms of dubious taste
+        dispense his <Annotation annotationId="140003balmofgilead">balm of Gilead</Annotation> in <span data-edition="ed1986" data-page="334"> </span>nostrums and apothegms of dubious taste
         to restore to health a generation of unfledged profligates let his
         practice consist better with the doctrines that now engross him. His
         marital breast is the repository of secrets which decorum is reluctant
@@ -1194,13 +1194,13 @@ const OxenOfTheSun = ({openNote, currentNoteId, visitedNotes, addToVisited}) => 
         inkle, strawberry mark and portwine stain were alleged by one as a
         <i>primafacie</i> and natural hypothetical explanation of swineheaded
         (the case of Madame Grissel Steevens was not forgotten) or doghaired
-        infants occasionally born. The hypothesis of a <Annotation annotationId="010079akasicrecords" visited={visitedNotes.has("010079akasicrecords")} annotationSelect={() => {openNote("010079akasicrecords"); addToVisited("010079akasicrecords")}} activeAnnotationId={currentNoteId}>plasmic memory</Annotation>, advanced
+        infants occasionally born. The hypothesis of a <Annotation annotationId="010079akasicrecords">plasmic memory</Annotation>, advanced
         by the Caledonian envoy and worthy of the metaphysical traditions of
         the land he stood for, envisaged in such cases an arrest of embryonic
         development at some stage antecedent to the human. An outlandish
         delegate sustained against both these views, with such heat as almost
         carried conviction, the theory of copulation between women and the males
-        of brutes, his authority being his own avouchment in support of <Annotation annotationId="010020ancientgreek" visited={visitedNotes.has("010020ancientgreek")} annotationSelect={() => {openNote("010020ancientgreek"); addToVisited("010020ancientgreek")}} activeAnnotationId={currentNoteId}>fables
+        of brutes, his authority being his own avouchment in support of <Annotation annotationId="010020ancientgreek">fables
         such as that of the Minotaur which the genius of the elegant Latin poet
         has handed down to us in the pages of his Metamorphoses</Annotation>. The impression
         made by his words was immediate but shortlived. It was effaced as easily
@@ -1220,22 +1220,22 @@ const OxenOfTheSun = ({openNote, currentNoteId, visitedNotes, addToVisited}) => 
         joined.
       </p>
       <p>
-        <Annotation annotationId="140020talebegan" visited={visitedNotes.has("140020talebegan")} annotationSelect={() => {openNote("140020talebegan"); addToVisited("140020talebegan")}} activeAnnotationId={currentNoteId}>But Malachias' tale began to freeze them with horror.</Annotation> He conjured up the
+        <Annotation annotationId="140020talebegan">But Malachias' tale began to freeze them with horror.</Annotation> He conjured up the
         scene before them. The secret panel beside the chimney slid back and
-        in the recess appeared... <Annotation annotationId="010023haines" visited={visitedNotes.has("010023haines")} annotationSelect={() => {openNote("010023haines"); addToVisited("010023haines")}} activeAnnotationId={currentNoteId}>Haines!</Annotation> Which of us did not feel his <span data-edition="ed1932" data-page="372"> </span>flesh
+        in the recess appeared... <Annotation annotationId="010023haines">Haines!</Annotation> Which of us did not feel his <span data-edition="ed1932" data-page="372"> </span>flesh
         creep! He had a portfolio full of Celtic literature in one hand, in the
         other a phial marked <i>Poison.</i> Surprise, horror, loathing were depicted
         on all faces while he eyed them with a ghastly grin. I anticipated some
         such reception, he began with an eldritch laugh, for which, it seems,
-        <Annotation annotationId="010141blamehistory" visited={visitedNotes.has("010141blamehistory")} annotationSelect={() => {openNote("010141blamehistory"); addToVisited("010141blamehistory")}} activeAnnotationId={currentNoteId}>history is to blame</Annotation>. Yes, it is true. I am the murderer of Samuel
+        <Annotation annotationId="010141blamehistory">history is to blame</Annotation>. Yes, it is true. I am the murderer of Samuel
         Childs. And how I am punished! The inferno has no terrors for me. This
         is the appearance is on me. Tare and ages, what way would I be resting
         at all, he muttered thickly, and I tramping Dublin this while back
         with my share of songs and himself after me the like of a soulth or a
         bullawurrus? My hell, and Ireland's, is in this <span data-edition="ed1986" data-page="336"> </span>life. It is what I tried
         to obliterate my crime. Distractions, rookshooting, the Erse language
-        (<Annotation annotationId="010091speakirish" visited={visitedNotes.has("010091speakirish")} annotationSelect={() => {openNote("010091speakirish"); addToVisited("010091speakirish")}} activeAnnotationId={currentNoteId}>he recited some</Annotation>), laudanum (he raised the phial to his lips), camping
-        out. In vain! His spectre stalks me. Dope is my only hope... Ah! (<Annotation annotationId="010025blackpanther" visited={visitedNotes.has("010025blackpanther")} annotationSelect={() => {openNote("010025blackpanther"); addToVisited("010025blackpanther")}} activeAnnotationId={currentNoteId}>The black panther!</Annotation> With a cry he suddenly vanished and the
+        (<Annotation annotationId="010091speakirish">he recited some</Annotation>), laudanum (he raised the phial to his lips), camping
+        out. In vain! His spectre stalks me. Dope is my only hope... Ah! (<Annotation annotationId="010025blackpanther">The black panther!</Annotation> With a cry he suddenly vanished and the
         panel slid back. An instant later his head appeared in the door opposite
         and said: Meet me at Westland Row station at ten past eleven. He was
         gone. Tears gushed from the eyes of the dissipated host. The seer
@@ -1261,10 +1261,10 @@ const OxenOfTheSun = ({openNote, currentNoteId, visitedNotes, addToVisited}) => 
         <span data-edition="ed1922" data-page="392"> </span>
         reminiscence, that staid agent of publicity and holder of a
         modest substance in the funds. He is
-        young Leopold, as in <Annotation annotationId="060030retrospective" visited={visitedNotes.has("060030retrospective")} annotationSelect={() => {openNote("060030retrospective"); addToVisited("060030retrospective")}} activeAnnotationId={currentNoteId}>a retrospective arrangement</Annotation>, a mirror within
+        young Leopold, as in <Annotation annotationId="060030retrospective">a retrospective arrangement</Annotation>, a mirror within
         a mirror (hey, presto!), he beholdeth himself. That young figure of then
         is seen, precociously manly, walking on a nipping morning from the old
-        house in Clanbrassil street to <Annotation annotationId="050020highschool" visited={visitedNotes.has("050020highschool")} annotationSelect={() => {openNote("050020highschool"); addToVisited("050020highschool")}} activeAnnotationId={currentNoteId}>the high school</Annotation>, his booksatchel on
+        house in Clanbrassil street to <Annotation annotationId="050020highschool">the high school</Annotation>, his booksatchel on
         him bandolierwise, and in it a goodly hunk of wheaten loaf, a mother's
         thought. Or it is the same figure, a year or so gone over, in his first
         hard hat (ah, that was a day!), already on the road, a fullfledged
@@ -1311,13 +1311,13 @@ const OxenOfTheSun = ({openNote, currentNoteId, visitedNotes, addToVisited}) => 
         haunches, a supple tendonous neck, the meek apprehensive skull. They
         fade, sad 
         <span data-edition="ed1939" data-page="297"> </span>
-        phantoms: all is gone. <Annotation annotationId="040061agendath" visited={visitedNotes.has("040061agendath")} annotationSelect={() => {openNote("040061agendath"); addToVisited("040061agendath")}} activeAnnotationId={currentNoteId}>Agendath</Annotation> is a waste land, a home of
-        screechowls and the sandblind upupa. Netaim, the golden, is no more. <Annotation annotationId="080008parallax" visited={visitedNotes.has("080008parallax")} annotationSelect={() => {openNote("080008parallax"); addToVisited("080008parallax")}} activeAnnotationId={currentNoteId}>And
+        phantoms: all is gone. <Annotation annotationId="040061agendath">Agendath</Annotation> is a waste land, a home of
+        screechowls and the sandblind upupa. Netaim, the golden, is no more. <Annotation annotationId="080008parallax">And
         on the highway of the clouds they come, muttering thunder of rebellion,
         the ghosts of beasts. Huuh! Hark! Huuh! Parallax stalks behind and goads
         them</Annotation>, the lancinating lightnings of whose brow <span data-edition="ed1932" data-page="374"> </span>are scorpions. Elk and
         yak, the bulls of Bashan and of Babylon, mammoth and mastodon, they come
-        trooping to <Annotation annotationId="040053deadsea" visited={visitedNotes.has("040053deadsea")} annotationSelect={() => {openNote("040053deadsea"); addToVisited("040053deadsea")}} activeAnnotationId={currentNoteId}>the sunken sea, <i>Lacus Mortis</i></Annotation>. Ominous revengeful zodiacal
+        trooping to <Annotation annotationId="040053deadsea">the sunken sea, <i>Lacus Mortis</i></Annotation>. Ominous revengeful zodiacal
         host! They moan, passing upon the clouds, horned and capricorned, the
         trumpeted with the tusked, the lionmaned, the giantantlered, snouter
         and crawler, rodent, ruminant and pachyderm, all their moving moaning
@@ -1328,7 +1328,7 @@ const OxenOfTheSun = ({openNote, currentNoteId, visitedNotes, addToVisited}) => 
         gulpings, the salt somnolent inexhaustible flood. And the equine portent
         grows again, magnified in the deserted heavens, nay to heaven's own
         magnitude, till it looms, vast, over the house of Virgo. And lo, wonder
-        of <Annotation annotationId="030087pastlife" visited={visitedNotes.has("030087pastlife")} annotationSelect={() => {openNote("030087pastlife"); addToVisited("030087pastlife")}} activeAnnotationId={currentNoteId}>metempsychosis</Annotation>, it is she, the everlasting bride, harbinger of the
+        of <Annotation annotationId="030087pastlife">metempsychosis</Annotation>, it is she, the everlasting bride, harbinger of the
         daystar, the bride, ever virgin. It is she, Martha, thou lost one,
         Millicent, the young, the dear, the radiant. How serene does she now
         arise, a queen among the Pleiades, in the penultimate antelucan hour,
@@ -1341,13 +1341,13 @@ const OxenOfTheSun = ({openNote, currentNoteId, visitedNotes, addToVisited}) => 
         upon the forehead of Taurus.
       </p>
       <p>
-        Francis was reminding Stephen of years before when they <span data-edition="ed1961" data-page="414"> </span>had been <Annotation annotationId="050052conmee" visited={visitedNotes.has("050052conmee")} annotationSelect={() => {openNote("050052conmee"); addToVisited("050052conmee")}} activeAnnotationId={currentNoteId}>at
+        Francis was reminding Stephen of years before when they <span data-edition="ed1961" data-page="414"> </span>had been <Annotation annotationId="050052conmee">at
         school together in Conmee's time</Annotation>. He asked about Glaucon, Alcibiades,
         <span data-edition="ed1986" data-page="338"> </span>Pisistratus. Where were they now? Neither knew. You have spoken of the
         past and its phantoms, Stephen said. Why think of them? If I call them
         into life across the waters of Lethe will not the poor ghosts troop to
-        my call? Who supposes it? I, Bous Stephanoumenos, <Annotation annotationId="020065bullockbefriending" visited={visitedNotes.has("020065bullockbefriending")} annotationSelect={() => {openNote("020065bullockbefriending"); addToVisited("020065bullockbefriending")}} activeAnnotationId={currentNoteId}>bullockbefriending
-        bard</Annotation>, am lord and giver of their life. <Annotation annotationId="010020ancientgreek" visited={visitedNotes.has("010020ancientgreek")} annotationSelect={() => {openNote("010020ancientgreek"); addToVisited("010020ancientgreek")}} activeAnnotationId={currentNoteId}>He encircled his gadding hair
+        my call? Who supposes it? I, Bous Stephanoumenos, <Annotation annotationId="020065bullockbefriending">bullockbefriending
+        bard</Annotation>, am lord and giver of their life. <Annotation annotationId="010020ancientgreek">He encircled his gadding hair
         with a coronal of vineleaves</Annotation>, smiling at Vincent. That answer and those
         leaves, Vincent said to him, will adorn you more fitly when something
         more, and greatly more, than a capful of light odes can call your genius
@@ -1404,7 +1404,7 @@ const OxenOfTheSun = ({openNote, currentNoteId, visitedNotes, addToVisited}) => 
         poor luck with Bass's mare perhaps this draught of his may serve me more
         propensely. He was laying his hand upon a winejar: Malachi saw it and
         withheld his act, pointing to the stranger and to the scarlet label.
-        Warily, Malachi whispered, preserve a <Annotation annotationId="010018druids" visited={visitedNotes.has("010018druids")} annotationSelect={() => {openNote("010018druids"); addToVisited("010018druids")}} activeAnnotationId={currentNoteId}>druid</Annotation> silence. His soul is far
+        Warily, Malachi whispered, preserve a <Annotation annotationId="010018druids">druid</Annotation> silence. His soul is far
         away. It is as painful perhaps to be awakened from a vision as to be
         born. Any object, intensely regarded, may be a gate of access to the
         incorruptible eon of <span data-edition="ed1932" data-page="376"> </span>the gods. Do you not think it, Stephen? Theosophos
@@ -1431,9 +1431,9 @@ const OxenOfTheSun = ({openNote, currentNoteId, visitedNotes, addToVisited}) => 
         scarlet appearance. He was simply and solely, as it subsequently
         transpired for reasons best known to himself, which put quite an
         altogether different complexion on the proceedings, after the moment
-        before's observations about boyhood days and the turf, <Annotation annotationId="160008littlepills" visited={visitedNotes.has("160008littlepills")} annotationSelect={() => {openNote("160008littlepills"); addToVisited("160008littlepills")}} activeAnnotationId={currentNoteId}>recollecting two</Annotation>
+        before's observations about boyhood days and the turf, <Annotation annotationId="160008littlepills">recollecting two</Annotation>
         <span data-edition="ed1939" data-page="299"> </span>
-        <Annotation annotationId="160008littlepills" visited={visitedNotes.has("160008littlepills")} annotationSelect={() => {openNote("160008littlepills"); addToVisited("160008littlepills")}} activeAnnotationId={currentNoteId}>or three private transactions of his own</Annotation> which the other two were as
+        <Annotation annotationId="160008littlepills">or three private transactions of his own</Annotation> which the other two were as
         mutually innocent of as the babe unborn. Eventually, however, both
         their eyes met and as soon as it began to dawn on him that the other was
         endeavouring to help himself to the thing he involuntarily determined
@@ -1459,7 +1459,7 @@ const OxenOfTheSun = ({openNote, currentNoteId, visitedNotes, addToVisited}) => 
         Costello, the eccentric, while at his side was seated in stolid repose
         the squat form of Madden. The chair of the resident indeed stood vacant
         before the hearth but on either flank of it the figure of Bannon in
-        explorer's kit of tweed shorts and salted cowhide <Annotation annotationId="020076brogues" visited={visitedNotes.has("020076brogues")} annotationSelect={() => {openNote("020076brogues"); addToVisited("020076brogues")}} activeAnnotationId={currentNoteId}>brogues</Annotation> contrasted
+        explorer's kit of tweed shorts and salted cowhide <Annotation annotationId="020076brogues">brogues</Annotation> contrasted
         sharply with the primrose elegance and townbred manners of Malachi
         Roland St John Mulligan. Lastly at the head of the board was the young
         poet who found a refuge from his labours of pedagogy and metaphysical
@@ -1473,7 +1473,7 @@ const OxenOfTheSun = ({openNote, currentNoteId, visitedNotes, addToVisited}) => 
         yet to come.
       </p>
       <p>
-        It had better be stated here and now at the outset that the <Annotation annotationId="010041killergod" visited={visitedNotes.has("010041killergod")} annotationSelect={() => {openNote("010041killergod"); addToVisited("010041killergod")}} activeAnnotationId={currentNoteId}>perverted
+        It had better be stated here and now at the outset that the <Annotation annotationId="010041killergod">perverted
         transcendentalism</Annotation> to which Mr S. Dedalus' (Div. Scep.) contentions
         would appear to prove him pretty badly addicted runs directly counter to
         accepted scientific methods. Science, it cannot be too often repeated,
@@ -1509,7 +1509,7 @@ const OxenOfTheSun = ({openNote, currentNoteId, visitedNotes, addToVisited}) => 
         said, were accountable for any and every fallingoff in the calibre of
         the race. Kalipedia, he prophesied, would soon be <span data-edition="ed1961" data-page="418"> </span>generally adopted
         and all the graces of life, genuinely good music, agreeable literature,
-        light philosophy, instructive pictures, <Annotation annotationId="080005venus" visited={visitedNotes.has("080005venus")} annotationSelect={() => {openNote("080005venus"); addToVisited("080005venus")}} activeAnnotationId={currentNoteId}>plastercast reproductions of
+        light philosophy, instructive pictures, <Annotation annotationId="080005venus">plastercast reproductions of
         the classical statues such as Venus and Apollo</Annotation>, artistic coloured
         photographs of prize babies, all these little attentions would enable
         ladies who were in a particular condition to pass the intervening months
@@ -1539,14 +1539,14 @@ const OxenOfTheSun = ({openNote, currentNoteId, visitedNotes, addToVisited}) => 
         Nature, we may rest assured, has her own good and cogent reasons for
         whatever she does and in all probability such deaths are due to some law
         of anticipation by which organisms in which morbous germs have taken
-        up their residence (modern science has conclusively shown that <Annotation annotationId="010079akasicrecords" visited={visitedNotes.has("010079akasicrecords")} annotationSelect={() => {openNote("010079akasicrecords"); addToVisited("010079akasicrecords")}} activeAnnotationId={currentNoteId}>only the
+        up their residence (modern science has conclusively shown that <Annotation annotationId="010079akasicrecords">only the
         plasmic substance can be said to be immortal</Annotation>) tend to disappear at an
         increasingly earlier stage of development, an arrangement which, though
         productive of <span data-edition="ed1932" data-page="379"> </span>pain to some of our feelings (notably the maternal), is
         nevertheless, some of us think, in the long run beneficial to the
         race in general in securing thereby the survival of the fittest. Mr S.
         Dedalus' (Div. Scep.) remark <span data-edition="ed1961" data-page="419"> </span>(or should it be called an interruption?)
-        that <Annotation annotationId="010041killergod" visited={visitedNotes.has("010041killergod")} annotationSelect={() => {openNote("010041killergod"); addToVisited("010041killergod")}} activeAnnotationId={currentNoteId}>an omnivorous being which can masticate, deglute, digest and
+        that <Annotation annotationId="010041killergod">an omnivorous being which can masticate, deglute, digest and
         apparently pass through the ordinary channel with pluterperfect
         imperturbability</Annotation> such multifarious aliments as cancrenous females
         emaciated by parturition, corpulent professional gentlemen, not to speak
@@ -1564,7 +1564,7 @@ const OxenOfTheSun = ({openNote, currentNoteId, visitedNotes, addToVisited}) => 
         cookable and eatable flesh of a calf newly dropped from its mother. In
         a recent public controversy with Mr L. Bloom (Pubb. Canv.) which took
         place in the commons' hall of the National Maternity Hospital, 29, 30
-        and 31 Holles street, of which, as is well known, <Annotation annotationId="140038drhorne" visited={visitedNotes.has("140038drhorne")} annotationSelect={() => {openNote("140038drhorne"); addToVisited("140038drhorne")}} activeAnnotationId={currentNoteId}>Dr A. Horne (Lic. in
+        and 31 Holles street, of which, as is well known, <Annotation annotationId="140038drhorne">Dr A. Horne (Lic. in
         Midw., F. K. Q. C. P. I.) is the able and popular master</Annotation>, he is reported
         by eyewitnesses as having stated that once a woman has let the cat
         into the bag (an esthetic allusion, presumably, to one of the most
@@ -1603,7 +1603,7 @@ const OxenOfTheSun = ({openNote, currentNoteId, visitedNotes, addToVisited}) => 
         of Waterford and Candahar) and now this last pledge of their union, a
         Purefoy if ever there was one, with the true Purefoy nose. Young hopeful
         will be christened Mortimer Edward after the influential third cousin of
-        Mr Purefoy in <Annotation annotationId="080013dublincastle" visited={visitedNotes.has("080013dublincastle")} annotationSelect={() => {openNote("080013dublincastle"); addToVisited("080013dublincastle")}} activeAnnotationId={currentNoteId}>the Treasury Remembrancer's office, Dublin Castle</Annotation>. And so
+        Mr Purefoy in <Annotation annotationId="080013dublincastle">the Treasury Remembrancer's office, Dublin Castle</Annotation>. And so
         time wags on: but father Cronion has dealt lightly here. No, <span data-edition="ed1986" data-page="343"> </span>let no sigh
         break from that bosom, dear gentle Mina. And Doady, knock the ashes from
         your pipe, the seasoned briar you still fancy when the curfew rings for
@@ -1646,7 +1646,7 @@ const OxenOfTheSun = ({openNote, currentNoteId, visitedNotes, addToVisited}) => 
         in thoughtful irrigation you saw another as fragrant sisterhood, Floey,
         Atty, Tiny and their darker friend with I know not what of arresting in
         her pose then, Our Lady of the Cherries, a comely brace of them pendent
-        from an ear, bringing out <Annotation annotationId="040063happywarmth" visited={visitedNotes.has("040063happywarmth")} annotationSelect={() => {openNote("040063happywarmth"); addToVisited("040063happywarmth")}} activeAnnotationId={currentNoteId}>the foreign warmth of the skin</Annotation> so daintily
+        from an ear, bringing out <Annotation annotationId="040063happywarmth">the foreign warmth of the skin</Annotation> so daintily
         against the cool ardent fruit. A lad of four or five in linseywoolsey
         (blossomtime but there will be cheer in the kindly hearth when ere long
         the bowls are gathered and hutched) is standing on the urn secured by
@@ -1685,7 +1685,7 @@ const OxenOfTheSun = ({openNote, currentNoteId, visitedNotes, addToVisited}) => 
         Callan taken aback in the hallway cannot stay them nor smiling surgeon
         coming downstairs with news of placentation ended, a full pound if a
         milligramme. They hark him on. The door! It is open? Ha! They are <span data-edition="ed1932" data-page="382"> </span>out
-        tumultuously, off for a minute's race, all bravely legging it, <Annotation annotationId="040089denzille" visited={visitedNotes.has("040089denzille")} annotationSelect={() => {openNote("040089denzille"); addToVisited("040089denzille")}} activeAnnotationId={currentNoteId}>Burke's
+        tumultuously, off for a minute's race, all bravely legging it, <Annotation annotationId="040089denzille">Burke's
         of Denzille and Holles</Annotation> their ulterior goal. Dixon follows giving them
         sharp language but raps out an oath, he too, and on. Bloom stays with
         nurse a thought to send a kind word to happy mother and nurseling up
@@ -1695,7 +1695,7 @@ const OxenOfTheSun = ({openNote, currentNoteId, visitedNotes, addToVisited}) => 
         going: Madam, when comes the storkbird for thee?
       </p>
       <p>
-        The air without is <Annotation annotationId="180010dewy" visited={visitedNotes.has("180010dewy")} annotationSelect={() => {openNote("180010dewy"); addToVisited("180010dewy")}} activeAnnotationId={currentNoteId}>impregnated with raindew moisture</Annotation>, life essence
+        The air without is <Annotation annotationId="180010dewy">impregnated with raindew moisture</Annotation>, life essence
         celestial, glistering on Dublin stone there under starshiny <i>coelum.</i>
         God's air, the Allfather's air, scintillant circumambient cessile air.
         Breathe it deep into thee. By heaven, Theodore Purefoy, thou hast done a
@@ -1706,7 +1706,7 @@ const OxenOfTheSun = ({openNote, currentNoteId, visitedNotes, addToVisited}) => 
         Serve! Toil on, labour like a very bandog and let scholarment and all
         Malthusiasts go hang. Thou art all their daddies, Theodore. Art drooping
         under thy load, bemoiled with butcher's bills at home and ingots (not
-        thine!) in the countinghouse? Head up! <Annotation annotationId="180010dewy" visited={visitedNotes.has("180010dewy")} annotationSelect={() => {openNote("180010dewy"); addToVisited("180010dewy")}} activeAnnotationId={currentNoteId}> For every newbegotten thou shalt
+        thine!) in the countinghouse? Head up! <Annotation annotationId="180010dewy"> For every newbegotten thou shalt
         gather thy homer of ripe wheat. See, thy fleece is drenched</Annotation>. Dost envy
         Darby Dullman there with his Joan? A canting jay and a rheumeyed
         curdog is all their progeny. Pshaw, I tell thee! He is a mule, a dead
@@ -1735,22 +1735,22 @@ const OxenOfTheSun = ({openNote, currentNoteId, visitedNotes, addToVisited}) => 
       </p>
       <p>
         All off for a buster, armstrong, hollering down the street. Bonafides.
-        Where you slep las nigh? <Annotation annotationId="040090naggin" visited={visitedNotes.has("040090naggin")} annotationSelect={() => {openNote("040090naggin"); addToVisited("040090naggin")}} activeAnnotationId={currentNoteId}>Timothy of the battered naggin.</Annotation> Like ole
+        Where you slep las nigh? <Annotation annotationId="040090naggin">Timothy of the battered naggin.</Annotation> Like ole
         Billyo. Any brollies or gumboots in the fambly? Where the Henry Nevil's
         sawbones and ole clo? Sorra one o' me knows. Hurrah there, Dix! Forward the ribbon counter. Where's Punch? All serene. Jay, look at the
-        drunken <Annotation annotationId="010097latinquarterhat" visited={visitedNotes.has("010097latinquarterhat")} annotationSelect={() => {openNote("010097latinquarterhat"); addToVisited("010097latinquarterhat")}} activeAnnotationId={currentNoteId}>minister</Annotation> coming out of the maternity hospal! <i>Benedicat vos
-        omnipotens Deus, Pater et Filius</i>. A make, mister. <Annotation annotationId="040089denzille" visited={visitedNotes.has("040089denzille")} annotationSelect={() => {openNote("040089denzille"); addToVisited("040089denzille")}} activeAnnotationId={currentNoteId}>The Denzille lane
+        drunken <Annotation annotationId="010097latinquarterhat">minister</Annotation> coming out of the maternity hospal! <i>Benedicat vos
+        omnipotens Deus, Pater et Filius</i>. A make, mister. <Annotation annotationId="040089denzille">The Denzille lane
         boys.</Annotation> Hell, blast ye! Scoot. Righto, Isaacs, shove em out of the
         bleeding limelight. 
         <span data-edition="ed1939" data-page="304"> </span>
         Yous join uz, dear sir? No hentrusion in life. Lou
         heap good man. Allee samee this bunch. <i>En avant, mes enfants!</i> Fire
         away number one on the gun. Burke's! Burke's! Thence they advanced five
-        parasangs. Slattery's mounted foot. Where's that bleeding awfur? <Annotation annotationId="010097latinquarterhat" visited={visitedNotes.has("010097latinquarterhat")} annotationSelect={() => {openNote("010097latinquarterhat"); addToVisited("010097latinquarterhat")}} activeAnnotationId={currentNoteId}>Parson
+        parasangs. Slattery's mounted foot. Where's that bleeding awfur? <Annotation annotationId="010097latinquarterhat">Parson
         Steve</Annotation>, apostates' creed! No, no, Mulligan! Abaft there! Shove ahead.
         Keep a watch on the clock. Chuckingout time. Mullee! What's on you? <i>Ma
         mère m'a mariée.</i> British Beatitudes! <i>Retamplan Digidi Boum Boum</i>.
-        Ayes have it. <Annotation annotationId="010064dundrum" visited={visitedNotes.has("010064dundrum")} annotationSelect={() => {openNote("010064dundrum"); addToVisited("010064dundrum")}} activeAnnotationId={currentNoteId}>To be printed and bound at the </Annotation><Annotation annotationId="010018druids" visited={visitedNotes.has("010018druids")} annotationSelect={() => {openNote("010018druids"); addToVisited("010018druids")}} activeAnnotationId={currentNoteId}>Druiddrum</Annotation> press by two
+        Ayes have it. <Annotation annotationId="010064dundrum">To be printed and bound at the </Annotation><Annotation annotationId="010018druids">Druiddrum</Annotation> press by two
         designing females. Calf covers of pissedon green. Last word in art
         shades. Most beautiful book come out of Ireland my time. <i>Silentium!</i>
         Get a spurt on. Tention. Proceed to nearest canteen and there annex
@@ -1765,12 +1765,12 @@ const OxenOfTheSun = ({openNote, currentNoteId, visitedNotes, addToVisited}) => 
       <p>
         Query. Who's astanding this here do? Proud possessor of damnall. Declare
         misery. Bet to the ropes. Me nantee saltee. Not a red at me this week
-        gone. Yours? Mead of our fathers for <Annotation annotationId="010129ubermensch" visited={visitedNotes.has("010129ubermensch")} annotationSelect={() => {openNote("010129ubermensch"); addToVisited("010129ubermensch")}} activeAnnotationId={currentNoteId}>the <i>Uebermensch</i></Annotation>. Dittoh. Five
+        gone. Yours? Mead of our fathers for <Annotation annotationId="010129ubermensch">the <i>Uebermensch</i></Annotation>. Dittoh. Five
         number ones. You, sir? Ginger cordial. Chase me, the cabby's caudle.
         Stimulate the 
         <span data-edition="ed1922" data-page="403"> </span>
         caloric. Winding of his ticker. Stopped short never to go
-        again when the old. <Annotation annotationId="030045absinthe" visited={visitedNotes.has("030045absinthe")} annotationSelect={() => {openNote("030045absinthe"); addToVisited("030045absinthe")}} activeAnnotationId={currentNoteId}>Absinthe</Annotation> for me, savvy? <i>Caramba!</i> Have an eggnog or
+        again when the old. <Annotation annotationId="030045absinthe">Absinthe</Annotation> for me, savvy? <i>Caramba!</i> Have an eggnog or
         a prairie oyster. Enemy? Avuncular's got my timepiece. Ten to. Obligated
         <span data-edition="ed1986" data-page="346"> </span>awful. Don't mention it. Got a pectoral trauma, eh, Dix? Pos fact. Got
         bet be a boomblebee whenever he wus settin sleepin in hes bit garten.
@@ -1781,14 +1781,14 @@ const OxenOfTheSun = ({openNote, currentNoteId, visitedNotes, addToVisited}) => 
         up. Five, seven, nine. Fine! Got a prime pair of mincepies, no kid. And
         her take me to rests and her anker of rum. Must be seen to be believed.
         Your starving eyes and allbeplastered neck you stole my heart, O
-        gluepot. Sir? <Annotation annotationId="040047potato" visited={visitedNotes.has("040047potato")} annotationSelect={() => {openNote("040047potato"); addToVisited("040047potato")}} activeAnnotationId={currentNoteId}>Spud again the rheumatiz?</Annotation> All poppycock, you'll scuse me
+        gluepot. Sir? <Annotation annotationId="040047potato">Spud again the rheumatiz?</Annotation> All poppycock, you'll scuse me
         saying. For the hoi polloi. I vear thee beest a gert vool. Well, doc?
         Back fro Lapland? Your corporosity sagaciating O K? How's the squaws
         and papooses? Womanbody after going on the straw? Stand and deliver.
         Password. There's hair. Ours the white death and the ruddy birth. Hi!
-        Spit in your own eye, boss! <Annotation annotationId="010043mummer" visited={visitedNotes.has("010043mummer")} annotationSelect={() => {openNote("010043mummer"); addToVisited("010043mummer")}} activeAnnotationId={currentNoteId}>Mummer</Annotation>'s wire. Cribbed out of Meredith.
-        Jesified orchidised polycimical <Annotation annotationId="010008jesuit" visited={visitedNotes.has("010008jesuit")} annotationSelect={() => {openNote("010008jesuit"); addToVisited("010008jesuit")}} activeAnnotationId={currentNoteId}>jesuit</Annotation>! Aunty mine's writing Pa Kinch.
-        <Annotation annotationId="010001buckmulligan" visited={visitedNotes.has("010001buckmulligan")} annotationSelect={() => {openNote("010001buckmulligan"); addToVisited("010001buckmulligan")}} activeAnnotationId={currentNoteId}>Baddybad Stephen lead astray goodygood Malachi.</Annotation>
+        Spit in your own eye, boss! <Annotation annotationId="010043mummer">Mummer</Annotation>'s wire. Cribbed out of Meredith.
+        Jesified orchidised polycimical <Annotation annotationId="010008jesuit">jesuit</Annotation>! Aunty mine's writing Pa Kinch.
+        <Annotation annotationId="010001buckmulligan">Baddybad Stephen lead astray goodygood Malachi.</Annotation>
       </p>
       <p>
         Hurroo! Collar the leather, youngun. Roun wi the nappy. Here, Jock braw
@@ -1796,9 +1796,9 @@ const OxenOfTheSun = ({openNote, currentNoteId, visitedNotes, addToVisited}) => 
         boil! My tipple. <i>Merci.</i> Here's to us. How's that? Leg before wicket.
         Don't stain my brandnew sitinems. Give's a shake of pepper, you there.
         Catch aholt. Caraway seed to carry away. Twig? Shrieks of silence. Every
-        cove to his gentry mort. <Annotation annotationId="080005venus" visited={visitedNotes.has("080005venus")} annotationSelect={() => {openNote("080005venus"); addToVisited("080005venus")}} activeAnnotationId={currentNoteId}>Venus Pandemos.</Annotation> <i>Les petites femmes</i>. <Annotation annotationId="010127photogirl" visited={visitedNotes.has("010127photogirl")} annotationSelect={() => {openNote("010127photogirl"); addToVisited("010127photogirl")}} activeAnnotationId={currentNoteId}>Bold bad
+        cove to his gentry mort. <Annotation annotationId="080005venus">Venus Pandemos.</Annotation> <i>Les petites femmes</i>. <Annotation annotationId="010127photogirl">Bold bad
         girl from the town of Mullingar.</Annotation> Tell her I was axing at her. Hauding
-        Sara by the wame. On the road to <Annotation annotationId="030150malahide" visited={visitedNotes.has("030150malahide")} annotationSelect={() => {openNote("030150malahide"); addToVisited("030150malahide")}} activeAnnotationId={currentNoteId}>Malahide</Annotation>. Me? <span data-edition="ed1961" data-page="425"> </span>If she who seduced me had
+        Sara by the wame. On the road to <Annotation annotationId="030150malahide">Malahide</Annotation>. Me? <span data-edition="ed1961" data-page="425"> </span>If she who seduced me had
         left but the name. What do you want for ninepence? Machree, macruiskeen.
         Smutty Moll for a mattress jig. And a pull all together. <i>Ex!</i>
       </p>
@@ -1825,10 +1825,10 @@ const OxenOfTheSun = ({openNote, currentNoteId, visitedNotes, addToVisited}) => 
         cheese it! Shut his blurry Dutch oven with a firm hand. Had the winner
         today till I tipped him a dead cert. The ruffin cly the nab of Stephen
         Hand as give me the jady coppaleen. He strike a <span data-edition="ed1932" data-page="385"> </span>telegramboy paddock wire
-        big bug Bass to the depot. Shove him <Annotation annotationId="010019money" visited={visitedNotes.has("010019money")} annotationSelect={() => {openNote("010019money"); addToVisited("010019money")}} activeAnnotationId={currentNoteId}>a joey</Annotation> and grahamise. Mare on form hot 
+        big bug Bass to the depot. Shove him <Annotation annotationId="010019money">a joey</Annotation> and grahamise. Mare on form hot 
         <span data-edition="ed1986" data-page="347"> </span>order. Guinea to a goosegog. Tell a cram, that. Gospeltrue. Criminal
         diversion? I think that yes. Sure thing. Land him in chokeechokee if the
-        harman beck copped the game. Madden back Madden's a maddening back. <Annotation annotationId="010088archangelmichael" visited={visitedNotes.has("010088archangelmichael")} annotationSelect={() => {openNote("010088archangelmichael"); addToVisited("010088archangelmichael")}} activeAnnotationId={currentNoteId}>O,
+        harman beck copped the game. Madden back Madden's a maddening back. <Annotation annotationId="010088archangelmichael">O,
         lust, our refuge and our strength.</Annotation> Decamping. Must you go? Off to mammy.
         Stand by. Hide my blushes someone. All in if he spots me. Comeahome,
         our Bantam. Horryvar, mong vioo. Dinna forget the cowslips for hersel.
@@ -1844,7 +1844,7 @@ const OxenOfTheSun = ({openNote, currentNoteId, visitedNotes, addToVisited}) => 
         most extreme poverty and one largesize grandacious thirst to terminate
         one expensive inaugurated libation? Give's a breather. Landlord,
         landlord, have you good <span data-edition="ed1961" data-page="426"> </span>wine, staboo? Hoots, mon, a wee drap to pree.
-        Cut and come again. Right Boniface! <Annotation annotationId="030045absinthe" visited={visitedNotes.has("030045absinthe")} annotationSelect={() => {openNote("030045absinthe"); addToVisited("030045absinthe")}} activeAnnotationId={currentNoteId}>Absinthe the lot. <i>Nos omnes
+        Cut and come again. Right Boniface! <Annotation annotationId="030045absinthe">Absinthe the lot. <i>Nos omnes
         biberimus viridum toxicum diabolus capiat posterioria nostria</i>.</Annotation>
         Closingtime, gents. Eh? Rome boose for the Bloom toff. I hear you say
         onions? Bloo? Cadges ads. Photo's papli, by all that's gorgeous. Play
@@ -1863,10 +1863,10 @@ const OxenOfTheSun = ({openNote, currentNoteId, visitedNotes, addToVisited}) => 
       <p>
         Golly, whatten tunket's yon guy in the mackintosh? Dusty Rhodes. Peep
         at his wearables. By mighty! What's he got? Jubilee mutton. Bovril,
-        by James. Wants it real bad. D'ye ken bare socks? Seedy cuss in <Annotation annotationId="010050dottyville" visited={visitedNotes.has("010050dottyville")} annotationSelect={() => {openNote("010050dottyville"); addToVisited("010050dottyville")}} activeAnnotationId={currentNoteId}>the
+        by James. Wants it real bad. D'ye ken bare socks? Seedy cuss in <Annotation annotationId="010050dottyville">the
         Richmond</Annotation>? Rawthere! Thought he had a deposit of lead in his penis.
         Trumpery insanity. Bartle the Bread we calls him. That, sir, was once
-        a prosperous cit. <Annotation annotationId="140039jackbuilt" visited={visitedNotes.has("140039jackbuilt")} annotationSelect={() => {openNote("140039jackbuilt"); addToVisited("140039jackbuilt")}} activeAnnotationId={currentNoteId}>Man all tattered and torn that married a maiden all
+        a prosperous cit. <Annotation annotationId="140039jackbuilt">Man all tattered and torn that married a maiden all
         forlorn.</Annotation> Slung her hook, she did. Here see lost love. Walking Mackintosh
         of lonely canyon. Tuck and turn in. Schedule time. Nix for the hornies.
         Pardon? 
@@ -1895,10 +1895,10 @@ const OxenOfTheSun = ({openNote, currentNoteId, visitedNotes, addToVisited}) => 
         come? Run, skelter, race. Pflaaaap!
       </p>
       <p>
-        Lynch! Hey? Sign on long o me. <Annotation annotationId="040089denzille" visited={visitedNotes.has("040089denzille")} annotationSelect={() => {openNote("040089denzille"); addToVisited("040089denzille")}} activeAnnotationId={currentNoteId}>Denzille lane this way. Change here for
+        Lynch! Hey? Sign on long o me. <Annotation annotationId="040089denzille">Denzille lane this way. Change here for
         Bawdyhouse.</Annotation> We two, she said, will seek the kips where shady Mary is.
         Righto, any old time. <i>Laetabuntur in cubilibus suis</i>. You coming long?
-        Whisper, who the sooty hell's the johnny in the black duds? Hush! <Annotation annotationId="020060jewmerchants" visited={visitedNotes.has("020060jewmerchants")} annotationSelect={() => {openNote("020060jewmerchants"); addToVisited("020060jewmerchants")}} activeAnnotationId={currentNoteId}>Sinned
+        Whisper, who the sooty hell's the johnny in the black duds? Hush! <Annotation annotationId="020060jewmerchants">Sinned
         against the light</Annotation> and even now that day is at hand when he shall come to
         judge the world by fire. Pflaap! <i>Ut implerentur scripturae</i>. Strike
         up a ballad. Then outspake medical Dick to his comrade medical Davy.

--- a/src/content/chapters/Penelope.js
+++ b/src/content/chapters/Penelope.js
@@ -1,17 +1,17 @@
 import Annotation from "../../components/Annotation";
 
 
-const Penelope = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
+const Penelope = () => {
   return (
     <div>
       <p></p>
       <center><font size="+2">[18]</font></center>
       <br/>
-      <Annotation annotationId="180005yesyes" visited={visitedNotes.has("180005yesyes")} annotationSelect={() => {openNote("180005yesyes"); addToVisited("180005yesyes")}} activeAnnotationId={currentNoteId}>Yes</Annotation> because he never did a thing like that before as ask to get his
-      breakfast in bed with a couple of eggs since the <Annotation annotationId="020066cityarms" visited={visitedNotes.has("020066cityarms")} annotationSelect={() => {openNote("020066cityarms"); addToVisited("020066cityarms")}} activeAnnotationId={currentNoteId}>City Arms hotel</Annotation>
+      <Annotation annotationId="180005yesyes">Yes</Annotation> because he never did a thing like that before as ask to get his
+      breakfast in bed with a couple of eggs since the <Annotation annotationId="020066cityarms">City Arms hotel</Annotation>
       when he used to be pretending to be laid up with a sick voice doing his
-      highness to make himself interesting for that old faggot <Annotation annotationId="060015riordan" visited={visitedNotes.has("060015riordan")} annotationSelect={() => {openNote("060015riordan"); addToVisited("060015riordan")}} activeAnnotationId={currentNoteId}>Mrs Riordan</Annotation>
-      that he thought he had a great leg of and she <Annotation annotationId="010019money" visited={visitedNotes.has("010019money")} annotationSelect={() => {openNote("010019money"); addToVisited("010019money")}} activeAnnotationId={currentNoteId}>never left us a farthing</Annotation>
+      highness to make himself interesting for that old faggot <Annotation annotationId="060015riordan">Mrs Riordan</Annotation>
+      that he thought he had a great leg of and she <Annotation annotationId="010019money">never left us a farthing</Annotation>
       all for masses for herself and her soul greatest miser ever was actually
       afraid to lay out 4d for her methylated spirit telling me all her
       ailments she had too much old chat in her about politics and earthquakes
@@ -22,16 +22,16 @@ const Penelope = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       she <span data-edition="ed1932" data-page="640"></span>didnt want us to cover our faces but she was a welleducated woman
       certainly and her gabby talk about Mr Riordan here and Mr Riordan there
       I suppose he was glad to get shut of her and her dog smelling my fur and
-      always edging to get up under my petticoats especially then <Annotation annotationId="080008parallax" visited={visitedNotes.has("080008parallax")} annotationSelect={() => {openNote("080008parallax"); addToVisited("080008parallax")}} activeAnnotationId={currentNoteId}>still I like
+      always edging to get up under my petticoats especially then <Annotation annotationId="080008parallax">still I like
       that in him</Annotation> polite to old women like that and waiters and beggars too
       hes not proud out of nothing but not always if ever he got anything
       really serious the matter with him its much better for them to go into
       a hospital where everything is clean but I suppose Id have to dring it
       into him for a month yes and then wed have a hospital nurse next thing
       on the carpet have him staying there till they throw him out or a nun
-      maybe like <Annotation annotationId="010127photogirl" visited={visitedNotes.has("010127photogirl")} annotationSelect={() => {openNote("010127photogirl"); addToVisited("010127photogirl")}} activeAnnotationId={currentNoteId}>the smutty photo he has</Annotation> shes as much a nun as Im not yes
+      maybe like <Annotation annotationId="010127photogirl">the smutty photo he has</Annotation> shes as much a nun as Im not yes
       because theyre so weak and puling when theyre sick they want a woman
-      to get well <Annotation annotationId="040040bluebottle" visited={visitedNotes.has("040040bluebottle")} annotationSelect={() => {openNote("040040bluebottle"); addToVisited("040040bluebottle")}} activeAnnotationId={currentNoteId}>if his nose bleeds youd think it was O tragic</Annotation> and that
+      to get well <Annotation annotationId="040040bluebottle">if his nose bleeds youd think it was O tragic</Annotation> and that
       dyinglooking one off the south circular when he sprained his foot at
       the choir party at the sugarloaf Mountain the day I wore that dress
       Miss Stack bringing him flowers the worst old ones she could find at the
@@ -49,7 +49,7 @@ const Penelope = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       night women if it was <span data-edition="ed1961" data-page="738"></span>down there he was really and the hotel story he
       made up a pack of lies to hide it planning it Hynes kept me who did I
       meet ah yes I met do you remember Menton and who else who let me see
-      <Annotation annotationId="170008precedingseries" visited={visitedNotes.has("170008precedingseries")} annotationSelect={() => {openNote("170008precedingseries"); addToVisited("170008precedingseries")}} activeAnnotationId={currentNoteId}>that big babbyface I saw him and he not long married flirting with a
+      <Annotation annotationId="170008precedingseries">that big babbyface I saw him and he not long married flirting with a
       young girl</Annotation> at Pooles Myriorama and turned my back on him when 
       <span data-edition="ed1939" data-page="521"> </span>
       he slinked
@@ -96,7 +96,7 @@ const Penelope = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       great squeeze going along by the Tolka in my hand there steals another
       I just pressed the back of his like that with my thumb to squeeze back
       singing the young May moon shes beaming love <span data-edition="ed1986" data-page="609"></span>because he has an idea
-      about him and me hes not such a fool <Annotation annotationId="110002atfourshe" visited={visitedNotes.has("110002atfourshe")} annotationSelect={() => {openNote("110002atfourshe"); addToVisited("110002atfourshe")}} activeAnnotationId={currentNoteId}>he said Im dining out and going to
+      about him and me hes not such a fool <Annotation annotationId="110002atfourshe">he said Im dining out and going to
       the Gaiety</Annotation> though Im not going to give him the satisfaction in any case
       God knows hes a change in a way not to be always and ever wearing the
       same old hat unless I paid some nicelooking boy to do it since I cant do
@@ -118,7 +118,7 @@ const Penelope = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       age of his life simply ruination for any woman and no satisfaction in it
       pretending to like it till he comes and then finish it off myself anyway
       and it makes your lips pale anyhow its done now once and for all with
-      all the talk of the world about it people make <Annotation annotationId="180006lordbyron" visited={visitedNotes.has("180006lordbyron")} annotationSelect={() => {openNote("180006lordbyron"); addToVisited("180006lordbyron")}} activeAnnotationId={currentNoteId}>its only the first time
+      all the talk of the world about it people make <Annotation annotationId="180006lordbyron">its only the first time
       after that its just the ordinary do it and think no more about it</Annotation> why
       cant you kiss a man without going and marrying him first you sometimes
       love to wildly when you feel that way so nice all 
@@ -127,7 +127,7 @@ const Penelope = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       yourself I wish some man or other would take me sometime when hes there
       and kiss me in his arms theres nothing like a kiss long and hot down to
       your soul <span data-edition="ed1961" data-page="740"></span>almost paralyses you then I hate that confession when I used
-      to go to <Annotation annotationId="170008precedingseries" visited={visitedNotes.has("170008precedingseries")} annotationSelect={() => {openNote("170008precedingseries"); addToVisited("170008precedingseries")}} activeAnnotationId={currentNoteId}>Father Corrigan he touched me father</Annotation> and what harm if he did
+      to go to <Annotation annotationId="170008precedingseries">Father Corrigan he touched me father</Annotation> and what harm if he did
       where and I said on the canal bank like a fool but whereabouts on your
       person my child on the leg behind high up was it yes rather high up was
       it where you sit down yes O Lord couldnt he say bottom right out and
@@ -173,7 +173,7 @@ const Penelope = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       call it was going to burst though his nose is not so big after I took
       off all my things with the blinds down after my hours dressing and
       perfuming and combing it like iron or some kind of a thick crowbar
-      standing all the time <Annotation annotationId="060020redbank" visited={visitedNotes.has("060020redbank")} annotationSelect={() => {openNote("060020redbank"); addToVisited("060020redbank")}} activeAnnotationId={currentNoteId}>he must have eaten oysters</Annotation> I think a few dozen <Annotation annotationId="080030cenarteco" visited={visitedNotes.has("080030cenarteco")} annotationSelect={() => {openNote("080030cenarteco"); addToVisited("080030cenarteco")}} activeAnnotationId={currentNoteId}>he
+      standing all the time <Annotation annotationId="060020redbank">he must have eaten oysters</Annotation> I think a few dozen <Annotation annotationId="080030cenarteco">he
       was in great singing voice no I never in all my life felt anyone had
       one the size of that to make you feel full up he must have eaten a whole
       sheep after</Annotation> whats the idea making us like that with a big hole in the
@@ -213,7 +213,7 @@ const Penelope = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       <span data-edition="ed1922" data-page="694"></span>
       because he
       used to be a bit on the jealous side whenever he asked who are you going
-      to and I said over to Floey and he made me the present of <Annotation annotationId="180006lordbyron" visited={visitedNotes.has("180006lordbyron")} annotationSelect={() => {openNote("180006lordbyron"); addToVisited("180006lordbyron")}} activeAnnotationId={currentNoteId}>Byrons poems</Annotation>
+      to and I said over to Floey and he made me the present of <Annotation annotationId="180006lordbyron">Byrons poems</Annotation>
       and the three pairs of gloves so that finished that I could quite easily
       get him to make it up any time I know how Id even supposing he got in
       with her again and was going out to see her somewhere Id know if he
@@ -240,7 +240,7 @@ const Penelope = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       thick when hes there they know by his sly eye blinking a bit putting on
       the indifferent when they come out with something the kind he is what
       spoils him I dont wonder in the least because he was very handsome at
-      that time <Annotation annotationId="180006lordbyron" visited={visitedNotes.has("180006lordbyron")} annotationSelect={() => {openNote("180006lordbyron"); addToVisited("180006lordbyron")}} activeAnnotationId={currentNoteId}>trying to look like lord Byron I said I liked though he
+      that time <Annotation annotationId="180006lordbyron">trying to look like lord Byron I said I liked though he
       was too beautiful for a man</Annotation> and he was a little before we got engaged
       afterwards though she didnt like it so much the day I was in fits of
       laughing with the giggles I couldnt stop <span data-edition="ed1961" data-page="743"></span>about all my hairpins falling
@@ -261,7 +261,7 @@ const Penelope = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       any moment what a man well its not the one way everyone goes mad Poldy
       anyhow whatever he does always wipes his feet on the mat when he comes
       in wet or shine and always blacks his own boots too and he always takes
-      off his hat when he comes up in the street like then and now hes <Annotation annotationId="080010upup" visited={visitedNotes.has("080010upup")} annotationSelect={() => {openNote("080010upup"); addToVisited("080010upup")}} activeAnnotationId={currentNoteId}>going
+      off his hat when he comes up in the street like then and now hes <Annotation annotationId="080010upup">going
       about in his slippers to look for £10000 for a postcard up up</Annotation>
       O Sweetheart May wouldnt a thing like that simply bore you stiff to
       extinction actually too stupid even to take his boots off now what
@@ -292,7 +292,7 @@ const Penelope = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         he made me buy takes you half an hour to let them down wetting all
         myself always with some brandnew fad every other week such a long one I
         did I forgot my suede gloves on the seat behind that I never got after
-        some robber of a woman and he wanted me to put it in the <Annotation annotationId="080012irishtimes" visited={visitedNotes.has("080012irishtimes")} annotationSelect={() => {openNote("080012irishtimes"); addToVisited("080012irishtimes")}} activeAnnotationId={currentNoteId}>Irish times</Annotation>
+        some robber of a woman and he wanted me to put it in the <Annotation annotationId="080012irishtimes">Irish times</Annotation>
         lost in the ladies lavatory D B C Dame street 
         <span data-edition="ed1922" data-page="696"></span>
         finder return to Mrs
@@ -303,10 +303,10 @@ const Penelope = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         that are too tight to walk in <span data-edition="ed1986" data-page="613"></span>my hand is nice like that if I only had a
         ring with the stone for my month a nice aquamarine Ill stick him for one
         and a gold bracelet I dont like my foot so much still I made him spend
-        once with my foot the night after <Annotation annotationId="040092professorgoodwin" visited={visitedNotes.has("040092professorgoodwin")} annotationSelect={() => {openNote("040092professorgoodwin"); addToVisited("040092professorgoodwin")}} activeAnnotationId={currentNoteId}>Goodwins botchup of a concert</Annotation> so cold
+        once with my foot the night after <Annotation annotationId="040092professorgoodwin">Goodwins botchup of a concert</Annotation> so cold
         and windy it was well we had that rum in the house to mull and the fire
         wasnt black out when he asked to take off my stockings lying on the
-        hearthrug in <Annotation annotationId="040049pleasantoldtimes" visited={visitedNotes.has("040049pleasantoldtimes")} annotationSelect={() => {openNote("040049pleasantoldtimes"); addToVisited("040049pleasantoldtimes")}} activeAnnotationId={currentNoteId}>Lombard street west</Annotation> and another time it was my muddy boots
+        hearthrug in <Annotation annotationId="040049pleasantoldtimes">Lombard street west</Annotation> and another time it was my muddy boots
         hed like me to walk in all the horses dung I could find but of course
         hes not natural like the rest of the world that I what did he say I
         could give 9 points in 10 to Katty Lanner and beat her what does that
@@ -314,7 +314,7 @@ const Penelope = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         just passed and the man with the curly hair in the Lucan dairy thats so
         polite I think I saw his face before somewhere I noticed him when I was
         tasting the butter so I took my time Bartell dArcy too that he used to
-        make fun of when <Annotation annotationId="170008precedingseries" visited={visitedNotes.has("170008precedingseries")} annotationSelect={() => {openNote("170008precedingseries"); addToVisited("170008precedingseries")}} activeAnnotationId={currentNoteId}>he commenced kissing me on the choir stairs</Annotation> after I
+        make fun of when <Annotation annotationId="170008precedingseries">he commenced kissing me on the choir stairs</Annotation> after I
         sang Gounods <i>Ave Maria</i> what are we waiting for O my heart kiss me
         straight on the brow and part which is my brown part he was pretty hot
         for all his tinny voice too my low notes he was always raving about if
@@ -339,7 +339,7 @@ const Penelope = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         sun so he could see every atom she had on when he saw me
         from behind following in the rain I saw him before he saw me however
         standing at the corner of the Harolds cross road with a new raincoat on
-        him with the muffler <Annotation annotationId="050041cricket" visited={visitedNotes.has("050041cricket")} annotationSelect={() => {openNote("050041cricket"); addToVisited("050041cricket")}} activeAnnotationId={currentNoteId}>in the Zingari colours</Annotation> to show off his complexion
+        him with the muffler <Annotation annotationId="050041cricket">in the Zingari colours</Annotation> to show off his complexion
         and the brown hat looking slyboots 
         <span data-edition="ed1939" data-page="526"> </span>
         as usual what was he doing there
@@ -365,10 +365,10 @@ const Penelope = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         to do everything too quick take all the pleasure out of it and father
         waiting all the <span data-edition="ed1932" data-page="648"></span>time for his dinner he told me to say I left my purse in
         the butchers and had to go back for it what a Deceiver then he <span data-edition="ed1961" data-page="746"></span>wrote me
-        <Annotation annotationId="050003otherworld" visited={visitedNotes.has("050003otherworld")} annotationSelect={() => {openNote("050003otherworld"); addToVisited("050003otherworld")}} activeAnnotationId={currentNoteId}>that letter with all those words in it</Annotation> how could he have the face to any
+        <Annotation annotationId="050003otherworld">that letter with all those words in it</Annotation> how could he have the face to any
         woman after his company manners making it so awkward after when we met
         asking me have I offended you with my eyelids down of course he saw I
-        wasnt he had a few brains not like that other fool <Annotation annotationId="040041dolphinsbarn" visited={visitedNotes.has("040041dolphinsbarn")} annotationSelect={() => {openNote("040041dolphinsbarn"); addToVisited("040041dolphinsbarn")}} activeAnnotationId={currentNoteId}>Henny Doyle</Annotation> he was
+        wasnt he had a few brains not like that other fool <Annotation annotationId="040041dolphinsbarn">Henny Doyle</Annotation> he was
         always breaking or tearing something in the charades I hate an unlucky
         man and if I knew what it meant of course I had to say no for form sake
         dont understand you I said and wasnt it natural so it is of course
@@ -379,12 +379,12 @@ const Penelope = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         when he sent me the 8 big poppies because mine 
         <span data-edition="ed1922" data-page="698"></span>
         was the 8th then I wrote
-        the night he kissed my heart <Annotation annotationId="040041dolphinsbarn" visited={visitedNotes.has("040041dolphinsbarn")} annotationSelect={() => {openNote("040041dolphinsbarn"); addToVisited("040041dolphinsbarn")}} activeAnnotationId={currentNoteId}>at Dolphins barn</Annotation> I couldnt describe it
+        the night he kissed my heart <Annotation annotationId="040041dolphinsbarn">at Dolphins barn</Annotation> I couldnt describe it
         simply it makes you feel like nothing on earth but he never knew how to
         embrace well like Gardner I hope hell come on Monday as he said at the
         same time four I hate people who come at all hours answer the door you
         think its the vegetables then its somebody and you all undressed or
-        the door of the filthy sloppy kitchen blows open the day <Annotation annotationId="170008precedingseries" visited={visitedNotes.has("170008precedingseries")} annotationSelect={() => {openNote("170008precedingseries"); addToVisited("170008precedingseries")}} activeAnnotationId={currentNoteId}>old frostyface
+        the door of the filthy sloppy kitchen blows open the day <Annotation annotationId="170008precedingseries">old frostyface
         Goodwin</Annotation> called about the concert in Lombard street and I just after
         dinner all flushed and tossed with boiling old stew dont look at me
         professor I had to say Im a fright yes but he was a real old gent in his
@@ -432,22 +432,22 @@ const Penelope = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         with him that gets you on on the stage the last concert I sang at where
         its over a year ago when was it St Teresas hall Clarendon St little
         chits of missies they have now singing Kathleen Kearney and her like
-        on account of father being in the army and my singing <Annotation annotationId="090001absentminded" visited={visitedNotes.has("090001absentminded")} annotationSelect={() => {openNote("090001absentminded"); addToVisited("090001absentminded")}} activeAnnotationId={currentNoteId}>the absentminded
+        on account of father being in the army and my singing <Annotation annotationId="090001absentminded">the absentminded
         beggar</Annotation> and wearing a brooch for Lord Roberts when I had the map of it
         all and Poldy not Irish enough was it him managed it this time I wouldnt
         put it past him like he got me on to sing in the <i>Stabat Mater</i> by going
-        around saying he was putting <Annotation annotationId="040068kindlylight" visited={visitedNotes.has("040068kindlylight")} annotationSelect={() => {openNote("040068kindlylight"); addToVisited("040068kindlylight")}} activeAnnotationId={currentNoteId}>Lead Kindly Light</Annotation> to music I put him up to
-        that till the <Annotation annotationId="010008jesuit" visited={visitedNotes.has("010008jesuit")} annotationSelect={() => {openNote("010008jesuit"); addToVisited("010008jesuit")}} activeAnnotationId={currentNoteId}>jesuits</Annotation> found out he was a freemason thumping the piano
+        around saying he was putting <Annotation annotationId="040068kindlylight">Lead Kindly Light</Annotation> to music I put him up to
+        that till the <Annotation annotationId="010008jesuit">jesuits</Annotation> found out he was a freemason thumping the piano
         lead Thou me on copied from some old opera yes and he was going about
         with some of them Sinner Fein lately or whatever they call themselves
-        talking his usual trash and nonsense he says <Annotation annotationId="030037griffith" visited={visitedNotes.has("030037griffith")} annotationSelect={() => {openNote("030037griffith"); addToVisited("030037griffith")}} activeAnnotationId={currentNoteId}>that little man he showed
+        talking his usual trash and nonsense he says <Annotation annotationId="030037griffith">that little man he showed
         me without the neck is very intelligent the coming man Griffith is he</Annotation>
         well he doesnt look it thats all I can say still it must have been him
         he knew there was a boycott I hate the mention of their politics after
-        the war that Pretoria and Ladysmith and Bloemfontein where <span data-edition="ed1961" data-page="748"></span><Annotation annotationId="010058bloodyswindle" visited={visitedNotes.has("010058bloodyswindle")} annotationSelect={() => {openNote("010058bloodyswindle"); addToVisited("010058bloodyswindle")}} activeAnnotationId={currentNoteId}>Gardner Lieut
-        Stanley G 8th Bn 2nd East Lancs Rgt of enteric fever</Annotation><Annotation annotationId="010058bloodyswindle" visited={visitedNotes.has("010058bloodyswindle")} annotationSelect={() => {openNote("010058bloodyswindle"); addToVisited("010058bloodyswindle")}} activeAnnotationId={currentNoteId}> he was a lovely
+        the war that Pretoria and Ladysmith and Bloemfontein where <span data-edition="ed1961" data-page="748"></span><Annotation annotationId="010058bloodyswindle">Gardner Lieut
+        Stanley G 8th Bn 2nd East Lancs Rgt of enteric fever</Annotation><Annotation annotationId="010058bloodyswindle"> he was a lovely
         fellow in khaki and just the right height over me Im sure he was brave
-        too he said I was lovely the evening we kissed goodbye </Annotation><Annotation annotationId="060016canals" visited={visitedNotes.has("060016canals")} annotationSelect={() => {openNote("060016canals"); addToVisited("060016canals")}} activeAnnotationId={currentNoteId}>at the canal lock</Annotation>
+        too he said I was lovely the evening we kissed goodbye </Annotation><Annotation annotationId="060016canals">at the canal lock</Annotation>
         my Irish beauty he was pale with excitement about going <span data-edition="ed1932" data-page="650"></span>away or wed be
         seen from the road he couldnt stand properly and I so hot as I never
         felt they could have made their peace in the beginning or old oom Paul
@@ -462,7 +462,7 @@ const Penelope = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         battles on the 15 acres the Black Watch with their kilts in time at the
         march past the 10th hussars the prince of Wales own or the lancers O the
         lancers theyre grand or the Dublins that won Tugela his father made his
-        money over <Annotation annotationId="010058bloodyswindle" visited={visitedNotes.has("010058bloodyswindle")} annotationSelect={() => {openNote("010058bloodyswindle"); addToVisited("010058bloodyswindle")}} activeAnnotationId={currentNoteId}>selling the horses for the cavalry</Annotation> well he could buy me a
+        money over <Annotation annotationId="010058bloodyswindle">selling the horses for the cavalry</Annotation> well he could buy me a
         nice present up in Belfast after what I gave him theyve 
         <span data-edition="ed1922" data-page="700"></span>
         lovely linen up
@@ -478,7 +478,7 @@ const Penelope = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         close in the handglass powdering a mirror never gives you the expression
         besides scrooching down on me like that all the time with his big
         hipbones hes heavy too with his hairy chest for this heat always having
-        to lie down for them better for him put it into me from behind <Annotation annotationId="170008precedingseries" visited={visitedNotes.has("170008precedingseries")} annotationSelect={() => {openNote("170008precedingseries"); addToVisited("170008precedingseries")}} activeAnnotationId={currentNoteId}>the way
+        to lie down for them better for him put it into me from behind <Annotation annotationId="170008precedingseries">the way
         Mrs Mastiansky told me her husband made her</Annotation> like the dogs do it and
         stick out her tongue as far as ever she could and he so quiet and mild
         with his tingating cither can you ever be up to men the way it takes
@@ -488,9 +488,9 @@ const Penelope = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         devil for a few minutes after he came back with the stoppress tearing up
         the <span data-edition="ed1961" data-page="749"></span>tickets and swearing blazes because he lost 20 quid he said he lost
         over that outsider that won and half he put on for me on account of
-        Lenehans tip cursing him to the lowest pits <Annotation annotationId="170008precedingseries" visited={visitedNotes.has("170008precedingseries")} annotationSelect={() => {openNote("170008precedingseries"); addToVisited("170008precedingseries")}} activeAnnotationId={currentNoteId}>that sponger he was making
+        Lenehans tip cursing him to the lowest pits <Annotation annotationId="170008precedingseries">that sponger he was making
         free with me</Annotation> after the Glencree dinner coming back that long joult over
-        <Annotation annotationId="010010mountains" visited={visitedNotes.has("010010mountains")} annotationSelect={() => {openNote("010010mountains"); addToVisited("010010mountains")}} activeAnnotationId={currentNoteId}>the featherbed mountain</Annotation> after <Annotation annotationId="060033corporation" visited={visitedNotes.has("060033corporation")} annotationSelect={() => {openNote("060033corporation"); addToVisited("060033corporation")}} activeAnnotationId={currentNoteId}>the lord Mayor</Annotation> <Annotation annotationId="170008precedingseries" visited={visitedNotes.has("170008precedingseries")} annotationSelect={() => {openNote("170008precedingseries"); addToVisited("170008precedingseries")}} activeAnnotationId={currentNoteId}>looking at me with his
+        <Annotation annotationId="010010mountains">the featherbed mountain</Annotation> after <Annotation annotationId="060033corporation">the lord Mayor</Annotation> <Annotation annotationId="170008precedingseries">looking at me with his
         dirty eyes Val Dillon that big heathen</Annotation> I first noticed him at dessert
         when I was cracking the nuts with my teeth I wished I could have picked
         every <span data-edition="ed1932" data-page="651"></span>morsel of that chicken out of my fingers it was so tasty
@@ -524,7 +524,7 @@ const Penelope = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         bottle of hogwash he tried to palm off as claret that he couldnt get
         anyone to drink God spare his spit for fear hed die of the drouth or
         I must do a few breathing exercises I wonder is that antifat any good
-        might overdo it the thin ones are not so much the fashion now <Annotation annotationId="020080mauve" visited={visitedNotes.has("020080mauve")} annotationSelect={() => {openNote("020080mauve"); addToVisited("020080mauve")}} activeAnnotationId={currentNoteId}>garters
+        might overdo it the thin ones are not so much the fashion now <Annotation annotationId="020080mauve">garters
         that much I have the violet pair I wore today</Annotation> thats all he bought me
         out of the cheque he got on the first O no there was the face lotion
         I finished the last of yesterday that made <span data-edition="ed1961" data-page="750"></span>my skin like new I told him
@@ -538,7 +538,7 @@ const Penelope = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         sure you cant get on in this world without style all going in food and
         rent when I get it Ill lash it around I tell you in fine style I always
         want to throw a handful of tea into the pot <span data-edition="ed1932" data-page="652"></span>measuring and mincing if
-        I buy a pair of old <Annotation annotationId="020076brogues" visited={visitedNotes.has("020076brogues")} annotationSelect={() => {openNote("020076brogues"); addToVisited("020076brogues")}} activeAnnotationId={currentNoteId}>brogues</Annotation> itself do you like those new shoes yes how
+        I buy a pair of old <Annotation annotationId="020076brogues">brogues</Annotation> itself do you like those new shoes yes how
         much were they Ive no clothes at all the brown costume and the skirt and
         jacket and the one at the cleaners 3 whats that for any woman cutting
         up this old hat and patching up the other the men wont look at you and
@@ -583,8 +583,8 @@ const Penelope = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         the money all the day of course he prefers plottering <span data-edition="ed1932" data-page="653"></span>about the house
         so you cant stir with him any side whats your programme today I wish hed
         even smoke a pipe like father to get the smell of a man or pretending
-        to be mooching about for advertisements when <Annotation annotationId="040037cattlemarket" visited={visitedNotes.has("040037cattlemarket")} annotationSelect={() => {openNote("040037cattlemarket"); addToVisited("040037cattlemarket")}} activeAnnotationId={currentNoteId}>he could have been in Mr
-        Cuffes still only for what he did</Annotation> <Annotation annotationId="170008precedingseries" visited={visitedNotes.has("170008precedingseries")} annotationSelect={() => {openNote("170008precedingseries"); addToVisited("170008precedingseries")}} activeAnnotationId={currentNoteId}>then sending me to try and patch it up</Annotation>
+        to be mooching about for advertisements when <Annotation annotationId="040037cattlemarket">he could have been in Mr
+        Cuffes still only for what he did</Annotation> <Annotation annotationId="170008precedingseries">then sending me to try and patch it up</Annotation>
         I could have got him promoted there to be the manager he gave me a great
         mirada once or twice first he was as stiff as the mischief really and
         truly Mrs Bloom only I felt rotten simply with the old rubbishy dress
@@ -614,12 +614,12 @@ const Penelope = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <p>
         yes I think he made them a bit firmer sucking them like that so long he
-        made me thirsty <Annotation annotationId="040019titbits" visited={visitedNotes.has("040019titbits")} annotationSelect={() => {openNote("040019titbits"); addToVisited("040019titbits")}} activeAnnotationId={currentNoteId}>titties he calls them</Annotation> I had to laugh yes this one anyhow
+        made me thirsty <Annotation annotationId="040019titbits">titties he calls them</Annotation> I had to laugh yes this one anyhow
         stiff the nipple gets for the least thing Ill get him to keep that up
         and Ill take those eggs beaten up with marsala fatten them out for him
         what are all those veins and things curious the way its made 2 the same
         in case of twins theyre supposed to represent beauty placed up there
-        <Annotation annotationId="080005venus" visited={visitedNotes.has("080005venus")} annotationSelect={() => {openNote("080005venus"); addToVisited("080005venus")}} activeAnnotationId={currentNoteId}>like those statues in the museum</Annotation> one of them pretending to hide it with
+        <Annotation annotationId="080005venus">like those statues in the museum</Annotation> one of them pretending to hide it with
         her hand are they so beautiful of course compared with what a man looks
         like with his two bags full and his other thing hanging down out of
         him or sticking up at you like a hatrack no wonder they hide it with a
@@ -627,7 +627,7 @@ const Penelope = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         woman is beauty of course thats admitted when <span data-edition="ed1932" data-page="654"></span>he said I could pose for a
         picture naked to some rich fellow in Holles street when he lost the
         job in Helys and I was selling the clothes and strumming in the coffee
-        palace <Annotation annotationId="040048slimmer" visited={visitedNotes.has("040048slimmer")} annotationSelect={() => {openNote("040048slimmer"); addToVisited("040048slimmer")}} activeAnnotationId={currentNoteId}>would I be like that bath of the nymph with my hair down yes only
+        palace <Annotation annotationId="040048slimmer">would I be like that bath of the nymph with my hair down yes only
         shes younger</Annotation> or Im a little like that dirty bitch in that Spanish photo
         he has nymphs used they go about like that I asked him that disgusting Cameron highlander behind the meat market or
         that other wretch with the red head behind the tree where the statue
@@ -638,27 +638,27 @@ const Penelope = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         they were a nice lot its well the Surreys relieved them
         <span data-edition="ed1939" data-page="531"> </span>
         theyre always trying to show it to you every time nearly I passed
-        outside <Annotation annotationId="080027greenhouses" visited={visitedNotes.has("080027greenhouses")} annotationSelect={() => {openNote("080027greenhouses"); addToVisited("080027greenhouses")}} activeAnnotationId={currentNoteId}>the mens greenhouse</Annotation> near the Harcourt street station just to
+        outside <Annotation annotationId="080027greenhouses">the mens greenhouse</Annotation> near the Harcourt street station just to
         try some fellow or other trying to catch my eye as if it was 1 of the
         7 wonders of the world O and the stink of those rotten places the night
         coming home with Poldy after the Comerfords party oranges and lemonade
         to make you feel nice and watery I went into 1 of them it was so biting
-        cold I couldnt keep it when was that 93 <Annotation annotationId="060016canals" visited={visitedNotes.has("060016canals")} annotationSelect={() => {openNote("060016canals"); addToVisited("060016canals")}} activeAnnotationId={currentNoteId}>the canal was frozen</Annotation> yes it was
+        cold I couldnt keep it when was that 93 <Annotation annotationId="060016canals">the canal was frozen</Annotation> yes it was
         a few months after a pity a couple of the Camerons werent there to see
         me squatting in the mens place meadero I tried to draw a picture of
         it before I tore it up like a sausage or something I wonder theyre not
         afraid going about of getting a kick or a bang of something there and
         that word <span data-edition="ed1961" data-page="753"></span>met something with hoses in it and he came out with some
-        jawbreakers about the incarnation he never can explain a thing simply <Annotation annotationId="180001bodycanunderstand" visited={visitedNotes.has("180001bodycanunderstand")} annotationSelect={() => {openNote("180001bodycanunderstand"); addToVisited("180001bodycanunderstand")}} activeAnnotationId={currentNoteId}>the way a body can understand</Annotation> then he goes and burns the bottom out of
+        jawbreakers about the incarnation he never can explain a thing simply <Annotation annotationId="180001bodycanunderstand">the way a body can understand</Annotation> then he goes and burns the bottom out of
         the pan all for his Kidney this one not so much theres the mark of his
         teeth still where he tried to bite the nipple I had to scream out arent
         they fearful trying to hurt you I had a great breast of milk with Milly
         enough for two what was the reason of that he said I could have got a
         pound a week as a wet nurse all swelled out the morning that delicate
-        looking student that stopped in n° 28 with the Citrons <Annotation annotationId="170008precedingseries" visited={visitedNotes.has("170008precedingseries")} annotationSelect={() => {openNote("170008precedingseries"); addToVisited("170008precedingseries")}} activeAnnotationId={currentNoteId}>Penrose nearly
+        looking student that stopped in n° 28 with the Citrons <Annotation annotationId="170008precedingseries">Penrose nearly
         caught me washing through the window</Annotation> only for I snapped up the towel to
         my face that was his studenting hurt me they used to weaning her till he
-        got <span data-edition="ed1986" data-page="620"></span><Annotation annotationId="170008precedingseries" visited={visitedNotes.has("170008precedingseries")} annotationSelect={() => {openNote("170008precedingseries"); addToVisited("170008precedingseries")}} activeAnnotationId={currentNoteId}>doctor Brady</Annotation> to give me the belladonna prescription I had to get him
+        got <span data-edition="ed1986" data-page="620"></span><Annotation annotationId="170008precedingseries">doctor Brady</Annotation> to give me the belladonna prescription I had to get him
         to suck them they were so hard he said it was sweeter and thicker than
         cows then he wanted to milk me into the tea well hes beyond everything I
         declare somebody ought to put him in the budget if I only could remember
@@ -684,10 +684,10 @@ const Penelope = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       <p>
         frseeeeeeeefronnnng train somewhere whistling the strength those engines
         have in them like big giants and the water rolling all over and out of
-        them all sides like the end of <Annotation annotationId="040035oldsweetsong" visited={visitedNotes.has("040035oldsweetsong")} annotationSelect={() => {openNote("040035oldsweetsong"); addToVisited("040035oldsweetsong")}} activeAnnotationId={currentNoteId}>Loves old sweeeetsonnnng</Annotation> the poor men
+        them all sides like the end of <Annotation annotationId="040035oldsweetsong">Loves old sweeeetsonnnng</Annotation> the poor men
         that have to be out all the night from their wives and families in those
         roasting engines stifling it was today Im glad I burned the half of
-        those old Freemans <span data-edition="ed1961" data-page="754"></span>and <Annotation annotationId="040034photobits" visited={visitedNotes.has("040034photobits")} annotationSelect={() => {openNote("040034photobits"); addToVisited("040034photobits")}} activeAnnotationId={currentNoteId}>Photo Bits</Annotation> leaving things like that lying about
+        those old Freemans <span data-edition="ed1961" data-page="754"></span>and <Annotation annotationId="040034photobits">Photo Bits</Annotation> leaving things like that lying about
         hes getting very careless and threw the rest of them up in the W C Ill
         get him to cut them tomorrow for me instead of having them there for
         the next year to get a few pence for them have him asking wheres last
@@ -775,7 +775,7 @@ const Penelope = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         waiting always waiting to guiiiide him toooo me waiting nor speeeed
         his flying feet their damn guns bursting and booming all over the shop
         especially the Queens birthday and throwing everything down in all
-        directions if you didnt open the windows when <Annotation annotationId="180004ulyssesgrant" visited={visitedNotes.has("180004ulyssesgrant")} annotationSelect={() => {openNote("180004ulyssesgrant"); addToVisited("180004ulyssesgrant")}} activeAnnotationId={currentNoteId}>general Ulysses Grant</Annotation>
+        directions if you didnt open the windows when <Annotation annotationId="180004ulyssesgrant">general Ulysses Grant</Annotation>
         whoever he was or did supposed to be some great fellow landed off the
         ship and old Sprague the consul that was there from before the flood
         dressed up poor man and he in mourning for the son then the same old
@@ -808,7 +808,7 @@ const Penelope = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         recognise me either when I half frowned at him outside Westland row
         chapel where does their great intelligence come in Id like to <span data-edition="ed1961" data-page="757"></span>know
         grey matter they have it all in their tail if you ask me those country
-        <span data-edition="ed1986" data-page="623"></span>gougers up in the <Annotation annotationId="020066cityarms" visited={visitedNotes.has("020066cityarms")} annotationSelect={() => {openNote("020066cityarms"); addToVisited("020066cityarms")}} activeAnnotationId={currentNoteId}>City Arms</Annotation> 
+        <span data-edition="ed1986" data-page="623"></span>gougers up in the <Annotation annotationId="020066cityarms">City Arms</Annotation> 
         <span data-edition="ed1939" data-page="534"> </span>
         intelligence they had a damn sight less than
         the bulls and cows they were selling the meat and the coalmans bell that
@@ -824,7 +824,7 @@ const Penelope = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         believe all I hear with a villa and eight rooms her father was an
         awfully nice man he was near seventy always goodhumoured well now Miss
         Tweedy or Miss Gillespie theres the pyannyer that was a solid silver
-        coffee service he had too on the mahogany <Annotation annotationId="020027sideboard" visited={visitedNotes.has("020027sideboard")} annotationSelect={() => {openNote("020027sideboard"); addToVisited("020027sideboard")}} activeAnnotationId={currentNoteId}>sideboard</Annotation> then dying so far
+        coffee service he had too on the mahogany <Annotation annotationId="020027sideboard">sideboard</Annotation> then dying so far
         away I hate people that have always their poor story to tell everybody
         has their own troubles that poor Nancy Blake died a month ago of acute
         pneumonia well I didnt know her so well as all that she was Floeys friend
@@ -840,7 +840,7 @@ const Penelope = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         believe love is sighing I am dying still if he wrote it I suppose thered
         be some truth in it true or no it fills up your whole day <span data-edition="ed1932" data-page="659"></span>and life
         always something to think about every moment and see it all round you
-        <Annotation annotationId="050003otherworld" visited={visitedNotes.has("050003otherworld")} annotationSelect={() => {openNote("050003otherworld"); addToVisited("050003otherworld")}} activeAnnotationId={currentNoteId}>like a new world</Annotation> I could write the answer in bed to let him imagine me
+        <Annotation annotationId="050003otherworld">like a new world</Annotation> I could write the answer in bed to let him imagine me
         short just a few words not those long crossed letters Atty Dillon used
         to write to the fellow that was something in the four courts that jilted
         her after out of the ladies letterwriter when I told her to say a few
@@ -874,7 +874,7 @@ const Penelope = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         I saw him following me along the Calle Real in the shop window then
         he tipped me just in passing but I never thought hed write making an
         appointment I had it inside my petticoat bodice all day reading it up
-        in every hole and corner while <Annotation annotationId="040018oldtweedy" visited={visitedNotes.has("040018oldtweedy")} annotationSelect={() => {openNote("040018oldtweedy"); addToVisited("040018oldtweedy")}} activeAnnotationId={currentNoteId}>father was up at the drill instructing</Annotation> to
+        in every hole and corner while <Annotation annotationId="040018oldtweedy">father was up at the drill instructing</Annotation> to
         find out by the handwriting or the language of stamps singing I remember
         shall I wear a white rose and I wanted to put on the old stupid clock to
         near the time he was the first man kissed me under the Moorish wall my
@@ -932,7 +932,7 @@ const Penelope = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         when I got over him that way when I unbuttoned him and took his out and
         drew back the skin it had a <span data-edition="ed1961" data-page="760"></span>kind of eye in it theyre all Buttons men
         down the middle on the wrong side of them Molly darling he called me
-        what was his name Jack Joe <Annotation annotationId="170008precedingseries" visited={visitedNotes.has("170008precedingseries")} annotationSelect={() => {openNote("170008precedingseries"); addToVisited("170008precedingseries")}} activeAnnotationId={currentNoteId}>Harry Mulvey</Annotation> was it yes I think a lieutenant
+        what was his name Jack Joe <Annotation annotationId="170008precedingseries">Harry Mulvey</Annotation> was it yes I think a lieutenant
         he was rather fair he had a laughing kind of a voice so I went round to
         the whatyoucallit everything was whatyoucallit moustache had he he said
         hed come back Lord its just like yesterday to me and if I was married
@@ -960,7 +960,7 @@ const Penelope = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         name Bloom when I used to write it in print to see how it looked on a
         visiting card or practising for the butcher and oblige M Bloom youre
         looking blooming Josie used to say after I married him well its better
-        than Breen or Briggs does brig or <Annotation annotationId="120014cockburn" visited={visitedNotes.has("120014cockburn")} annotationSelect={() => {openNote("120014cockburn"); addToVisited("120014cockburn")}} activeAnnotationId={currentNoteId}>those awful names with bottom in them
+        than Breen or Briggs does brig or <Annotation annotationId="120014cockburn">those awful names with bottom in them
         Mrs Ramsbottom or some other kind of a bottom</Annotation> Mulvey I wouldnt go mad
         <span data-edition="ed1986" data-page="626"></span>about either or suppose I divorced him Mrs Boylan my mother whoever she
         was might have given me a nicer name the Lord knows after the lovely
@@ -999,7 +999,7 @@ const Penelope = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
           no he hadnt a moustache that was Gardner yes 
         I can see his face
         clean shaven Frseeeeeeeeeeeeeeeeeeeefrong that train again weeping tone
-        <Annotation annotationId="040035oldsweetsong" visited={visitedNotes.has("040035oldsweetsong")} annotationSelect={() => {openNote("040035oldsweetsong"); addToVisited("040035oldsweetsong")}} activeAnnotationId={currentNoteId}>once in the dear deaead days beyond recall close my eyes breath my lips
+        <Annotation annotationId="040035oldsweetsong">once in the dear deaead days beyond recall close my eyes breath my lips
         forward kiss sad look eyes open piano ere oer the world the mists began
         I hate that istsbeg comes loves sweet sooooooooooong</Annotation> Ill let that out
         full when I get in front of the footlights again Kathleen Kearney
@@ -1021,7 +1021,7 @@ const Penelope = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         first thats fit to <span data-edition="ed1932" data-page="663"></span>be looked at and a daughter like mine or see if they
         can excite a swell with money that can pick and choose whoever he wants
         like Boylan to do it 4 or 5 times locked in each others arms or the
-        voice either I could have been a prima donna only I married him <Annotation annotationId="040035oldsweetsong" visited={visitedNotes.has("040035oldsweetsong")} annotationSelect={() => {openNote("040035oldsweetsong"); addToVisited("040035oldsweetsong")}} activeAnnotationId={currentNoteId}>comes
+        voice either I could have been a prima donna only I married him <Annotation annotationId="040035oldsweetsong">comes
         looooves old deep down chin back not too much make it double</Annotation> My Ladys
         Bower is too long for an encore about the moated grange at twilight and
         vaunted rooms yes Ill sing Winds that blow from the south that he gave
@@ -1061,7 +1061,7 @@ const Penelope = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         Goodbye <span data-edition="ed1961" data-page="763"></span>to my sleep for this night anyhow I hope hes not going to get in
         with those medicals leading him astray to imagine hes young again coming
         in at 4 in the morning it must be if not more still he had the manners
-        not to wake me what do they find to gabber about all night <Annotation annotationId="050049comehometoma" visited={visitedNotes.has("050049comehometoma")} annotationSelect={() => {openNote("050049comehometoma"); addToVisited("050049comehometoma")}} activeAnnotationId={currentNoteId}>squandering
+        not to wake me what do they find to gabber about all night <Annotation annotationId="050049comehometoma">squandering
         money and getting drunker and drunker couldnt they drink water</Annotation> then he
         starts giving us his orders for eggs and tea and Findon haddy <span data-edition="ed1932" data-page="664"></span>and hot
         buttered toast I suppose well have him sitting up like the king of
@@ -1079,7 +1079,7 @@ const Penelope = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         and apple from the London and Newcastle Williams and Woods goes twice as
         far only for the bones I hate those eels cod yes Ill get a nice piece
         of cod Im always getting enough for 3 forgetting anyway Im sick of that
-        everlasting butchers meat from <Annotation annotationId="040007dorsetstreet" visited={visitedNotes.has("040007dorsetstreet")} annotationSelect={() => {openNote("040007dorsetstreet"); addToVisited("040007dorsetstreet")}} activeAnnotationId={currentNoteId}>Buckleys</Annotation> loin chops and leg beef and rib
+        everlasting butchers meat from <Annotation annotationId="040007dorsetstreet">Buckleys</Annotation> loin chops and leg beef and rib
         steak and scrag of mutton and calfs pluck the very name is enough or
         a picnic suppose we all gave 5/- each and or let him pay it and invite
         some other woman for him who Mrs Fleming and drove out to the furry glen
@@ -1087,9 +1087,9 @@ const Penelope = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         first like he does with the letters no not with Boylan there yes with
         some cold veal and ham mixed sandwiches there are little houses down
         at the bottom of the banks there on purpose but its as hot as blazes he
-        says not a <Annotation annotationId="040029bankholiday" visited={visitedNotes.has("040029bankholiday")} annotationSelect={() => {openNote("040029bankholiday"); addToVisited("040029bankholiday")}} activeAnnotationId={currentNoteId}>bank holiday</Annotation> anyhow I hate those ruck of Mary Ann coalboxes
+        says not a <Annotation annotationId="040029bankholiday">bank holiday</Annotation> anyhow I hate those ruck of Mary Ann coalboxes
         out for the day Whit Monday is a cursed day too no wonder that bee bit
-        him better the seaside but Id never again in this life get into a boat with him after him at <Annotation annotationId="010066brayhead" visited={visitedNotes.has("010066brayhead")} annotationSelect={() => {openNote("010066brayhead"); addToVisited("010066brayhead")}} activeAnnotationId={currentNoteId}>Bray</Annotation> telling the boatman he knew how to row if
+        him better the seaside but Id never again in this life get into a boat with him after him at <Annotation annotationId="010066brayhead">Bray</Annotation> telling the boatman he knew how to row if
         anyone asked could he ride the steeplechase for the gold cup hed say
         yes then it came on to get rough the old thing crookeding about and the
         weight all down my side telling me pull the right reins now pull the
@@ -1099,18 +1099,18 @@ const Penelope = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         his flannel trousers Id like to have tattered them down off him before
         all the people and give him what that one calls flagellate till he was
         black and blue do him all the good in the world only for that longnosed
-        chap I dont know who he is with <Annotation annotationId="170008precedingseries" visited={visitedNotes.has("170008precedingseries")} annotationSelect={() => {openNote("170008precedingseries"); addToVisited("170008precedingseries")}} activeAnnotationId={currentNoteId}>that other beauty Burke</Annotation> out of the <Annotation annotationId="020066cityarms" visited={visitedNotes.has("020066cityarms")} annotationSelect={() => {openNote("020066cityarms"); addToVisited("020066cityarms")}} activeAnnotationId={currentNoteId}>City
+        chap I dont know who he is with <Annotation annotationId="170008precedingseries">that other beauty Burke</Annotation> out of the <Annotation annotationId="020066cityarms">City
         Arms hotel</Annotation> was there spying around as usual on the slip always where he
         wasnt wanted if there was a row on youd vomit a better face there was no
         love lost between us thats 1 consolation I wonder what kind is that book
-        he brought me Sweets of Sin by a gentleman of <span data-edition="ed1932" data-page="665"></span>fashion some other <Annotation annotationId="040003nicename" visited={visitedNotes.has("040003nicename")} annotationSelect={() => {openNote("040003nicename"); addToVisited("040003nicename")}} activeAnnotationId={currentNoteId}>Mr de
-        Kock I suppose the people gave him that nickname</Annotation> going about with <Annotation annotationId="140004anastomosis" visited={visitedNotes.has("140004anastomosis")} annotationSelect={() => {openNote("140004anastomosis"); addToVisited("140004anastomosis")}} activeAnnotationId={currentNoteId}>his
+        he brought me Sweets of Sin by a gentleman of <span data-edition="ed1932" data-page="665"></span>fashion some other <Annotation annotationId="040003nicename">Mr de
+        Kock I suppose the people gave him that nickname</Annotation> going about with <Annotation annotationId="140004anastomosis">his
         tube</Annotation> from one woman to another I couldnt even change my new white shoes
         all ruined 
         <span data-edition="ed1939" data-page="539"> </span>
-        with the saltwater and <Annotation annotationId="010075featherfans" visited={visitedNotes.has("010075featherfans")} annotationSelect={() => {openNote("010075featherfans"); addToVisited("010075featherfans")}} activeAnnotationId={currentNoteId}>the hat I had with that feather all
+        with the saltwater and <Annotation annotationId="010075featherfans">the hat I had with that feather all
         blowy and tossed on me how annoying and provoking</Annotation> because the smell of
-        the sea excited me of course <Annotation annotationId="180008sardines" visited={visitedNotes.has("180008sardines")} annotationSelect={() => {openNote("180008sardines"); addToVisited("180008sardines")}} activeAnnotationId={currentNoteId}>the sardines and the bream in Catalan bay
+        the sea excited me of course <Annotation annotationId="180008sardines">the sardines and the bream in Catalan bay
         round the back of the rock they were fine all silver in the fishermens
         baskets</Annotation> old Luigi near a hundred they said came from Genoa and the tall
         old chap with 
@@ -1155,7 +1155,7 @@ const Penelope = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         against the door just as I was washing myself there below with the glove
         get on your nerves then doing the loglady all day put her in a glasscase
         with two at a time to look at her if he knew she broke off the hand off
-        <Annotation annotationId="080005venus" visited={visitedNotes.has("080005venus")} annotationSelect={() => {openNote("080005venus"); addToVisited("080005venus")}} activeAnnotationId={currentNoteId}>that little gimcrack statue</Annotation> with her roughness and carelessness before
+        <Annotation annotationId="080005venus">that little gimcrack statue</Annotation> with her roughness and carelessness before
         she left that I got that little Italian 
         <span data-edition="ed1922" data-page="716"></span>
         boy to mend so that you cant
@@ -1184,11 +1184,11 @@ const Penelope = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         blackbottom and I had to tell her not to cock her legs up like that on
         show on the windowsill before all the people passing they all look at
         her like me when I was her age of course any old rag looks well on
-        you then a great touchmenot too in her own way at <Annotation annotationId="130003martinharvey" visited={visitedNotes.has("130003martinharvey")} annotationSelect={() => {openNote("130003martinharvey"); addToVisited("130003martinharvey")}} activeAnnotationId={currentNoteId}>the Only Way</Annotation> in <Annotation annotationId="110005theatreroyal" visited={visitedNotes.has("110005theatreroyal")} annotationSelect={() => {openNote("110005theatreroyal"); addToVisited("110005theatreroyal")}} activeAnnotationId={currentNoteId}>the
+        you then a great touchmenot too in her own way at <Annotation annotationId="130003martinharvey">the Only Way</Annotation> in <Annotation annotationId="110005theatreroyal">the
         Theatre royal</Annotation> take your foot away out of that I hate people touching
         me afraid of her life Id crush her skirt with the pleats a lot of that
         touching must go on in theatres in the crush in the dark theyre always
-        trying to wiggle up to you that fellow <Annotation annotationId="060040gaietytheatre" visited={visitedNotes.has("060040gaietytheatre")} annotationSelect={() => {openNote("060040gaietytheatre"); addToVisited("060040gaietytheatre")}} activeAnnotationId={currentNoteId}>in the pit at the Gaiety for
+        trying to wiggle up to you that fellow <Annotation annotationId="060040gaietytheatre">in the pit at the Gaiety for
         Beerbohm Tree</Annotation> in Trilby the last time Ill ever go there to be squashed
         like that for any Trilby or her barebum every two minutes tipping me
         there and looking away hes a bit daft I think I saw him <span data-edition="ed1932" data-page="667"></span>after trying to
@@ -1204,7 +1204,7 @@ const Penelope = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         sealingwax though she clapped 
         <span data-edition="ed1922" data-page="717"></span>
         when the curtain came down because he
-        looked so handsome then we had <Annotation annotationId="130003martinharvey" visited={visitedNotes.has("130003martinharvey")} annotationSelect={() => {openNote("130003martinharvey"); addToVisited("130003martinharvey")}} activeAnnotationId={currentNoteId}>Martin Harvey</Annotation> for breakfast dinner and
+        looked so handsome then we had <Annotation annotationId="130003martinharvey">Martin Harvey</Annotation> for breakfast dinner and
         supper I thought to myself afterwards it must be real love if a man
         gives up his life for her that way for nothing I suppose there are a
         few men like that left its hard to believe in it though unless it really
@@ -1242,7 +1242,7 @@ const Penelope = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         the smell bringing in his friends to entertain them like the night he
         walked home with a dog if you please that might have been mad especially
         Simon Dedalus son his father such a criticiser with his glasses up with
-        his tall hat on him at <Annotation annotationId="050041cricket" visited={visitedNotes.has("050041cricket")} annotationSelect={() => {openNote("050041cricket"); addToVisited("050041cricket")}} activeAnnotationId={currentNoteId}>the cricket match</Annotation> and a great big hole in his
+        his tall hat on him at <Annotation annotationId="050041cricket">the cricket match</Annotation> and a great big hole in his
         sock one thing laughing at the other and his son that got all those
         prizes for whatever he won them in the intermediate imagine climbing
         over the railings if 
@@ -1260,16 +1260,16 @@ const Penelope = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         drink and he beats her Ill have to hunt around again for someone every
         day I get up theres some new thing on sweet God <span data-edition="ed1961" data-page="768"></span>sweet God well when Im
         stretched out dead in my grave I suppose Ill have some peace I want to
-        get up a minute if Im let wait O Jesus wait yes <Annotation annotationId="180003waterscomedown" visited={visitedNotes.has("180003waterscomedown")} annotationSelect={() => {openNote("180003waterscomedown"); addToVisited("180003waterscomedown")}} activeAnnotationId={currentNoteId}>that thing has come on
+        get up a minute if Im let wait O Jesus wait yes <Annotation annotationId="180003waterscomedown">that thing has come on
         me</Annotation> yes now wouldnt that afflict you of course all the poking and rooting
         and ploughing he had up in me now what am I to do Friday Saturday Sunday
         wouldnt that pester the soul out of a body unless he likes it some men
         do God knows theres always something wrong with us 5 days every 3 or 4
         weeks usual monthly auction isnt it simply sickening that night it came
-        on me like that the one and only time we were in <Annotation annotationId="060040gaietytheatre" visited={visitedNotes.has("060040gaietytheatre")} annotationSelect={() => {openNote("060040gaietytheatre"); addToVisited("060040gaietytheatre")}} activeAnnotationId={currentNoteId}>a box that Michael Gunn
+        on me like that the one and only time we were in <Annotation annotationId="060040gaietytheatre">a box that Michael Gunn
         gave him to see Mrs Kendal and her husband at the Gaiety</Annotation> something he
         did about insurance for him in Drimmies I was fit to be tied though I
-        wouldnt give in with <Annotation annotationId="170008precedingseries" visited={visitedNotes.has("170008precedingseries")} annotationSelect={() => {openNote("170008precedingseries"); addToVisited("170008precedingseries")}} activeAnnotationId={currentNoteId}>that gentleman of fashion staring down at me</Annotation> with
+        wouldnt give in with <Annotation annotationId="170008precedingseries">that gentleman of fashion staring down at me</Annotation> with
         his glasses and him the other side of me talking about Spinoza and his
         soul thats dead I suppose millions of years <span data-edition="ed1986" data-page="632"></span>ago I smiled the best I
         could all in a swamp leaning forward as if I was interested having to
@@ -1286,17 +1286,17 @@ const Penelope = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         <span data-edition="ed1939" data-page="542"> </span>
         such fools too you could be a
         widow or divorced 40 times over a daub of red ink would do or blackberry
-        juice no thats too purply <Annotation annotationId="180003waterscomedown" visited={visitedNotes.has("180003waterscomedown")} annotationSelect={() => {openNote("180003waterscomedown"); addToVisited("180003waterscomedown")}} activeAnnotationId={currentNoteId}>O Jamesy let me up out of this pooh</Annotation> sweets of
+        juice no thats too purply <Annotation annotationId="180003waterscomedown">O Jamesy let me up out of this pooh</Annotation> sweets of
         sin whoever suggested that business for women what between clothes and
         cooking and children this 
         <span data-edition="ed1922" data-page="719"></span>
-        damned old bed too <Annotation annotationId="040091jingle" visited={visitedNotes.has("040091jingle")} annotationSelect={() => {openNote("040091jingle"); addToVisited("040091jingle")}} activeAnnotationId={currentNoteId}>jingling like the dickens</Annotation>
+        damned old bed too <Annotation annotationId="040091jingle">jingling like the dickens</Annotation>
         I suppose they could hear us away over the other side of the park till I
         suggested to put the quilt on the floor with the pillow under my bottom
         I wonder is it nicer in the day I think it is easy I think Ill cut
         all this hair off me there scalding me I might look like a young girl
         wouldnt he get the great suckin the next time he turned up my clothes on
-        me Id give anything to see his face wheres <Annotation annotationId="040057orangekeyed" visited={visitedNotes.has("040057orangekeyed")} annotationSelect={() => {openNote("040057orangekeyed"); addToVisited("040057orangekeyed")}} activeAnnotationId={currentNoteId}>the chamber</Annotation> gone easy Ive a
+        me Id give anything to see his face wheres <Annotation annotationId="040057orangekeyed">the chamber</Annotation> gone easy Ive a
         holy horror of its breaking under me after that old commode I wonder
         was I too heavy sitting on his knee I made him sit on the <span data-edition="ed1961" data-page="769"></span>easychair
         purposely when I took off only my blouse and skirt first in the other
@@ -1308,7 +1308,7 @@ const Penelope = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         never saw a better pair of thighs than that look how white they are the
         smoothest place is right there between this bit here how soft like a
         peach easy God I wouldnt mind being a man and get up on a lovely woman
-        O Lord what a row youre making like the jersey lily easy easy <Annotation annotationId="180003waterscomedown" visited={visitedNotes.has("180003waterscomedown")} annotationSelect={() => {openNote("180003waterscomedown"); addToVisited("180003waterscomedown")}} activeAnnotationId={currentNoteId}>O how the
+        O Lord what a row youre making like the jersey lily easy easy <Annotation annotationId="180003waterscomedown">O how the
         waters come down at Lahore</Annotation>
       </p>
       <p>
@@ -1343,14 +1343,14 @@ const Penelope = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         severe his nose intelligent like that you be damned you lying strap O
         anything no matter who except an idiot he was clever enough to spot
         that of course that was all thinking of him and his mad crazy letters
-        my Precious one <Annotation annotationId="040015whitebutton" visited={visitedNotes.has("040015whitebutton")} annotationSelect={() => {openNote("040015whitebutton"); addToVisited("040015whitebutton")}} activeAnnotationId={currentNoteId}>everything connected with your glorious Body everything
+        my Precious one <Annotation annotationId="040015whitebutton">everything connected with your glorious Body everything
         underlined that comes from it</Annotation> is a thing of beauty and of joy for ever
         <span data-edition="ed1939" data-page="543"> </span>
         something he got out of some nonsensical book that he had me always at
         myself 4 and 5 times a day sometimes and I said I hadnt are you sure
         O yes I said I am quite sure in a way that shut him up I knew what was
         coming next only natural weakness it was he excited me I dont know how
-        the first night ever we met when I was living in <Annotation annotationId="040041dolphinsbarn" visited={visitedNotes.has("040041dolphinsbarn")} annotationSelect={() => {openNote("040041dolphinsbarn"); addToVisited("040041dolphinsbarn")}} activeAnnotationId={currentNoteId}>Rehoboth terrace</Annotation> we
+        the first night ever we met when I was living in <Annotation annotationId="040041dolphinsbarn">Rehoboth terrace</Annotation> we
         stood staring at one another for about 10 minutes as if we met somewhere
         I suppose on account of my being jewess looking after my mother he used
         to amuse me the things he said with the half sloothering smile on him
@@ -1369,7 +1369,7 @@ const Penelope = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         do it I suppose there isnt in all creation another man with the habits
         he has look at the way hes sleeping at the foot of the bed how can he
         without a hard bolster its well he doesnt kick or he might knock out
-        all my teeth breathing <Annotation annotationId="050031buddhagod" visited={visitedNotes.has("050031buddhagod")} annotationSelect={() => {openNote("050031buddhagod"); addToVisited("050031buddhagod")}} activeAnnotationId={currentNoteId}>with his hand on his nose like that Indian god
+        all my teeth breathing <Annotation annotationId="050031buddhagod">with his hand on his nose like that Indian god
         he took me to show one wet Sunday in the museum in Kildare street all
         yellow in a pinafore lying on his side on his hand with his ten toes
         sticking out that he said was a bigger religion than the jews and
@@ -1388,14 +1388,14 @@ const Penelope = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         often enough and he thinks father bought it from Lord Napier that I used
         to admire when I was a little girl because I told him easy piano O
         I like my bed God here we are as bad as ever after 16 years how many
-        houses were we in at all <Annotation annotationId="040049pleasantoldtimes" visited={visitedNotes.has("040049pleasantoldtimes")} annotationSelect={() => {openNote("040049pleasantoldtimes"); addToVisited("040049pleasantoldtimes")}} activeAnnotationId={currentNoteId}>Raymond terrace</Annotation> and Ontario terrace and Lombard
+        houses were we in at all <Annotation annotationId="040049pleasantoldtimes">Raymond terrace</Annotation> and Ontario terrace and Lombard
         street and Holles street and he goes about whistling every time were on
         the run again his huguenots or the frogs march pretending to help the
-        men with our 4 sticks of furniture and then the <Annotation annotationId="020066cityarms" visited={visitedNotes.has("020066cityarms")} annotationSelect={() => {openNote("020066cityarms"); addToVisited("020066cityarms")}} activeAnnotationId={currentNoteId}>City Arms hotel</Annotation> worse
+        men with our 4 sticks of furniture and then the <Annotation annotationId="020066cityarms">City Arms hotel</Annotation> worse
         and worse says Warden Daly that charming place on the landing always
         somebody inside praying then leaving all their stinks after them
         always know who was in there last every time were just getting on right
-        something happens or he puts his big foot in it Thoms and Helys and <Annotation annotationId="040037cattlemarket" visited={visitedNotes.has("040037cattlemarket")} annotationSelect={() => {openNote("040037cattlemarket"); addToVisited("040037cattlemarket")}} activeAnnotationId={currentNoteId}>Mr
+        something happens or he puts his big foot in it Thoms and Helys and <Annotation annotationId="040037cattlemarket">Mr
         Cuffes</Annotation> and Drimmies either hes going to be run into prison over his old
         lottery tickets that was to be all our salvations or he goes and gives
         impudence well have him coming home with the sack soon out of the
@@ -1405,7 +1405,7 @@ const Penelope = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         consolation that he 
         <span data-edition="ed1939" data-page="544"> </span>
         says is so capable and sincerely Irish he is indeed
-        judging by the sincerity of the trousers I saw on him wait <Annotation annotationId="040008georgeschurch" visited={visitedNotes.has("040008georgeschurch")} annotationSelect={() => {openNote("040008georgeschurch"); addToVisited("040008georgeschurch")}} activeAnnotationId={currentNoteId}>theres
+        judging by the sincerity of the trousers I saw on him wait <Annotation annotationId="040008georgeschurch">theres
         Georges church bells wait 3 quarters the hour wait 2 oclock</Annotation> well
         thats a nice hour of the night for him to be coming home at to anybody
         climbing down into the area if anybody saw him Ill knock him off that
@@ -1442,9 +1442,9 @@ const Penelope = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         is the fruits of Mr Paddy Dignam yes they were all in great style at the
         grand funeral in the paper Boylan brought in if they saw a real officers
         funeral thatd be something reversed arms muffled drums the poor horse
-        walking behind in black L Boom and <Annotation annotationId="050037tomkernan" visited={visitedNotes.has("050037tomkernan")} annotationSelect={() => {openNote("050037tomkernan"); addToVisited("050037tomkernan")}} activeAnnotationId={currentNoteId}>Tom Kernan that drunken little
+        walking behind in black L Boom and <Annotation annotationId="050037tomkernan">Tom Kernan that drunken little
         barrelly man that bit his tongue off falling down the mens W C drunk</Annotation>
-        in some place or other and <Annotation annotationId="060034martincunningham" visited={visitedNotes.has("060034martincunningham")} annotationSelect={() => {openNote("060034martincunningham"); addToVisited("060034martincunningham")}} activeAnnotationId={currentNoteId}>Martin Cunningham</Annotation> and the two Dedaluses and
+        in some place or other and <Annotation annotationId="060034martincunningham">Martin Cunningham</Annotation> and the two Dedaluses and
         Fanny MCoys husband white head of cabbage skinny thing with a turn in
         her eye trying to sing my songs shed want to be born all over again and
         her old green dress with the lowneck as she cant attract them any other
@@ -1456,30 +1456,30 @@ const Penelope = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         hes getting a bit grey over the ears theyre a nice lot all of them well
         theyre not going to get my husband again into their clutches if I can
         help it making fun of him then behind his back I know well when he goes
-        on with his idiotics because <Annotation annotationId="050049comehometoma" visited={visitedNotes.has("050049comehometoma")} annotationSelect={() => {openNote("050049comehometoma"); addToVisited("050049comehometoma")}} activeAnnotationId={currentNoteId}>he has sense enough not to squander every
-        penny piece he earns down their gullets and looks after his</Annotation> <span data-edition="ed1961" data-page="773"></span> <Annotation annotationId="050049comehometoma" visited={visitedNotes.has("050049comehometoma")} annotationSelect={() => {openNote("050049comehometoma"); addToVisited("050049comehometoma")}} activeAnnotationId={currentNoteId}>wife and
+        on with his idiotics because <Annotation annotationId="050049comehometoma">he has sense enough not to squander every
+        penny piece he earns down their gullets and looks after his</Annotation> <span data-edition="ed1961" data-page="773"></span> <Annotation annotationId="050049comehometoma">wife and
         family goodfornothings</Annotation> poor Paddy Dignam all the same Im sorry in a
         way for him what are his wife and 5 children going to do unless he was
         insured comical little teetotum 
         <span data-edition="ed1939" data-page="545"> </span>
-        <Annotation annotationId="040067poordignam" visited={visitedNotes.has("040067poordignam")} annotationSelect={() => {openNote("040067poordignam"); addToVisited("040067poordignam")}} activeAnnotationId={currentNoteId}>always stuck up in some pub corner</Annotation> and
+        <Annotation annotationId="040067poordignam">always stuck up in some pub corner</Annotation> and
         her or her son waiting Bill
         <span data-edition="ed1922" data-page="723"></span>
         Bailey wont you please come home her widows
         weeds wont improve her appearance theyre awfully becoming though if
         youre goodlooking what men wasnt he yes he was at the Glencree dinner
         and Ben Dollard base barreltone the night he borrowed the swallowtail
-        to sing out of in Holles street <Annotation annotationId="170008precedingseries" visited={visitedNotes.has("170008precedingseries")} annotationSelect={() => {openNote("170008precedingseries"); addToVisited("170008precedingseries")}} activeAnnotationId={currentNoteId}>squeezed and squashed into them</Annotation> and
+        to sing out of in Holles street <Annotation annotationId="170008precedingseries">squeezed and squashed into them</Annotation> and
         grinning all over his big Dolly face like a wellwhipped childs botty
         didnt he look a balmy ballocks sure enough that must have been a
         spectacle on the stage imagine paying 5/- in the preserved seats for
-        that to see him and <Annotation annotationId="170008precedingseries" visited={visitedNotes.has("170008precedingseries")} annotationSelect={() => {openNote("170008precedingseries"); addToVisited("170008precedingseries")}} activeAnnotationId={currentNoteId}>Simon Dedalus too he
+        that to see him and <Annotation annotationId="170008precedingseries">Simon Dedalus too he
         was always turning up half screwed</Annotation> singing the second verse first the
         old love is the new was one of his so sweetly sang the maiden on the
         hawthorn bough he was always on for flirtyfying too when I sang Maritana
         with him at Freddy Mayers private opera he had a delicious glorious
-        voice Phoebe dearest <Annotation annotationId="110006goodbyesweetheart" visited={visitedNotes.has("110006goodbyesweetheart")} annotationSelect={() => {openNote("110006goodbyesweetheart"); addToVisited("110006goodbyesweetheart")}} activeAnnotationId={currentNoteId}>goodbye sweetheart <i>sweet</i>heart he always sang it
-        not like Bartell Darcy</Annotation> <span data-edition="ed1986" data-page="636"></span><Annotation annotationId="110006goodbyesweetheart" visited={visitedNotes.has("110006goodbyesweetheart")} annotationSelect={() => {openNote("110006goodbyesweetheart"); addToVisited("110006goodbyesweetheart")}} activeAnnotationId={currentNoteId}>sweet <i>tart</i> goodbye</Annotation> of course he had the gift of
+        voice Phoebe dearest <Annotation annotationId="110006goodbyesweetheart">goodbye sweetheart <i>sweet</i>heart he always sang it
+        not like Bartell Darcy</Annotation> <span data-edition="ed1986" data-page="636"></span><Annotation annotationId="110006goodbyesweetheart">sweet <i>tart</i> goodbye</Annotation> of course he had the gift of
         the voice so there was no art in it all over you like a warm showerbath
         O Maritana wildwood flower we sang splendidly though it was a bit too
         high for my register even transposed and he was married at the time to
@@ -1489,7 +1489,7 @@ const Penelope = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         what is he driving at now showing him my photo its not good of me I
         ought to have got it taken in drapery that never looks out of fashion
         still I look young in it I wonder he didnt make him a present of it
-        altogether and me too after all why not <Annotation annotationId="180007kingsbridge" visited={visitedNotes.has("180007kingsbridge")} annotationSelect={() => {openNote("180007kingsbridge"); addToVisited("180007kingsbridge")}} activeAnnotationId={currentNoteId}>I saw him driving down to the
+        altogether and me too after all why not <Annotation annotationId="180007kingsbridge">I saw him driving down to the
         Kingsbridge station with his father and mother I was in mourning thats
         11 years ago now yes hed be 11</Annotation> though what was the good in going into
         mourning for what was neither one thing nor the other the first cry was
@@ -1512,7 +1512,7 @@ const Penelope = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         into his eyes or
         standing up like a red Indian what do they go about like that for only
         getting themselves and their poetry laughed at I always liked poetry
-        when I was a girl first <Annotation annotationId="180006lordbyron" visited={visitedNotes.has("180006lordbyron")} annotationSelect={() => {openNote("180006lordbyron"); addToVisited("180006lordbyron")}} activeAnnotationId={currentNoteId}>I thought he was a poet like lord Byron</Annotation> and not
+        when I was a girl first <Annotation annotationId="180006lordbyron">I thought he was a poet like lord Byron</Annotation> and not
         an ounce of it in his composition I thought he was quite different I
         wonder is he too young hes about wait 88 I was married 88 Milly is 15
         yesterday 89 what age was he then at Dillons 5 or 6 about 88 I suppose
@@ -1521,7 +1521,7 @@ const Penelope = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         down in the old kitchen with him taking Eppss cocoa and talking of
         course he pretended to understand it all probably he told him he was
         out of Trinity college hes very young to be a professor I hope hes not
-        a professor like <Annotation annotationId="170008precedingseries" visited={visitedNotes.has("170008precedingseries")} annotationSelect={() => {openNote("170008precedingseries"); addToVisited("170008precedingseries")}} activeAnnotationId={currentNoteId}>Goodwin was he was a patent professor of John Jameson</Annotation>
+        a professor like <Annotation annotationId="170008precedingseries">Goodwin was he was a patent professor of John Jameson</Annotation>
         they all write about some woman in their poetry well I suppose he wont
         find many like 
         <span data-edition="ed1939" data-page="546"> </span>
@@ -1537,17 +1537,17 @@ const Penelope = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         and Keyess ad and Tom the Devils ad then if anything goes wrong in their
         business we have to suffer Im sure hes very distinguished Id like to
         meet a man like that God not those other ruck besides hes young those
-        fine young men I could see <Annotation annotationId="180002margate" visited={visitedNotes.has("180002margate")} annotationSelect={() => {openNote("180002margate"); addToVisited("180002margate")}} activeAnnotationId={currentNoteId}>down in Margate strand bathing place</Annotation> from the
+        fine young men I could see <Annotation annotationId="180002margate">down in Margate strand bathing place</Annotation> from the
         side of the rock standing up in the sun naked like a God or something
         and then plunging into the sea with them why arent all men like that
-        thered be some consolation for a woman like <Annotation annotationId="080005venus" visited={visitedNotes.has("080005venus")} annotationSelect={() => {openNote("080005venus"); addToVisited("080005venus")}} activeAnnotationId={currentNoteId}>that lovely little statue he
+        thered be some consolation for a woman like <Annotation annotationId="080005venus">that lovely little statue he
         bought</Annotation> I <span data-edition="ed1932" data-page="675"></span>could look at him all day long curly head and his shoulders
         his finger up for you to listen theres real beauty and poetry for you
         I <span data-edition="ed1961" data-page="775"></span>often felt I wanted to kiss him all over also his lovely young cock
         there so simple I wouldnt mind taking him in my mouth if nobody was
         looking as if it was asking you to suck it so clean and white he looks
         with his boyish face I would too in ½ a minute even if some of it went
-        down what its only <Annotation annotationId="180010dewy" visited={visitedNotes.has("180010dewy")} annotationSelect={() => {openNote("180010dewy"); addToVisited("180010dewy")}} activeAnnotationId={currentNoteId}>like gruel or the dew</Annotation> theres no danger besides hed
+        down what its only <Annotation annotationId="180010dewy">like gruel or the dew</Annotation> theres no danger besides hed
         be so clean compared with those pigs of men I suppose never dream of
         washing it from 1 years end to the other the most of them only thats
         what gives the women the moustaches Im sure itll be grand if I can only
@@ -1564,7 +1564,7 @@ const Penelope = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         I going to do about him though
       </p>
       <p>
-        <Annotation annotationId="180009nornonothing" visited={visitedNotes.has("180009nornonothing")} annotationSelect={() => {openNote("180009nornonothing"); addToVisited("180009nornonothing")}} activeAnnotationId={currentNoteId}>no thats no way for him has he no manners nor no refinement nor no
+        <Annotation annotationId="180009nornonothing">no thats no way for him has he no manners nor no refinement nor no
         nothing</Annotation> in his nature slapping us behind like that on my bottom because
         I didnt call him Hugh the ignoramus that doesnt know poetry from a
         cabbage thats what you get for not keeping them in their proper place
@@ -1607,7 +1607,7 @@ const Penelope = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         him after that hed kiss anything unnatural where we havent 1 atom of any
         kind of expression in us all of us the same 2 lumps of lard before ever
         Id do that to a man pfooh the dirty brutes the mere thought is enough
-        I kiss the feet of you señorita theres some sense in that <Annotation annotationId="040047potato" visited={visitedNotes.has("040047potato")} annotationSelect={() => {openNote("040047potato"); addToVisited("040047potato")}} activeAnnotationId={currentNoteId}>didnt he kiss
+        I kiss the feet of you señorita theres some sense in that <Annotation annotationId="040047potato">didnt he kiss
         our halldoor yes he did what a madman nobody understands his cracked
         ideas but me</Annotation> still of course a woman wants to be embraced 20 times a day
         almost to make her look young no matter by who so long as to be in love
@@ -1655,7 +1655,7 @@ const Penelope = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         theyre not satisfied and I none was he not able to make one it wasnt my
         fault we came together when I was watching the two dogs up in her behind
         in the middle of the naked street that disheartened me altogether I
-        suppose I oughtnt to have buried him in <Annotation annotationId="030091ruddywool" visited={visitedNotes.has("030091ruddywool")} annotationSelect={() => {openNote("030091ruddywool"); addToVisited("030091ruddywool")}} activeAnnotationId={currentNoteId}>that little woolly jacket I
+        suppose I oughtnt to have buried him in <Annotation annotationId="030091ruddywool">that little woolly jacket I
         knitted</Annotation> crying as I was but give it to some poor child but I knew well
         Id never have another our 1st death too it was we were never the same
         since O Im not going to think myself into the glooms about that any
@@ -1722,8 +1722,8 @@ const Penelope = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         longing way then Ill throw him up his eggs and tea in the moustachecup
         she gave him to make his mouth bigger I suppose hed like my nice cream
         too I know what Ill do Ill go about rather gay not too much singing a
-        bit now and then <Annotation annotationId="040025lacidarem" visited={visitedNotes.has("040025lacidarem")} annotationSelect={() => {openNote("040025lacidarem"); addToVisited("040025lacidarem")}} activeAnnotationId={currentNoteId}>mi fa pietà Masetto</Annotation> then Ill start dressing myself to
-        go out <Annotation annotationId="040025lacidarem" visited={visitedNotes.has("040025lacidarem")} annotationSelect={() => {openNote("040025lacidarem"); addToVisited("040025lacidarem")}} activeAnnotationId={currentNoteId}>presto non son più forte</Annotation> Ill put on my best shift and drawers let
+        bit now and then <Annotation annotationId="040025lacidarem">mi fa pietà Masetto</Annotation> then Ill start dressing myself to
+        go out <Annotation annotationId="040025lacidarem">presto non son più forte</Annotation> Ill put on my best shift and drawers let
         him have a good eyeful out of that to make his micky stand for him Ill
         let him know if thats what he wanted that his wife is fucked 
         <span data-edition="ed1922" data-page="729"></span>
@@ -1799,7 +1799,7 @@ const Penelope = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         Howth head in the grey tweed suit and his straw hat the day I got him to
         propose to me yes first I gave him the bit of seedcake out of my mouth
         and it was leapyear like now yes 16 years ago my God after that long
-        kiss I near lost my breath yes <Annotation annotationId="050026henryflower" visited={visitedNotes.has("050026henryflower")} annotationSelect={() => {openNote("050026henryflower"); addToVisited("050026henryflower")}} activeAnnotationId={currentNoteId}>he said I was a flower of the mountain
+        kiss I near lost my breath yes <Annotation annotationId="050026henryflower">he said I was a flower of the mountain
         yes so we are flowers all a womans body</Annotation> yes that <span data-edition="ed1932" data-page="681"></span>was one true thing he
         said in his life and the sun shines for you today yes that was why I
         liked him because I saw he understood or felt what a woman is and I knew
@@ -1837,7 +1837,7 @@ const Penelope = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         him with my eyes to ask again yes and then he asked me would I yes to
         say yes my mountain flower and first I put my arms around him yes and
         drew him down to me so he could feel my breasts all perfume yes and his
-        heart was going like mad and <Annotation annotationId="180005yesyes" visited={visitedNotes.has("180005yesyes")} annotationSelect={() => {openNote("180005yesyes"); addToVisited("180005yesyes")}} activeAnnotationId={currentNoteId}>yes I said yes I will Yes</Annotation>.
+        heart was going like mad and <Annotation annotationId="180005yesyes">yes I said yes I will Yes</Annotation>.
       </p>
       <br/><br/><br/>
       <span data-edition="ed1922" data-page="732"></span>

--- a/src/content/chapters/Proteus.js
+++ b/src/content/chapters/Proteus.js
@@ -1,18 +1,18 @@
 import Annotation from "../../components/Annotation";
 
 
-const Proteus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
+const Proteus = () => {
   return (
     <div>
       <p></p>
-      <center><font size="+2"><Annotation annotationId="030000proteus" visited={visitedNotes.has("030000proteus")} annotationSelect={() => {openNote("030000proteus"); addToVisited("030000proteus")}} activeAnnotationId={currentNoteId}>[3]</Annotation></font></center>
+      <center><font size="+2"><Annotation annotationId="030000proteus">[3]</Annotation></font></center>
       <br/>
-      <Annotation annotationId="030034ineluctable" visited={visitedNotes.has("030034ineluctable")} annotationSelect={() => {openNote("030034ineluctable"); addToVisited("030034ineluctable")}} activeAnnotationId={currentNoteId}>Ineluctable modality of the visible</Annotation>: at least that if no more, thought
-      through my eyes. <Annotation annotationId="030020signatures" visited={visitedNotes.has("030020signatures")} annotationSelect={() => {openNote("030020signatures"); addToVisited("030020signatures")}} activeAnnotationId={currentNoteId}>Signatures of all things</Annotation> <Annotation annotationId="030001sandymount" visited={visitedNotes.has("030001sandymount")} annotationSelect={() => {openNote("030001sandymount"); addToVisited("030001sandymount")}} activeAnnotationId={currentNoteId}>I am here</Annotation> to read, seaspawn
-      and seawrack, <Annotation annotationId="010125hightide" visited={visitedNotes.has("010125hightide")} annotationSelect={() => {openNote("010125hightide"); addToVisited("010125hightide")}} activeAnnotationId={currentNoteId}>the nearing tide</Annotation>, that rusty boot. <Annotation annotationId="010031snotgreen" visited={visitedNotes.has("010031snotgreen")} annotationSelect={() => {openNote("010031snotgreen"); addToVisited("010031snotgreen")}} activeAnnotationId={currentNoteId}>Snotgreen</Annotation>, bluesilver,
-      rust: <Annotation annotationId="030030colouredsigns" visited={visitedNotes.has("030030colouredsigns")} annotationSelect={() => {openNote("030030colouredsigns"); addToVisited("030030colouredsigns")}} activeAnnotationId={currentNoteId}>coloured signs</Annotation>. Limits of <Annotation annotationId="030025baldhewas" visited={visitedNotes.has("030025baldhewas")} annotationSelect={() => {openNote("030025baldhewas"); addToVisited("030025baldhewas")}} activeAnnotationId={currentNoteId}>the diaphane. But he adds: in bodies.</Annotation>
+      <Annotation annotationId="030034ineluctable">Ineluctable modality of the visible</Annotation>: at least that if no more, thought
+      through my eyes. <Annotation annotationId="030020signatures">Signatures of all things</Annotation> <Annotation annotationId="030001sandymount">I am here</Annotation> to read, seaspawn
+      and seawrack, <Annotation annotationId="010125hightide">the nearing tide</Annotation>, that rusty boot. <Annotation annotationId="010031snotgreen">Snotgreen</Annotation>, bluesilver,
+      rust: <Annotation annotationId="030030colouredsigns">coloured signs</Annotation>. Limits of <Annotation annotationId="030025baldhewas">the diaphane. But he adds: in bodies.</Annotation>
       Then he was aware of them bodies before of them coloured. How? By
-      <Annotation annotationId="030035knockingsconce" visited={visitedNotes.has("030035knockingsconce")} annotationSelect={() => {openNote("030035knockingsconce"); addToVisited("030035knockingsconce")}} activeAnnotationId={currentNoteId}>knocking his sconce against them</Annotation>, sure. Go easy. <Annotation annotationId="030025baldhewas" visited={visitedNotes.has("030025baldhewas")} annotationSelect={() => {openNote("030025baldhewas"); addToVisited("030025baldhewas")}} activeAnnotationId={currentNoteId}>Bald he was and a
+      <Annotation annotationId="030035knockingsconce">knocking his sconce against them</Annotation>, sure. Go easy. <Annotation annotationId="030025baldhewas">Bald he was and a
       millionaire, <i>maestro di color che sanno</i>.</Annotation> Limit of the diaphane in. Why
       in? Diaphane, adiaphane. If you can put your five fingers through it it
       is a gate, if not a door. Shut your eyes and see.
@@ -21,91 +21,91 @@ const Proteus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         Stephen closed his eyes to hear his boots crush crackling wrack and
         shells. You are walking through it howsomever. I am, a stride at a time.
         A very short space of time through very short times of space. Five, six:
-        the <Annotation annotationId="030009laocoon" visited={visitedNotes.has("030009laocoon")} annotationSelect={() => {openNote("030009laocoon"); addToVisited("030009laocoon")}} activeAnnotationId={currentNoteId}><i>nacheinander</i></Annotation>. Exactly: and that is the ineluctable modality of the
-        audible. Open your eyes. No. Jesus! If I fell over <Annotation annotationId="030041likeawhale" visited={visitedNotes.has("030041likeawhale")} annotationSelect={() => {openNote("030041likeawhale"); addToVisited("030041likeawhale")}} activeAnnotationId={currentNoteId}>a cliff that beetles
-        o'er his base</Annotation>, fell through the <Annotation annotationId="030009laocoon" visited={visitedNotes.has("030009laocoon")} annotationSelect={() => {openNote("030009laocoon"); addToVisited("030009laocoon")}} activeAnnotationId={currentNoteId}><i>nebeneinander</i></Annotation> ineluctably! I am
-        getting on nicely in the dark. My <Annotation annotationId="010099ashplant" visited={visitedNotes.has("010099ashplant")} annotationSelect={() => {openNote("010099ashplant"); addToVisited("010099ashplant")}} activeAnnotationId={currentNoteId}>ash sword</Annotation> hangs at my side. <Annotation annotationId="030003theydo" visited={visitedNotes.has("030003theydo")} annotationSelect={() => {openNote("030003theydo"); addToVisited("030003theydo")}} activeAnnotationId={currentNoteId}>Tap with
-        it: they do.</Annotation> My two feet in <Annotation annotationId="030010hislegs" visited={visitedNotes.has("030010hislegs")} annotationSelect={() => {openNote("030010hislegs"); addToVisited("030010hislegs")}} activeAnnotationId={currentNoteId}>his boots</Annotation> are at the ends of his legs,
-        <i>nebeneinander</i>. Sounds solid: made by <Annotation annotationId="030092losdemiurgos" visited={visitedNotes.has("030092losdemiurgos")} annotationSelect={() => {openNote("030092losdemiurgos"); addToVisited("030092losdemiurgos")}} activeAnnotationId={currentNoteId}>the mallet of <i>Los Demiurgos</i>.
-        Am I walking into eternity</Annotation> along <Annotation annotationId="030001sandymount" visited={visitedNotes.has("030001sandymount")} annotationSelect={() => {openNote("030001sandymount"); addToVisited("030001sandymount")}} activeAnnotationId={currentNoteId}>Sandymount strand</Annotation>? Crush, crack, crick,
-        crick. Wild <Annotation annotationId="030103shellgrit" visited={visitedNotes.has("030103shellgrit")} annotationSelect={() => {openNote("030103shellgrit"); addToVisited("030103shellgrit")}} activeAnnotationId={currentNoteId}>sea money</Annotation>. <Annotation annotationId="030006dominiedeasy" visited={visitedNotes.has("030006dominiedeasy")} annotationSelect={() => {openNote("030006dominiedeasy"); addToVisited("030006dominiedeasy")}} activeAnnotationId={currentNoteId}>Dominie Deasy kens them a'.</Annotation> 
+        the <Annotation annotationId="030009laocoon"><i>nacheinander</i></Annotation>. Exactly: and that is the ineluctable modality of the
+        audible. Open your eyes. No. Jesus! If I fell over <Annotation annotationId="030041likeawhale">a cliff that beetles
+        o'er his base</Annotation>, fell through the <Annotation annotationId="030009laocoon"><i>nebeneinander</i></Annotation> ineluctably! I am
+        getting on nicely in the dark. My <Annotation annotationId="010099ashplant">ash sword</Annotation> hangs at my side. <Annotation annotationId="030003theydo">Tap with
+        it: they do.</Annotation> My two feet in <Annotation annotationId="030010hislegs">his boots</Annotation> are at the ends of his legs,
+        <i>nebeneinander</i>. Sounds solid: made by <Annotation annotationId="030092losdemiurgos">the mallet of <i>Los Demiurgos</i>.
+        Am I walking into eternity</Annotation> along <Annotation annotationId="030001sandymount">Sandymount strand</Annotation>? Crush, crack, crick,
+        crick. Wild <Annotation annotationId="030103shellgrit">sea money</Annotation>. <Annotation annotationId="030006dominiedeasy">Dominie Deasy kens them a'.</Annotation> 
       </p>
       <p><i>
         Won't you come to Sandymount, <br/>
-        <Annotation annotationId="030127madelinethemare" visited={visitedNotes.has("030127madelinethemare")} annotationSelect={() => {openNote("030127madelinethemare"); addToVisited("030127madelinethemare")}} activeAnnotationId={currentNoteId}>Madeline the mare</Annotation>?</i>
+        <Annotation annotationId="030127madelinethemare">Madeline the mare</Annotation>?</i>
       </p>
       <p>
-        Rhythm begins, you see. I hear. A <Annotation annotationId="030007catalectic" visited={visitedNotes.has("030007catalectic")} annotationSelect={() => {openNote("030007catalectic"); addToVisited("030007catalectic")}} activeAnnotationId={currentNoteId}>catalectic tetrameter of iambs</Annotation>
+        Rhythm begins, you see. I hear. A <Annotation annotationId="030007catalectic">catalectic tetrameter of iambs</Annotation>
         marching. No, agallop: <i>deline the mare</i>.
       </p>
       <span data-edition="ed1922" data-page="37"></span>
       <p>
         Open your eyes now. I will. One moment. Has all vanished since? If I
-        open and am for ever in the black adiaphane. <Annotation annotationId="030031basta" visited={visitedNotes.has("030031basta")} annotationSelect={() => {openNote("030031basta"); addToVisited("030031basta")}} activeAnnotationId={currentNoteId}><i>Basta</i>!</Annotation> I will see if I
+        open and am for ever in the black adiaphane. <Annotation annotationId="030031basta"><i>Basta</i>!</Annotation> I will see if I
         can see.
       </p>
       <p>
-        See now. There all the time without you: and <Annotation annotationId="020025asitwas" visited={visitedNotes.has("020025asitwas")} annotationSelect={() => {openNote("020025asitwas"); addToVisited("020025asitwas")}} activeAnnotationId={currentNoteId}>ever shall be</Annotation>, <Annotation annotationId="030025baldhewas" visited={visitedNotes.has("030025baldhewas")} annotationSelect={() => {openNote("030025baldhewas"); addToVisited("030025baldhewas")}} activeAnnotationId={currentNoteId}>world
+        See now. There all the time without you: and <Annotation annotationId="020025asitwas">ever shall be</Annotation>, <Annotation annotationId="030025baldhewas">world
         without end</Annotation>.
       </p>
       <p>
-        They came down the <Annotation annotationId="030032leahys" visited={visitedNotes.has("030032leahys")} annotationSelect={() => {openNote("030032leahys"); addToVisited("030032leahys")}} activeAnnotationId={currentNoteId}>steps from Leahy's terrace</Annotation> prudently, <Annotation annotationId="030033frauenzimmer" visited={visitedNotes.has("030033frauenzimmer")} annotationSelect={() => {openNote("030033frauenzimmer"); addToVisited("030033frauenzimmer")}} activeAnnotationId={currentNoteId}><i>Frauenzimmer</i></Annotation>:
+        They came down the <Annotation annotationId="030032leahys">steps from Leahy's terrace</Annotation> prudently, <Annotation annotationId="030033frauenzimmer"><i>Frauenzimmer</i></Annotation>:
         and down the shelving shore flabbily, their splayed feet sinking <span data-edition="ed1932" data-page="34"> </span>in
-        the silted sand. Like me, like <Annotation annotationId="010032sweetmother" visited={visitedNotes.has("010032sweetmother")} annotationSelect={() => {openNote("010032sweetmother"); addToVisited("010032sweetmother")}} activeAnnotationId={currentNoteId}>Algy,</Annotation> coming down to our <Annotation annotationId="010039mightymother" visited={visitedNotes.has("010039mightymother")} annotationSelect={() => {openNote("010039mightymother"); addToVisited("010039mightymother")}} activeAnnotationId={currentNoteId}>mighty mother</Annotation>.
-        Number one <Annotation annotationId="030054swunglourdily" visited={visitedNotes.has("030054swunglourdily")} annotationSelect={() => {openNote("030054swunglourdily"); addToVisited("030054swunglourdily")}} activeAnnotationId={currentNoteId}>swung lourdily her midwife's bag, the other's gamp poked</Annotation> in
-        the beach. From <Annotation annotationId="030060theliberties" visited={visitedNotes.has("030060theliberties")} annotationSelect={() => {openNote("030060theliberties"); addToVisited("030060theliberties")}} activeAnnotationId={currentNoteId}>the liberties</Annotation>, out for the day. Mrs Florence MacCabe,
-        relict of the late Patk MacCabe, deeply lamented, of <Annotation annotationId="030023bridestreet" visited={visitedNotes.has("030023bridestreet")} annotationSelect={() => {openNote("030023bridestreet"); addToVisited("030023bridestreet")}} activeAnnotationId={currentNoteId}>Bride Street</Annotation>. <span data-edition="ed1986" data-page="31"> </span>One
-        of her sisterhood lugged me squealing into life. <Annotation annotationId="030026exnihilo" visited={visitedNotes.has("030026exnihilo")} annotationSelect={() => {openNote("030026exnihilo"); addToVisited("030026exnihilo")}} activeAnnotationId={currentNoteId}>Creation from nothing.</Annotation>
+        the silted sand. Like me, like <Annotation annotationId="010032sweetmother">Algy,</Annotation> coming down to our <Annotation annotationId="010039mightymother">mighty mother</Annotation>.
+        Number one <Annotation annotationId="030054swunglourdily">swung lourdily her midwife's bag, the other's gamp poked</Annotation> in
+        the beach. From <Annotation annotationId="030060theliberties">the liberties</Annotation>, out for the day. Mrs Florence MacCabe,
+        relict of the late Patk MacCabe, deeply lamented, of <Annotation annotationId="030023bridestreet">Bride Street</Annotation>. <span data-edition="ed1986" data-page="31"> </span>One
+        of her sisterhood lugged me squealing into life. <Annotation annotationId="030026exnihilo">Creation from nothing.</Annotation>
         What has she in the bag? A misbirth <span data-edition="ed1961" data-page="37"> </span> with a trailing navelcord, hushed
-        in <Annotation annotationId="030091ruddywool" visited={visitedNotes.has("030091ruddywool")} annotationSelect={() => {openNote("030091ruddywool"); addToVisited("030091ruddywool")}} activeAnnotationId={currentNoteId}>ruddy wool</Annotation>. The cords of all link back, strandentwining cable of
-        all flesh. That is why mystic monks. <Annotation annotationId="030095beasgods" visited={visitedNotes.has("030095beasgods")} annotationSelect={() => {openNote("030095beasgods"); addToVisited("030095beasgods")}} activeAnnotationId={currentNoteId}>Will you be as </Annotation> 
+        in <Annotation annotationId="030091ruddywool">ruddy wool</Annotation>. The cords of all link back, strandentwining cable of
+        all flesh. That is why mystic monks. <Annotation annotationId="030095beasgods">Will you be as </Annotation> 
         <span data-edition="ed1939" data-page="30"> </span>
-        <Annotation annotationId="030095beasgods" visited={visitedNotes.has("030095beasgods")} annotationSelect={() => {openNote("030095beasgods"); addToVisited("030095beasgods")}} activeAnnotationId={currentNoteId}>gods?</Annotation> Gaze in your
-        <Annotation annotationId="010065omphalos" visited={visitedNotes.has("010065omphalos")} annotationSelect={() => {openNote("010065omphalos"); addToVisited("010065omphalos")}} activeAnnotationId={currentNoteId}>omphalos</Annotation>. <Annotation annotationId="030008edenville" visited={visitedNotes.has("030008edenville")} annotationSelect={() => {openNote("030008edenville"); addToVisited("030008edenville")}} activeAnnotationId={currentNoteId}>Hello! Kinch here. Put me on to Edenville. Aleph, alpha:
+        <Annotation annotationId="030095beasgods">gods?</Annotation> Gaze in your
+        <Annotation annotationId="010065omphalos">omphalos</Annotation>. <Annotation annotationId="030008edenville">Hello! Kinch here. Put me on to Edenville. Aleph, alpha:
         nought, nought, one.</Annotation>
       </p>
       <p>
-        Spouse and <Annotation annotationId="030083nakedeve" visited={visitedNotes.has("030083nakedeve")} annotationSelect={() => {openNote("030083nakedeve"); addToVisited("030083nakedeve")}} activeAnnotationId={currentNoteId}>helpmate of Adam Kadmon: Heva, naked Eve. She had no navel.</Annotation>
+        Spouse and <Annotation annotationId="030083nakedeve">helpmate of Adam Kadmon: Heva, naked Eve. She had no navel.</Annotation>
         Gaze. Belly without blemish, bulging big, a buckler of taut vellum,
         no, whiteheaped corn, orient and immortal, standing from everlasting to
-        everlasting. <Annotation annotationId="010148uncleanloins" visited={visitedNotes.has("010148uncleanloins")} annotationSelect={() => {openNote("010148uncleanloins"); addToVisited("010148uncleanloins")}} activeAnnotationId={currentNoteId}>Womb of sin.</Annotation>
+        everlasting. <Annotation annotationId="010148uncleanloins">Womb of sin.</Annotation>
       </p>
       <p>
-        Wombed in sin darkness I was too, <Annotation annotationId="030026exnihilo" visited={visitedNotes.has("030026exnihilo")} annotationSelect={() => {openNote("030026exnihilo"); addToVisited("030026exnihilo")}} activeAnnotationId={currentNoteId}>made not begotten</Annotation>. By them, <Annotation annotationId="030090knowthevoice" visited={visitedNotes.has("030090knowthevoice")} annotationSelect={() => {openNote("030090knowthevoice"); addToVisited("030090knowthevoice")}} activeAnnotationId={currentNoteId}>the man
-        with my voice</Annotation> and my eyes and <Annotation annotationId="010045waxandrosewood" visited={visitedNotes.has("010045waxandrosewood")} annotationSelect={() => {openNote("010045waxandrosewood"); addToVisited("010045waxandrosewood")}} activeAnnotationId={currentNoteId}>a ghostwoman with ashes on her breath</Annotation>.
-        They clasped and sundered, did <Annotation annotationId="080028multiply" visited={visitedNotes.has("080028multiply")} annotationSelect={() => {openNote("080028multiply"); addToVisited("080028multiply")}} activeAnnotationId={currentNoteId}>the coupler's will</Annotation>. <Annotation annotationId="030026exnihilo" visited={visitedNotes.has("030026exnihilo")} annotationSelect={() => {openNote("030026exnihilo"); addToVisited("030026exnihilo")}} activeAnnotationId={currentNoteId}>From before the ages
+        Wombed in sin darkness I was too, <Annotation annotationId="030026exnihilo">made not begotten</Annotation>. By them, <Annotation annotationId="030090knowthevoice">the man
+        with my voice</Annotation> and my eyes and <Annotation annotationId="010045waxandrosewood">a ghostwoman with ashes on her breath</Annotation>.
+        They clasped and sundered, did <Annotation annotationId="080028multiply">the coupler's will</Annotation>. <Annotation annotationId="030026exnihilo">From before the ages
         He willed me and now may not will me away or ever. A <i>lex eterna</i> stays
-        about Him.</Annotation> Is that then <Annotation annotationId="010119trinity" visited={visitedNotes.has("010119trinity")} annotationSelect={() => {openNote("010119trinity"); addToVisited("010119trinity")}} activeAnnotationId={currentNoteId}>the divine substance wherein Father and Son are
+        about Him.</Annotation> Is that then <Annotation annotationId="010119trinity">the divine substance wherein Father and Son are
         consubstantial? Where is poor dear Arius</Annotation> to try conclusions? Warring
-        his life long on the <Annotation annotationId="030096contransmag" visited={visitedNotes.has("030096contransmag")} annotationSelect={() => {openNote("030096contransmag"); addToVisited("030096contransmag")}} activeAnnotationId={currentNoteId}>contransmagnificandjewbangtantiality</Annotation>. <Annotation annotationId="030040arius" visited={visitedNotes.has("030040arius")} annotationSelect={() => {openNote("030040arius"); addToVisited("030040arius")}} activeAnnotationId={currentNoteId}>Illstarred
+        his life long on the <Annotation annotationId="030096contransmag">contransmagnificandjewbangtantiality</Annotation>. <Annotation annotationId="030040arius">Illstarred
         heresiarch. In a Greek watercloset he breathed his last: euthanasia.
         With beaded mitre and with crozier, stalled upon his throne, widower of
         a widowed see, with upstiffed omophorion, with clotted hinderparts.</Annotation>
       </p>
       <p>
-        Airs romped round him, <Annotation annotationId="030041likeawhale" visited={visitedNotes.has("030041likeawhale")} annotationSelect={() => {openNote("030041likeawhale"); addToVisited("030041likeawhale")}} activeAnnotationId={currentNoteId}>nipping and eager airs</Annotation>. They are coming, waves.
-        The whitemaned seahorses, champing, brightwindbridled, <Annotation annotationId="030042mananaan" visited={visitedNotes.has("030042mananaan")} annotationSelect={() => {openNote("030042mananaan"); addToVisited("030042mananaan")}} activeAnnotationId={currentNoteId}>the steeds of
+        Airs romped round him, <Annotation annotationId="030041likeawhale">nipping and eager airs</Annotation>. They are coming, waves.
+        The whitemaned seahorses, champing, brightwindbridled, <Annotation annotationId="030042mananaan">the steeds of
         Mananaan</Annotation>.
       </p>
       <p>
-        I mustn't forget <Annotation annotationId="020064telegraph" visited={visitedNotes.has("020064telegraph")} annotationSelect={() => {openNote("020064telegraph"); addToVisited("020064telegraph")}} activeAnnotationId={currentNoteId}>his letter for the press</Annotation>. And after? <Annotation annotationId="010049shiptavern" visited={visitedNotes.has("010049shiptavern")} annotationSelect={() => {openNote("010049shiptavern"); addToVisited("010049shiptavern")}} activeAnnotationId={currentNoteId}>The Ship, half
-        twelve.</Annotation> By the way <Annotation annotationId="020035owenothing" visited={visitedNotes.has("020035owenothing")} annotationSelect={() => {openNote("020035owenothing"); addToVisited("020035owenothing")}} activeAnnotationId={currentNoteId}>go easy with that money</Annotation> like a good young imbecile.  Yes, I must.
+        I mustn't forget <Annotation annotationId="020064telegraph">his letter for the press</Annotation>. And after? <Annotation annotationId="010049shiptavern">The Ship, half
+        twelve.</Annotation> By the way <Annotation annotationId="020035owenothing">go easy with that money</Annotation> like a good young imbecile.  Yes, I must.
       </p>
       <p>
-        His pace slackened. Here. Am I going to <Annotation annotationId="030113richiegoulding" visited={visitedNotes.has("030113richiegoulding")} annotationSelect={() => {openNote("030113richiegoulding"); addToVisited("030113richiegoulding")}} activeAnnotationId={currentNoteId}>aunt Sara's</Annotation> or not? My
-        consubstantial <Annotation annotationId="030050fathersvoice" visited={visitedNotes.has("030050fathersvoice")} annotationSelect={() => {openNote("030050fathersvoice"); addToVisited("030050fathersvoice")}} activeAnnotationId={currentNoteId}>father's voice</Annotation>. Did you see anything of your artist
+        His pace slackened. Here. Am I going to <Annotation annotationId="030113richiegoulding">aunt Sara's</Annotation> or not? My
+        consubstantial <Annotation annotationId="030050fathersvoice">father's voice</Annotation>. Did you see anything of your artist
         brother <span data-edition="ed1922" data-page="38"></span>
-        Stephen lately? No? Sure he's not down in <Annotation annotationId="030015irishtown" visited={visitedNotes.has("030015irishtown")} annotationSelect={() => {openNote("030015irishtown"); addToVisited("030015irishtown")}} activeAnnotationId={currentNoteId}>Strasburg terrace</Annotation> with
-        his aunt Sally? Couldn't he <Annotation annotationId="010020ancientgreek" visited={visitedNotes.has("010020ancientgreek")} annotationSelect={() => {openNote("010020ancientgreek"); addToVisited("010020ancientgreek")}} activeAnnotationId={currentNoteId}>fly a bit higher</Annotation> than that, eh? And and and
+        Stephen lately? No? Sure he's not down in <Annotation annotationId="030015irishtown">Strasburg terrace</Annotation> with
+        his aunt Sally? Couldn't he <Annotation annotationId="010020ancientgreek">fly a bit higher</Annotation> than that, eh? And and and
         and tell us, Stephen, how is uncle Si? O weeping God, the things I
-        married into! De boys up in de hayloft. The drunken little <Annotation annotationId="030113richiegoulding" visited={visitedNotes.has("030113richiegoulding")} annotationSelect={() => {openNote("030113richiegoulding"); addToVisited("030113richiegoulding")}} activeAnnotationId={currentNoteId}>costdrawer</Annotation>
-        and his brother, the cornet player. <Annotation annotationId="030065gondoliers" visited={visitedNotes.has("030065gondoliers")} annotationSelect={() => {openNote("030065gondoliers"); addToVisited("030065gondoliers")}} activeAnnotationId={currentNoteId}>Highly respectable gondoliers!</Annotation> And
+        married into! De boys up in de hayloft. The drunken little <Annotation annotationId="030113richiegoulding">costdrawer</Annotation>
+        and his brother, the cornet player. <Annotation annotationId="030065gondoliers">Highly respectable gondoliers!</Annotation> And
         skeweyed Walter sirring his father, no less! Sir. Yes, sir. No, sir.
-        <Annotation annotationId="030064jesuswept" visited={visitedNotes.has("030064jesuswept")} annotationSelect={() => {openNote("030064jesuswept"); addToVisited("030064jesuswept")}} activeAnnotationId={currentNoteId}>Jesus wept</Annotation>: and no wonder, by Christ!
+        <Annotation annotationId="030064jesuswept">Jesus wept</Annotation>: and no wonder, by Christ!
       </p>
       <span data-edition="ed1932" data-page="35"> </span>
       <p>
-        <Annotation annotationId="030014wheezybell" visited={visitedNotes.has("030014wheezybell")} annotationSelect={() => {openNote("030014wheezybell"); addToVisited("030014wheezybell")}} activeAnnotationId={currentNoteId}>I pull the wheezy bell</Annotation> of their shuttered cottage: and wait. They <Annotation annotationId="030016coignofvantage" visited={visitedNotes.has("030016coignofvantage")} annotationSelect={() => {openNote("030016coignofvantage"); addToVisited("030016coignofvantage")}} activeAnnotationId={currentNoteId}>take
+        <Annotation annotationId="030014wheezybell">I pull the wheezy bell</Annotation> of their shuttered cottage: and wait. They <Annotation annotationId="030016coignofvantage">take
         me for a dun, peer out from a coign of vantage</Annotation>.
       </p>
       <p>
@@ -122,7 +122,7 @@ const Proteus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         —{" "}We thought you were someone else.
       </p>
       <p>
-        In his broad bed <Annotation annotationId="030113richiegoulding" visited={visitedNotes.has("030113richiegoulding")} annotationSelect={() => {openNote("030113richiegoulding"); addToVisited("030113richiegoulding")}} activeAnnotationId={currentNoteId}>nuncle Richie</Annotation>, pillowed and blanketed, extends over the
+        In his broad bed <Annotation annotationId="030113richiegoulding">nuncle Richie</Annotation>, pillowed and blanketed, extends over the
         hillock of his knees a sturdy forearm. Cleanchested. He has washed the
         upper moiety.
       </p>
@@ -132,16 +132,16 @@ const Proteus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       <span data-edition="ed1986" data-page="32"> </span>
       <p>
         He lays aside the lapboard whereon he drafts his bills of costs for
-        the eyes of <Annotation annotationId="030121mastergoff" visited={visitedNotes.has("030121mastergoff")} annotationSelect={() => {openNote("030121mastergoff"); addToVisited("030121mastergoff")}} activeAnnotationId={currentNoteId}>master Goff and master Shapland Tandy</Annotation>, filing consents and
-        common searches and a writ of <Annotation annotationId="030102viditdeus" visited={visitedNotes.has("030102viditdeus")} annotationSelect={() => {openNote("030102viditdeus"); addToVisited("030102viditdeus")}} activeAnnotationId={currentNoteId}><i>Duces Tecum</i></Annotation>. A <Annotation annotationId="030062bogoak" visited={visitedNotes.has("030062bogoak")} annotationSelect={() => {openNote("030062bogoak"); addToVisited("030062bogoak")}} activeAnnotationId={currentNoteId}>bogoak</Annotation> frame over his
-        bald head: <Annotation annotationId="030066requiescat" visited={visitedNotes.has("030066requiescat")} annotationSelect={() => {openNote("030066requiescat"); addToVisited("030066requiescat")}} activeAnnotationId={currentNoteId}>Wilde's <i>Requiescat</i></Annotation>. The drone of his misleading whistle
+        the eyes of <Annotation annotationId="030121mastergoff">master Goff and master Shapland Tandy</Annotation>, filing consents and
+        common searches and a writ of <Annotation annotationId="030102viditdeus"><i>Duces Tecum</i></Annotation>. A <Annotation annotationId="030062bogoak">bogoak</Annotation> frame over his
+        bald head: <Annotation annotationId="030066requiescat">Wilde's <i>Requiescat</i></Annotation>. The drone of his misleading whistle
         brings Walter back.
       </p>
       <p>
         —{" "}Yes, sir?
       </p>
       <p>
-        —{" "}<Annotation annotationId="030063lithiawater" visited={visitedNotes.has("030063lithiawater")} annotationSelect={() => {openNote("030063lithiawater"); addToVisited("030063lithiawater")}} activeAnnotationId={currentNoteId}>Malt</Annotation> for Richie and Stephen, tell mother. Where is she?
+        —{" "}<Annotation annotationId="030063lithiawater">Malt</Annotation> for Richie and Stephen, tell mother. Where is she?
       </p>
       <p>
         —{" "}Bathing Crissie, sir.
@@ -153,7 +153,7 @@ const Proteus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         —{" "}No, uncle Richie...
       </p>
       <p>
-        —{" "}Call me Richie. Damn your <Annotation annotationId="030063lithiawater" visited={visitedNotes.has("030063lithiawater")} annotationSelect={() => {openNote("030063lithiawater"); addToVisited("030063lithiawater")}} activeAnnotationId={currentNoteId}>lithia water</Annotation>. It lowers. Whusky!
+        —{" "}Call me Richie. Damn your <Annotation annotationId="030063lithiawater">lithia water</Annotation>. It lowers. Whusky!
       </p>
       <p>
         —{" "}Uncle Richie, really...
@@ -169,16 +169,16 @@ const Proteus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         —{" "}He has nothing to sit down on, sir.
       </p>
       <p>
-        —{" "}He has nowhere to put it, you mug. Bring in our <Annotation annotationId="030094chippendale" visited={visitedNotes.has("030094chippendale")} annotationSelect={() => {openNote("030094chippendale"); addToVisited("030094chippendale")}} activeAnnotationId={currentNoteId}>chippendale chair</Annotation>.
+        —{" "}He has nowhere to put it, you mug. Bring in our <Annotation annotationId="030094chippendale">chippendale chair</Annotation>.
         Would you like a bite of something? None of your damned lawdeedaw airs
         here. The rich of a rasher fried with a herring? Sure? So much the
-        better. We have nothing in the house but <Annotation annotationId="030076backachepills" visited={visitedNotes.has("030076backachepills")} annotationSelect={() => {openNote("030076backachepills"); addToVisited("030076backachepills")}} activeAnnotationId={currentNoteId}>backache pills</Annotation>.
+        better. We have nothing in the house but <Annotation annotationId="030076backachepills">backache pills</Annotation>.
       </p>
       <p>
-        <Annotation annotationId="030056allerta" visited={visitedNotes.has("030056allerta")} annotationSelect={() => {openNote("030056allerta"); addToVisited("030056allerta")}} activeAnnotationId={currentNoteId}><i>All'erta</i>!</Annotation>
+        <Annotation annotationId="030056allerta"><i>All'erta</i>!</Annotation>
       </p>
       <p>
-        He drones bars of Ferrando's <Annotation annotationId="030031basta" visited={visitedNotes.has("030031basta")} annotationSelect={() => {openNote("030031basta"); addToVisited("030031basta")}} activeAnnotationId={currentNoteId}><i>aria di sortita</i></Annotation>. The grandest number,
+        He drones bars of Ferrando's <Annotation annotationId="030031basta"><i>aria di sortita</i></Annotation>. The grandest number,
         Stephen, in the whole opera. Listen.
       </p>
       <span data-edition="ed1922" data-page="39"></span>
@@ -187,43 +187,43 @@ const Proteus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         his fists bigdrumming on his padded knees.
       </p>
       <p>
-        <Annotation annotationId="030016coignofvantage" visited={visitedNotes.has("030016coignofvantage")} annotationSelect={() => {openNote("030016coignofvantage"); addToVisited("030016coignofvantage")}} activeAnnotationId={currentNoteId}>This wind is sweeter.</Annotation>
+        <Annotation annotationId="030016coignofvantage">This wind is sweeter.</Annotation>
       </p>
       <p>
-        <Annotation annotationId="030057ownhouse" visited={visitedNotes.has("030057ownhouse")} annotationSelect={() => {openNote("030057ownhouse"); addToVisited("030057ownhouse")}} activeAnnotationId={currentNoteId}>Houses of decay</Annotation>, mine, his and all. You told the <Annotation annotationId="010157clongowes" visited={visitedNotes.has("010157clongowes")} annotationSelect={() => {openNote("010157clongowes"); addToVisited("010157clongowes")}} activeAnnotationId={currentNoteId}>Clongowes</Annotation> gentry you
-        had an uncle a judge and an uncle a general in the army. <Annotation annotationId="030133comeout" visited={visitedNotes.has("030133comeout")} annotationSelect={() => {openNote("030133comeout"); addToVisited("030133comeout")}} activeAnnotationId={currentNoteId}>Come out of
-        them</Annotation>, Stephen. Beauty is not there. Nor in the stagnant bay of <Annotation annotationId="030047marshlibrary" visited={visitedNotes.has("030047marshlibrary")} annotationSelect={() => {openNote("030047marshlibrary"); addToVisited("030047marshlibrary")}} activeAnnotationId={currentNoteId}>Marsh's
-        library</Annotation> where you read the fading prophecies of <Annotation annotationId="030048joachim" visited={visitedNotes.has("030048joachim")} annotationSelect={() => {openNote("030048joachim"); addToVisited("030048joachim")}} activeAnnotationId={currentNoteId}>Joachim Abbas</Annotation>. For whom?
-        <Annotation annotationId="030047marshlibrary" visited={visitedNotes.has("030047marshlibrary")} annotationSelect={() => {openNote("030047marshlibrary"); addToVisited("030047marshlibrary")}} activeAnnotationId={currentNoteId}>The hundredheaded rabble of the cathedral close</Annotation>. A hater <span data-edition="ed1932" data-page="36"> </span>of his kind
+        <Annotation annotationId="030057ownhouse">Houses of decay</Annotation>, mine, his and all. You told the <Annotation annotationId="010157clongowes">Clongowes</Annotation> gentry you
+        had an uncle a judge and an uncle a general in the army. <Annotation annotationId="030133comeout">Come out of
+        them</Annotation>, Stephen. Beauty is not there. Nor in the stagnant bay of <Annotation annotationId="030047marshlibrary">Marsh's
+        library</Annotation> where you read the fading prophecies of <Annotation annotationId="030048joachim">Joachim Abbas</Annotation>. For whom?
+        <Annotation annotationId="030047marshlibrary">The hundredheaded rabble of the cathedral close</Annotation>. A hater <span data-edition="ed1932" data-page="36"> </span>of his kind
         ran from them to the wood of madness, his mane foaming in the moon,
-        his eyeballs stars. <Annotation annotationId="030061furiousdean" visited={visitedNotes.has("030061furiousdean")} annotationSelect={() => {openNote("030061furiousdean"); addToVisited("030061furiousdean")}} activeAnnotationId={currentNoteId}>Houyhnhnm, horsenostrilled.</Annotation> The oval equine
-        faces, <Annotation annotationId="030122equinefaces" visited={visitedNotes.has("030122equinefaces")} annotationSelect={() => {openNote("030122equinefaces"); addToVisited("030122equinefaces")}} activeAnnotationId={currentNoteId}>Temple, Buck Mulligan, Foxy Campbell, Lanternjaws</Annotation>. Abbas
+        his eyeballs stars. <Annotation annotationId="030061furiousdean">Houyhnhnm, horsenostrilled.</Annotation> The oval equine
+        faces, <Annotation annotationId="030122equinefaces">Temple, Buck Mulligan, Foxy Campbell, Lanternjaws</Annotation>. Abbas
         father, furious dean, what offence laid <span data-edition="ed1961" data-page="39"> </span>fire to their brains? Paff!
-        <Annotation annotationId="030101calve" visited={visitedNotes.has("030101calve")} annotationSelect={() => {openNote("030101calve"); addToVisited("030101calve")}} activeAnnotationId={currentNoteId}><i>Descende, calve, ut ne nimium decalveris</i>.</Annotation> A <Annotation annotationId="010136nimbus" visited={visitedNotes.has("010136nimbus")} annotationSelect={() => {openNote("010136nimbus"); addToVisited("010136nimbus")}} activeAnnotationId={currentNoteId}>garland of grey hair</Annotation>
-        on his comminated head see him me clambering <Annotation annotationId="030101calve" visited={visitedNotes.has("030101calve")} annotationSelect={() => {openNote("030101calve"); addToVisited("030101calve")}} activeAnnotationId={currentNoteId}>down to the footpace
+        <Annotation annotationId="030101calve"><i>Descende, calve, ut ne nimium decalveris</i>.</Annotation> A <Annotation annotationId="010136nimbus">garland of grey hair</Annotation>
+        on his comminated head see him me clambering <Annotation annotationId="030101calve">down to the footpace
         (<i>descende</i>!), clutching a monstrance, basiliskeyed. Get down, bald poll!</Annotation>
-        A choir gives back menace and echo, assisting about <Annotation annotationId="030110altarshorns" visited={visitedNotes.has("030110altarshorns")} annotationSelect={() => {openNote("030110altarshorns"); addToVisited("030110altarshorns")}} activeAnnotationId={currentNoteId}>the altar's horns,
-        the snorted Latin of jackpriests</Annotation> moving burly in their <Annotation annotationId="010005ungirdled" visited={visitedNotes.has("010005ungirdled")} annotationSelect={() => {openNote("010005ungirdled"); addToVisited("010005ungirdled")}} activeAnnotationId={currentNoteId}>albs, tonsured</Annotation>
-        and oiled and gelded, fat with <Annotation annotationId="030019kidneysofwheat" visited={visitedNotes.has("030019kidneysofwheat")} annotationSelect={() => {openNote("030019kidneysofwheat"); addToVisited("030019kidneysofwheat")}} activeAnnotationId={currentNoteId}>the fat of kidneys of wheat</Annotation>.
+        A choir gives back menace and echo, assisting about <Annotation annotationId="030110altarshorns">the altar's horns,
+        the snorted Latin of jackpriests</Annotation> moving burly in their <Annotation annotationId="010005ungirdled">albs, tonsured</Annotation>
+        and oiled and gelded, fat with <Annotation annotationId="030019kidneysofwheat">the fat of kidneys of wheat</Annotation>.
       </p>
       <p>
         And at the same instant perhaps a priest round the corner is elevating
-        it. <Annotation annotationId="030018dringdring" visited={visitedNotes.has("030018dringdring")} annotationSelect={() => {openNote("030018dringdring"); addToVisited("030018dringdring")}} activeAnnotationId={currentNoteId}>Dringdring!</Annotation> And two streets off another locking it into a pyx.
+        it. <Annotation annotationId="030018dringdring">Dringdring!</Annotation> And two streets off another locking it into a pyx.
         Dringadring! And in a ladychapel another taking housel all to his own
-        cheek. Dringdring! Down, up, forward, back. <Annotation annotationId="030044danoccam" visited={visitedNotes.has("030044danoccam")} annotationSelect={() => {openNote("030044danoccam"); addToVisited("030044danoccam")}} activeAnnotationId={currentNoteId}>Dan Occam</Annotation> thought of that,
-        invincible doctor. A <Annotation annotationId="030142mistymorning" visited={visitedNotes.has("030142mistymorning")} annotationSelect={() => {openNote("030142mistymorning"); addToVisited("030142mistymorning")}} activeAnnotationId={currentNoteId}>misty English morning</Annotation> the imp <Annotation annotationId="030044danoccam" visited={visitedNotes.has("030044danoccam")} annotationSelect={() => {openNote("030044danoccam"); addToVisited("030044danoccam")}} activeAnnotationId={currentNoteId}>hypostasis</Annotation> tickled
+        cheek. Dringdring! Down, up, forward, back. <Annotation annotationId="030044danoccam">Dan Occam</Annotation> thought of that,
+        invincible doctor. A <Annotation annotationId="030142mistymorning">misty English morning</Annotation> the imp <Annotation annotationId="030044danoccam">hypostasis</Annotation> tickled
         his <span data-edition="ed1986" data-page="33"> </span>brain. Bringing his host down and kneeling he heard twine with his
         second bell the first bell in the transept (he is lifting his) and,
         rising, heard (now I am lifting) their two bells (he is kneeling) twang
         in diphthong.
       </p>
       <p>
-        <Annotation annotationId="030097neverbeasaint" visited={visitedNotes.has("030097neverbeasaint")} annotationSelect={() => {openNote("030097neverbeasaint"); addToVisited("030097neverbeasaint")}} activeAnnotationId={currentNoteId}>Cousin Stephen, you will never be a saint.</Annotation> <Annotation annotationId="030085isleofsaints" visited={visitedNotes.has("030085isleofsaints")} annotationSelect={() => {openNote("030085isleofsaints"); addToVisited("030085isleofsaints")}} activeAnnotationId={currentNoteId}>Isle of saints.</Annotation> You were
-        <Annotation annotationId="030084awfullyholy" visited={visitedNotes.has("030084awfullyholy")} annotationSelect={() => {openNote("030084awfullyholy"); addToVisited("030084awfullyholy")}} activeAnnotationId={currentNoteId}>awfully holy</Annotation>, weren't you? You prayed to the Blessed Virgin that you
-        might not have a red nose. You prayed to the devil in <Annotation annotationId="030077serpentine" visited={visitedNotes.has("030077serpentine")} annotationSelect={() => {openNote("030077serpentine"); addToVisited("030077serpentine")}} activeAnnotationId={currentNoteId}>Serpentine avenue</Annotation>
+        <Annotation annotationId="030097neverbeasaint">Cousin Stephen, you will never be a saint.</Annotation> <Annotation annotationId="030085isleofsaints">Isle of saints.</Annotation> You were
+        <Annotation annotationId="030084awfullyholy">awfully holy</Annotation>, weren't you? You prayed to the Blessed Virgin that you
+        might not have a red nose. You prayed to the devil in <Annotation annotationId="030077serpentine">Serpentine avenue</Annotation>
         that the fubsy widow in front might lift her clothes still more from the
-        wet street. <Annotation annotationId="030031basta" visited={visitedNotes.has("030031basta")} annotationSelect={() => {openNote("030031basta"); addToVisited("030031basta")}} activeAnnotationId={currentNoteId}><i>O si, certo</i>!</Annotation> Sell your soul for that, do, dyed rags pinned
-        round a squaw. More tell me, more still!! On the top of <Annotation annotationId="030021howthtram" visited={visitedNotes.has("030021howthtram")} annotationSelect={() => {openNote("030021howthtram"); addToVisited("030021howthtram")}} activeAnnotationId={currentNoteId}>the Howth tram</Annotation>
+        wet street. <Annotation annotationId="030031basta"><i>O si, certo</i>!</Annotation> Sell your soul for that, do, dyed rags pinned
+        round a squaw. More tell me, more still!! On the top of <Annotation annotationId="030021howthtram">the Howth tram</Annotation>
         alone crying to the rain: <i>naked women</i>! What about that,
         eh?
       </p>
@@ -232,15 +232,15 @@ const Proteus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <p>
         Reading two pages apiece of seven books every night, eh? I was young.
-        You bowed to yourself in the mirror, <Annotation annotationId="010121applause" visited={visitedNotes.has("010121applause")} annotationSelect={() => {openNote("010121applause"); addToVisited("010121applause")}} activeAnnotationId={currentNoteId}>stepping forward to applause</Annotation>
+        You bowed to yourself in the mirror, <Annotation annotationId="010121applause">stepping forward to applause</Annotation>
         earnestly, striking face. Hurray for the Goddamned idiot! Hray! No-one
         saw: tell no-one. Books you were going to write with letters for titles.
         Have you read his <span data-edition="ed1922" data-page="40"></span>
         F? O yes, but I prefer Q. Yes, but W is wonderful. O
-        yes, W. Remember your <Annotation annotationId="030098epiphanies" visited={visitedNotes.has("030098epiphanies")} annotationSelect={() => {openNote("030098epiphanies"); addToVisited("030098epiphanies")}} activeAnnotationId={currentNoteId}>epiphanies</Annotation> on green oval leaves, deeply
-        deep, <Annotation annotationId="030139alexandria" visited={visitedNotes.has("030139alexandria")} annotationSelect={() => {openNote("030139alexandria"); addToVisited("030139alexandria")}} activeAnnotationId={currentNoteId}>copies to be sent if you died to all the great libraries of the
+        yes, W. Remember your <Annotation annotationId="030098epiphanies">epiphanies</Annotation> on green oval leaves, deeply
+        deep, <Annotation annotationId="030139alexandria">copies to be sent if you died to all the great libraries of the
         world, including Alexandria</Annotation>? Someone was to read them there after a few
-        thousand years, <Annotation annotationId="030111pico" visited={visitedNotes.has("030111pico")} annotationSelect={() => {openNote("030111pico"); addToVisited("030111pico")}} activeAnnotationId={currentNoteId}>a mahamanvantara. Pico della Mirandola</Annotation> like. Ay, <Annotation annotationId="030041likeawhale" visited={visitedNotes.has("030041likeawhale")} annotationSelect={() => {openNote("030041likeawhale"); addToVisited("030041likeawhale")}} activeAnnotationId={currentNoteId}>very
+        thousand years, <Annotation annotationId="030111pico">a mahamanvantara. Pico della Mirandola</Annotation> like. Ay, <Annotation annotationId="030041likeawhale">very
         like a whale.</Annotation> When 
         <span data-edition="ed1939" data-page="32"> </span>
         one reads these strange pages of one long gone one
@@ -248,207 +248,207 @@ const Proteus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <p>
         The grainy sand had gone from under his feet. His boots trod again
-        a damp crackling mast, razorshells, squeaking pebbles, <span data-edition="ed1961" data-page="40"> </span><Annotation annotationId="030038pebbles" visited={visitedNotes.has("030038pebbles")} annotationSelect={() => {openNote("030038pebbles"); addToVisited("030038pebbles")}} activeAnnotationId={currentNoteId}>that on the</Annotation>
-        <span data-edition="ed1932" data-page="37"> </span><Annotation annotationId="030038pebbles" visited={visitedNotes.has("030038pebbles")} annotationSelect={() => {openNote("030038pebbles"); addToVisited("030038pebbles")}} activeAnnotationId={currentNoteId}>unnumbered pebbles beats</Annotation>, wood sieved by the shipworm, <Annotation annotationId="030002lostarmada" visited={visitedNotes.has("030002lostarmada")} annotationSelect={() => {openNote("030002lostarmada"); addToVisited("030002lostarmada")}} activeAnnotationId={currentNoteId}>lost Armada</Annotation>.
+        a damp crackling mast, razorshells, squeaking pebbles, <span data-edition="ed1961" data-page="40"> </span><Annotation annotationId="030038pebbles">that on the</Annotation>
+        <span data-edition="ed1932" data-page="37"> </span><Annotation annotationId="030038pebbles">unnumbered pebbles beats</Annotation>, wood sieved by the shipworm, <Annotation annotationId="030002lostarmada">lost Armada</Annotation>.
         Unwholesome sandflats waited to suck his treading soles, breathing
-        upward <Annotation annotationId="030039sewage" visited={visitedNotes.has("030039sewage")} annotationSelect={() => {openNote("030039sewage"); addToVisited("030039sewage")}} activeAnnotationId={currentNoteId}>sewage breath</Annotation>. He coasted them, walking warily. A porterbottle
+        upward <Annotation annotationId="030039sewage">sewage breath</Annotation>. He coasted them, walking warily. A porterbottle
         stood up, stogged to its waist, in the cakey sand dough. A sentinel:
-        <Annotation annotationId="030124dreadfulthirst" visited={visitedNotes.has("030124dreadfulthirst")} annotationSelect={() => {openNote("030124dreadfulthirst"); addToVisited("030124dreadfulthirst")}} activeAnnotationId={currentNoteId}>isle of dreadful thirst</Annotation>. Broken hoops on the shore; at the land a maze
+        <Annotation annotationId="030124dreadfulthirst">isle of dreadful thirst</Annotation>. Broken hoops on the shore; at the land a maze
         of dark cunning nets; farther away chalkscrawled backdoors and on the
-        higher beach a dryingline with two crucified shirts. <Annotation annotationId="030099ringsend" visited={visitedNotes.has("030099ringsend")} annotationSelect={() => {openNote("030099ringsend"); addToVisited("030099ringsend")}} activeAnnotationId={currentNoteId}>Ringsend: wigwams</Annotation>
-        of brown steersmen and master mariners. <Annotation annotationId="030103shellgrit" visited={visitedNotes.has("030103shellgrit")} annotationSelect={() => {openNote("030103shellgrit"); addToVisited("030103shellgrit")}} activeAnnotationId={currentNoteId}>Human shells.</Annotation>
+        higher beach a dryingline with two crucified shirts. <Annotation annotationId="030099ringsend">Ringsend: wigwams</Annotation>
+        of brown steersmen and master mariners. <Annotation annotationId="030103shellgrit">Human shells.</Annotation>
       </p>
       <p>
         He halted. I have passed the way to aunt Sara's. Am I not going there?
-        <Annotation annotationId="030010hislegs" visited={visitedNotes.has("030010hislegs")} annotationSelect={() => {openNote("030010hislegs"); addToVisited("030010hislegs")}} activeAnnotationId={currentNoteId}>Seems not.</Annotation> No-one about. He turned northeast and crossed the firmer sand
-        towards <Annotation annotationId="030004pigeonhouse" visited={visitedNotes.has("030004pigeonhouse")} annotationSelect={() => {openNote("030004pigeonhouse"); addToVisited("030004pigeonhouse")}} activeAnnotationId={currentNoteId}>the Pigeonhouse</Annotation>.
+        <Annotation annotationId="030010hislegs">Seems not.</Annotation> No-one about. He turned northeast and crossed the firmer sand
+        towards <Annotation annotationId="030004pigeonhouse">the Pigeonhouse</Annotation>.
       </p>
       <p>
-        <i>—{" "}<Annotation annotationId="010150fatherbird" visited={visitedNotes.has("010150fatherbird")} annotationSelect={() => {openNote("010150fatherbird"); addToVisited("010150fatherbird")}} activeAnnotationId={currentNoteId}>Qui vous a mis dans cette fichue position?</Annotation></i>
+        <i>—{" "}<Annotation annotationId="010150fatherbird">Qui vous a mis dans cette fichue position?</Annotation></i>
       </p>
       <p>
-        <i>—{" "}<Annotation annotationId="010150fatherbird" visited={visitedNotes.has("010150fatherbird")} annotationSelect={() => {openNote("010150fatherbird"); addToVisited("010150fatherbird")}} activeAnnotationId={currentNoteId}>C'est le pigeon, Joseph.</Annotation></i>
+        <i>—{" "}<Annotation annotationId="010150fatherbird">C'est le pigeon, Joseph.</Annotation></i>
       </p>
       <p>
-        Patrice, home on furlough, lapped warm milk with me in the <Annotation annotationId="030125barmacmahon" visited={visitedNotes.has("030125barmacmahon")} annotationSelect={() => {openNote("030125barmacmahon"); addToVisited("030125barmacmahon")}} activeAnnotationId={currentNoteId}>bar MacMahon</Annotation>.
-        Son of the <Annotation annotationId="030027wildgoose" visited={visitedNotes.has("030027wildgoose")} annotationSelect={() => {openNote("030027wildgoose"); addToVisited("030027wildgoose")}} activeAnnotationId={currentNoteId}>wild goose</Annotation>, Kevin Egan of Paris. <Annotation annotationId="010150fatherbird" visited={visitedNotes.has("010150fatherbird")} annotationSelect={() => {openNote("010150fatherbird"); addToVisited("010150fatherbird")}} activeAnnotationId={currentNoteId}>My father's a bird</Annotation>, he
-        lapped the sweet <Annotation annotationId="030005lapped" visited={visitedNotes.has("030005lapped")} annotationSelect={() => {openNote("030005lapped"); addToVisited("030005lapped")}} activeAnnotationId={currentNoteId}><i>lait chaud</i></Annotation> with pink young tongue, plump bunny's
-        face. Lap, <Annotation annotationId="030005lapped" visited={visitedNotes.has("030005lapped")} annotationSelect={() => {openNote("030005lapped"); addToVisited("030005lapped")}} activeAnnotationId={currentNoteId}><i>lapin.</i></Annotation> He hopes to win in the <Annotation annotationId="030005lapped" visited={visitedNotes.has("030005lapped")} annotationSelect={() => {openNote("030005lapped"); addToVisited("030005lapped")}} activeAnnotationId={currentNoteId}><i>gros lots</i></Annotation>. About the nature
-        of women he read in <Annotation annotationId="030126michelet" visited={visitedNotes.has("030126michelet")} annotationSelect={() => {openNote("030126michelet"); addToVisited("030126michelet")}} activeAnnotationId={currentNoteId}>Michelet</Annotation>. But he must send me <Annotation annotationId="010150fatherbird" visited={visitedNotes.has("010150fatherbird")} annotationSelect={() => {openNote("010150fatherbird"); addToVisited("010150fatherbird")}} activeAnnotationId={currentNoteId}><i>La Vie de Jésus</i> by
+        Patrice, home on furlough, lapped warm milk with me in the <Annotation annotationId="030125barmacmahon">bar MacMahon</Annotation>.
+        Son of the <Annotation annotationId="030027wildgoose">wild goose</Annotation>, Kevin Egan of Paris. <Annotation annotationId="010150fatherbird">My father's a bird</Annotation>, he
+        lapped the sweet <Annotation annotationId="030005lapped"><i>lait chaud</i></Annotation> with pink young tongue, plump bunny's
+        face. Lap, <Annotation annotationId="030005lapped"><i>lapin.</i></Annotation> He hopes to win in the <Annotation annotationId="030005lapped"><i>gros lots</i></Annotation>. About the nature
+        of women he read in <Annotation annotationId="030126michelet">Michelet</Annotation>. But he must send me <Annotation annotationId="010150fatherbird"><i>La Vie de Jésus</i> by
         M. Léo Taxil</Annotation>. Lent it to his friend.
       </p>
       <span data-edition="ed1986" data-page="34"> </span>
       <p>
-        <i>—{" "}<Annotation annotationId="030005lapped" visited={visitedNotes.has("030005lapped")} annotationSelect={() => {openNote("030005lapped"); addToVisited("030005lapped")}} activeAnnotationId={currentNoteId}>C'est tordant, vous savez. Moi, je suis socialiste. Je ne crois pas
+        <i>—{" "}<Annotation annotationId="030005lapped">C'est tordant, vous savez. Moi, je suis socialiste. Je ne crois pas
         en l'existence de Dieu. Faut pas le dire à mon père.</Annotation></i>
       </p>
       <p>
-        <i>—{" "}<Annotation annotationId="030005lapped" visited={visitedNotes.has("030005lapped")} annotationSelect={() => {openNote("030005lapped"); addToVisited("030005lapped")}} activeAnnotationId={currentNoteId}>Il croit?</Annotation></i>
+        <i>—{" "}<Annotation annotationId="030005lapped">Il croit?</Annotation></i>
       </p>
       <p>
-        <i>—<Annotation annotationId="030005lapped" visited={visitedNotes.has("030005lapped")} annotationSelect={() => {openNote("030005lapped"); addToVisited("030005lapped")}} activeAnnotationId={currentNoteId}>Mon père, oui.</Annotation></i>
+        <i>—<Annotation annotationId="030005lapped">Mon père, oui.</Annotation></i>
       </p>
       <p>
-        <Annotation annotationId="030033frauenzimmer" visited={visitedNotes.has("030033frauenzimmer")} annotationSelect={() => {openNote("030033frauenzimmer"); addToVisited("030033frauenzimmer")}} activeAnnotationId={currentNoteId}><i>Schluss</i>.</Annotation> He laps.
+        <Annotation annotationId="030033frauenzimmer"><i>Schluss</i>.</Annotation> He laps.
       </p>
       <p>
-        My <Annotation annotationId="010097latinquarterhat" visited={visitedNotes.has("010097latinquarterhat")} annotationSelect={() => {openNote("010097latinquarterhat"); addToVisited("010097latinquarterhat")}} activeAnnotationId={currentNoteId}>Latin quarter hat</Annotation>. <Annotation annotationId="010096contradictmyself" visited={visitedNotes.has("010096contradictmyself")} annotationSelect={() => {openNote("010096contradictmyself"); addToVisited("010096contradictmyself")}} activeAnnotationId={currentNoteId}>God, we simply must dress the character. I want
+        My <Annotation annotationId="010097latinquarterhat">Latin quarter hat</Annotation>. <Annotation annotationId="010096contradictmyself">God, we simply must dress the character. I want
         puce gloves.</Annotation> You were a student, weren't you? Of what in the other
-        devil's name? <Annotation annotationId="030073paysayenn" visited={visitedNotes.has("030073paysayenn")} annotationSelect={() => {openNote("030073paysayenn"); addToVisited("030073paysayenn")}} activeAnnotationId={currentNoteId}>Paysayenn. P. C. N., you know: <i>physiques, chimiques et
-        naturelles</i>.</Annotation> Aha. Eating your <Annotation annotationId="010019money" visited={visitedNotes.has("010019money")} annotationSelect={() => {openNote("010019money"); addToVisited("010019money")}} activeAnnotationId={currentNoteId}>groatsworth</Annotation> of <Annotation annotationId="030073paysayenn" visited={visitedNotes.has("030073paysayenn")} annotationSelect={() => {openNote("030073paysayenn"); addToVisited("030073paysayenn")}} activeAnnotationId={currentNoteId}><i>mou en civet</i></Annotation>, <Annotation annotationId="030134fleshpots" visited={visitedNotes.has("030134fleshpots")} annotationSelect={() => {openNote("030134fleshpots"); addToVisited("030134fleshpots")}} activeAnnotationId={currentNoteId}>fleshpots
+        devil's name? <Annotation annotationId="030073paysayenn">Paysayenn. P. C. N., you know: <i>physiques, chimiques et
+        naturelles</i>.</Annotation> Aha. Eating your <Annotation annotationId="010019money">groatsworth</Annotation> of <Annotation annotationId="030073paysayenn"><i>mou en civet</i></Annotation>, <Annotation annotationId="030134fleshpots">fleshpots
         of Egypt</Annotation>, elbowed by belching cabmen. Just say in the most natural
-        tone: when I was in Paris, <Annotation annotationId="030151punchedtickets" visited={visitedNotes.has("030151punchedtickets")} annotationSelect={() => {openNote("030151punchedtickets"); addToVisited("030151punchedtickets")}} activeAnnotationId={currentNoteId}><i>boul' Mich'</i></Annotation>, I used to. Yes, <Annotation annotationId="030151punchedtickets" visited={visitedNotes.has("030151punchedtickets")} annotationSelect={() => {openNote("030151punchedtickets"); addToVisited("030151punchedtickets")}} activeAnnotationId={currentNoteId}>used to
+        tone: when I was in Paris, <Annotation annotationId="030151punchedtickets"><i>boul' Mich'</i></Annotation>, I used to. Yes, <Annotation annotationId="030151punchedtickets">used to
         carry punched tickets to prove an alibi if they arrested</Annotation>
-        <span data-edition="ed1922" data-page="41"></span><Annotation annotationId="030151punchedtickets" visited={visitedNotes.has("030151punchedtickets")} annotationSelect={() => {openNote("030151punchedtickets"); addToVisited("030151punchedtickets")}} activeAnnotationId={currentNoteId}>you for murder
+        <span data-edition="ed1922" data-page="41"></span><Annotation annotationId="030151punchedtickets">you for murder
         somewhere. Justice. On the night of the seventeenth of February 1904</Annotation> the
         prisoner was seen by two witnesses. Other fellow did it: other me.
-        Hat, tie, overcoat, nose. <Annotation annotationId="030073paysayenn" visited={visitedNotes.has("030073paysayenn")} annotationSelect={() => {openNote("030073paysayenn"); addToVisited("030073paysayenn")}} activeAnnotationId={currentNoteId}><i>Lui, c'est moi</i>.</Annotation> You seem to have enjoyed
+        Hat, tie, overcoat, nose. <Annotation annotationId="030073paysayenn"><i>Lui, c'est moi</i>.</Annotation> You seem to have enjoyed
         yourself.
       </p>
       <p>
         Proudly walking. Whom were you trying to walk like? Forget: a
         dispossessed. With mother's money order, eight shillings, the banging
         door of the post office slammed in your face by the <span data-edition="ed1961" data-page="41"> </span>usher. Hunger
-        <Annotation annotationId="010130toothless" visited={visitedNotes.has("010130toothless")} annotationSelect={() => {openNote("010130toothless"); addToVisited("010130toothless")}} activeAnnotationId={currentNoteId}>toothache</Annotation>. <Annotation annotationId="030073paysayenn" visited={visitedNotes.has("030073paysayenn")} annotationSelect={() => {openNote("030073paysayenn"); addToVisited("030073paysayenn")}} activeAnnotationId={currentNoteId}><i>Encore deux minutes</i>. Look clock. Must get. <i>Fermé</i>.</Annotation> Hired
+        <Annotation annotationId="010130toothless">toothache</Annotation>. <Annotation annotationId="030073paysayenn"><i>Encore deux minutes</i>. Look clock. Must get. <i>Fermé</i>.</Annotation> Hired
         dog! Shoot him to bloody bits with a bang shotgun, bits man spattered
-        walls all brass buttons. <Annotation annotationId="030100clackback" visited={visitedNotes.has("030100clackback")} annotationSelect={() => {openNote("030100clackback"); addToVisited("030100clackback")}} activeAnnotationId={currentNoteId}>Bits all khrrrrklak in place clack back.</Annotation> Not
+        walls all brass buttons. <Annotation annotationId="030100clackback">Bits all khrrrrklak in place clack back.</Annotation> Not
         hurt? <span data-edition="ed1932" data-page="38"> </span>O, that's all right. Shake hands. See what I meant, see? O, that's
         all right. Shake a shake. O, that's all only all right.
       </p>
-      <p>You were going to do wonders, what? Missionary to Europe after <Annotation annotationId="020018columbanus" visited={visitedNotes.has("020018columbanus")} annotationSelect={() => {openNote("020018columbanus"); addToVisited("020018columbanus")}} activeAnnotationId={currentNoteId}>fiery Columbanus. Fiacre and Scotus</Annotation> on their creepystools in heaven spilt from
-        their pintpots, loudlatinlaughing: <Annotation annotationId="020018columbanus" visited={visitedNotes.has("020018columbanus")} annotationSelect={() => {openNote("020018columbanus"); addToVisited("020018columbanus")}} activeAnnotationId={currentNoteId}><i>Euge! Euge!</i></Annotation> Pretending to speak
+      <p>You were going to do wonders, what? Missionary to Europe after <Annotation annotationId="020018columbanus">fiery Columbanus. Fiacre and Scotus</Annotation> on their creepystools in heaven spilt from
+        their pintpots, loudlatinlaughing: <Annotation annotationId="020018columbanus"><i>Euge! Euge!</i></Annotation> Pretending to speak
         broken English as you dragged your valise, porter threepence, across
-        the slimy pier at Newhaven. <Annotation annotationId="030073paysayenn" visited={visitedNotes.has("030073paysayenn")} annotationSelect={() => {openNote("030073paysayenn"); addToVisited("030073paysayenn")}} activeAnnotationId={currentNoteId}><i>Comment?</i></Annotation> Rich booty you brought back; <Annotation annotationId="030074culotterouge" visited={visitedNotes.has("030074culotterouge")} annotationSelect={() => {openNote("030074culotterouge"); addToVisited("030074culotterouge")}} activeAnnotationId={currentNoteId}><i>Le Tutu</i>, five</Annotation> 
+        the slimy pier at Newhaven. <Annotation annotationId="030073paysayenn"><i>Comment?</i></Annotation> Rich booty you brought back; <Annotation annotationId="030074culotterouge"><i>Le Tutu</i>, five</Annotation> 
         <span data-edition="ed1939" data-page="33"> </span>
-        <Annotation annotationId="030074culotterouge" visited={visitedNotes.has("030074culotterouge")} annotationSelect={() => {openNote("030074culotterouge"); addToVisited("030074culotterouge")}} activeAnnotationId={currentNoteId}>tattered numbers of <i>Pantalon Blanc et Culotte Rouge</i></Annotation>; a
-        blue French telegram, <Annotation annotationId="030148notherdying" visited={visitedNotes.has("030148notherdying")} annotationSelect={() => {openNote("030148notherdying"); addToVisited("030148notherdying")}} activeAnnotationId={currentNoteId}>curiosity to show</Annotation>:
+        <Annotation annotationId="030074culotterouge">tattered numbers of <i>Pantalon Blanc et Culotte Rouge</i></Annotation>; a
+        blue French telegram, <Annotation annotationId="030148notherdying">curiosity to show</Annotation>:
       </p>
       <p>
-        <Annotation annotationId="030148notherdying" visited={visitedNotes.has("030148notherdying")} annotationSelect={() => {openNote("030148notherdying"); addToVisited("030148notherdying")}} activeAnnotationId={currentNoteId}>—{" "}Nother dying come home father.</Annotation>
+        <Annotation annotationId="030148notherdying">—{" "}Nother dying come home father.</Annotation>
       </p>
       <p>
-        The aunt thinks <Annotation annotationId="010042prayforme" visited={visitedNotes.has("010042prayforme")} annotationSelect={() => {openNote("010042prayforme"); addToVisited("010042prayforme")}} activeAnnotationId={currentNoteId}>you killed your mother</Annotation>. That's why she won't.
+        The aunt thinks <Annotation annotationId="010042prayforme">you killed your mother</Annotation>. That's why she won't.
       </p>
-      <p><Annotation annotationId="030104hannigan" visited={visitedNotes.has("030104hannigan")} annotationSelect={() => {openNote("030104hannigan"); addToVisited("030104hannigan")}} activeAnnotationId={currentNoteId}><i>Then here's a health to Mulligan's aunt <br/>
+      <p><Annotation annotationId="030104hannigan"><i>Then here's a health to Mulligan's aunt <br/>
         And I'll tell you the reason why. <br/>
         She always kept things decent in <br/>
         The Hannigan famileye.</i></Annotation>
       </p>
       <p>
         His feet marched in sudden proud rhythm over the sand furrows, along by
-        the boulders of <Annotation annotationId="030004pigeonhouse" visited={visitedNotes.has("030004pigeonhouse")} annotationSelect={() => {openNote("030004pigeonhouse"); addToVisited("030004pigeonhouse")}} activeAnnotationId={currentNoteId}>the south wall</Annotation>. He stared at them proudly, piled stone
+        the boulders of <Annotation annotationId="030004pigeonhouse">the south wall</Annotation>. He stared at them proudly, piled stone
         mammoth skulls. Gold light on sea, on sand, on boulders. The sun is
         there, the slender trees, the lemon houses.
       </p>
       <p>
         Paris rawly waking, crude sunlight on her lemon streets. Moist pith of
-        farls of bread, the <Annotation annotationId="030045absinthe" visited={visitedNotes.has("030045absinthe")} annotationSelect={() => {openNote("030045absinthe"); addToVisited("030045absinthe")}} activeAnnotationId={currentNoteId}>froggreen wormwood</Annotation>, her matin incense, court
-        the air. <Annotation annotationId="030031basta" visited={visitedNotes.has("030031basta")} annotationSelect={() => {openNote("030031basta"); addToVisited("030031basta")}} activeAnnotationId={currentNoteId}>Belluomo</Annotation> rises from the bed of his wife's lover's wife, the
+        farls of bread, the <Annotation annotationId="030045absinthe">froggreen wormwood</Annotation>, her matin incense, court
+        the air. <Annotation annotationId="030031basta">Belluomo</Annotation> rises from the bed of his wife's lover's wife, the
         kerchiefed housewife is astir, a saucer of acetic acid in her hands. In
         Rodot's Yvonne <span data-edition="ed1986" data-page="35"> </span>and Madeleine newmake their tumbled beauties, shattering
-        with gold teeth <Annotation annotationId="030022chaussons" visited={visitedNotes.has("030022chaussons")} annotationSelect={() => {openNote("030022chaussons"); addToVisited("030022chaussons")}} activeAnnotationId={currentNoteId}><i>chaussons</i></Annotation> of pastry, their mouths yellowed with <Annotation annotationId="030022chaussons" visited={visitedNotes.has("030022chaussons")} annotationSelect={() => {openNote("030022chaussons"); addToVisited("030022chaussons")}} activeAnnotationId={currentNoteId}>the
+        with gold teeth <Annotation annotationId="030022chaussons"><i>chaussons</i></Annotation> of pastry, their mouths yellowed with <Annotation annotationId="030022chaussons">the
         <i>pus</i> of <i>flan breton</i></Annotation>. Faces of Paris men go by, their wellpleased
-        pleasers, curled <Annotation annotationId="030022chaussons" visited={visitedNotes.has("030022chaussons")} annotationSelect={() => {openNote("030022chaussons"); addToVisited("030022chaussons")}} activeAnnotationId={currentNoteId}>conquistadores</Annotation>.
+        pleasers, curled <Annotation annotationId="030022chaussons">conquistadores</Annotation>.
       </p>
       <span data-edition="ed1922" data-page="42"></span>
       <p>
-        <Annotation annotationId="030143noonslumbers" visited={visitedNotes.has("030143noonslumbers")} annotationSelect={() => {openNote("030143noonslumbers"); addToVisited("030143noonslumbers")}} activeAnnotationId={currentNoteId}>Noon slumbers.</Annotation> <Annotation annotationId="030051kevinegan" visited={visitedNotes.has("030051kevinegan")} annotationSelect={() => {openNote("030051kevinegan"); addToVisited("030051kevinegan")}} activeAnnotationId={currentNoteId}>Kevin Egan rolls gunpowder cigarettes</Annotation> through fingers
-        smeared with printer's ink, sipping his <Annotation annotationId="030045absinthe" visited={visitedNotes.has("030045absinthe")} annotationSelect={() => {openNote("030045absinthe"); addToVisited("030045absinthe")}} activeAnnotationId={currentNoteId}>green fairy</Annotation> as Patrice his
-        white. About us gobblers fork spiced beans down their gullets. <Annotation annotationId="030022chaussons" visited={visitedNotes.has("030022chaussons")} annotationSelect={() => {openNote("030022chaussons"); addToVisited("030022chaussons")}} activeAnnotationId={currentNoteId}><i>Un demi
+        <Annotation annotationId="030143noonslumbers">Noon slumbers.</Annotation> <Annotation annotationId="030051kevinegan">Kevin Egan rolls gunpowder cigarettes</Annotation> through fingers
+        smeared with printer's ink, sipping his <Annotation annotationId="030045absinthe">green fairy</Annotation> as Patrice his
+        white. About us gobblers fork spiced beans down their gullets. <Annotation annotationId="030022chaussons"><i>Un demi
         setier!</i></Annotation> A jet of coffee steam from the burnished caldron. She serves me
-        at his beck. <Annotation annotationId="030022chaussons" visited={visitedNotes.has("030022chaussons")} annotationSelect={() => {openNote("030022chaussons"); addToVisited("030022chaussons")}} activeAnnotationId={currentNoteId}><i>Il est irlandais. Hollandais? Non fromage. Deux irlandais,
-        nous, Irlande,</i></Annotation> <span data-edition="ed1961" data-page="42"> </span><Annotation annotationId="030022chaussons" visited={visitedNotes.has("030022chaussons")} annotationSelect={() => {openNote("030022chaussons"); addToVisited("030022chaussons")}} activeAnnotationId={currentNoteId}>vous savez ah, oui!</Annotation> She thought you wanted a cheese
+        at his beck. <Annotation annotationId="030022chaussons"><i>Il est irlandais. Hollandais? Non fromage. Deux irlandais,
+        nous, Irlande,</i></Annotation> <span data-edition="ed1961" data-page="42"> </span><Annotation annotationId="030022chaussons">vous savez ah, oui!</Annotation> She thought you wanted a cheese
         <i>hollandais</i>. Your postprandial, do you know that word? Postprandial.
         There was a fellow I knew once in Barcelona, queer fellow, used to call
-        it his postprandial. Well: <Annotation annotationId="030036slainte" visited={visitedNotes.has("030036slainte")} annotationSelect={() => {openNote("030036slainte"); addToVisited("030036slainte")}} activeAnnotationId={currentNoteId}><i>slainte!</i></Annotation> Around the slabbed tables the
+        it his postprandial. Well: <Annotation annotationId="030036slainte"><i>slainte!</i></Annotation> Around the slabbed tables the
         tangle of wined breaths and grumbling gorges. His breath hangs over our
         saucestained plates, the green fairy's fang thrusting between his lips.
-        Of Ireland, the <Annotation annotationId="030086dalcassians" visited={visitedNotes.has("030086dalcassians")} annotationSelect={() => {openNote("030086dalcassians"); addToVisited("030086dalcassians")}} activeAnnotationId={currentNoteId}>Dalcassians</Annotation>, of hopes, conspiracies, of <Annotation annotationId="030037griffith" visited={visitedNotes.has("030037griffith")} annotationSelect={() => {openNote("030037griffith"); addToVisited("030037griffith")}} activeAnnotationId={currentNoteId}>Arthur Griffith</Annotation>
-        now. To yoke me<span data-edition="ed1932" data-page="39"> </span> as his <Annotation annotationId="030146yokefellow" visited={visitedNotes.has("030146yokefellow")} annotationSelect={() => {openNote("030146yokefellow"); addToVisited("030146yokefellow")}} activeAnnotationId={currentNoteId}>yokefellow</Annotation>,
-        our crimes our common cause. <Annotation annotationId="030090knowthevoice" visited={visitedNotes.has("030090knowthevoice")} annotationSelect={() => {openNote("030090knowthevoice"); addToVisited("030090knowthevoice")}} activeAnnotationId={currentNoteId}>You're your father's son. I know the voice.</Annotation>
+        Of Ireland, the <Annotation annotationId="030086dalcassians">Dalcassians</Annotation>, of hopes, conspiracies, of <Annotation annotationId="030037griffith">Arthur Griffith</Annotation>
+        now. To yoke me<span data-edition="ed1932" data-page="39"> </span> as his <Annotation annotationId="030146yokefellow">yokefellow</Annotation>,
+        our crimes our common cause. <Annotation annotationId="030090knowthevoice">You're your father's son. I know the voice.</Annotation>
         His fustian shirt, sanguineflowered, trembles its Spanish tassels at
-        his secrets. <Annotation annotationId="010122germanjews" visited={visitedNotes.has("010122germanjews")} annotationSelect={() => {openNote("010122germanjews"); addToVisited("010122germanjews")}} activeAnnotationId={currentNoteId}>M. Drumont, famous journalist</Annotation>, Drumont, know what he called
-        queen Victoria? Old hag with the yellow teeth. <Annotation annotationId="030022chaussons" visited={visitedNotes.has("030022chaussons")} annotationSelect={() => {openNote("030022chaussons"); addToVisited("030022chaussons")}} activeAnnotationId={currentNoteId}><i>Vieille ogresse</i>
-        with the <i>dents jaunes</i>.</Annotation> <Annotation annotationId="050002maudgonne" visited={visitedNotes.has("050002maudgonne")} annotationSelect={() => {openNote("050002maudgonne"); addToVisited("050002maudgonne")}} activeAnnotationId={currentNoteId}>Maud Gonne, beautiful woman, <i>La Patrie</i>, M.
-        Millevoye,</Annotation> <Annotation annotationId="030075licentious" visited={visitedNotes.has("030075licentious")} annotationSelect={() => {openNote("030075licentious"); addToVisited("030075licentious")}} activeAnnotationId={currentNoteId}>Félix Faure, know how he died? Licentious men.</Annotation> The <Annotation annotationId="030022chaussons" visited={visitedNotes.has("030022chaussons")} annotationSelect={() => {openNote("030022chaussons"); addToVisited("030022chaussons")}} activeAnnotationId={currentNoteId}>froeken,
+        his secrets. <Annotation annotationId="010122germanjews">M. Drumont, famous journalist</Annotation>, Drumont, know what he called
+        queen Victoria? Old hag with the yellow teeth. <Annotation annotationId="030022chaussons"><i>Vieille ogresse</i>
+        with the <i>dents jaunes</i>.</Annotation> <Annotation annotationId="050002maudgonne">Maud Gonne, beautiful woman, <i>La Patrie</i>, M.
+        Millevoye,</Annotation> <Annotation annotationId="030075licentious">Félix Faure, know how he died? Licentious men.</Annotation> The <Annotation annotationId="030022chaussons">froeken,
         <i>bonne à tout faire</i>, who rubs male nakedness in the bath at Upsala.
         <i>Moi faire</i>, she said, <i>Tous les messieurs</i>.</Annotation> Not this <i>Monsieur</i>, I
         said. Most licentious custom. Bath a most private thing. I wouldn't let
-        my brother, not even my own brother, most lascivious thing. <Annotation annotationId="030045absinthe" visited={visitedNotes.has("030045absinthe")} annotationSelect={() => {openNote("030045absinthe"); addToVisited("030045absinthe")}} activeAnnotationId={currentNoteId}>Green eyes,
+        my brother, not even my own brother, most lascivious thing. <Annotation annotationId="030045absinthe">Green eyes,
         I see you. Fang, I feel.</Annotation> Lascivious people.
       </p>
       <p>
         The blue fuse burns deadly between hands and burns clear. Loose
         tobaccoshreds catch fire: a flame and acrid smoke light our corner. Raw
-        facebones under his <Annotation annotationId="020043corpses" visited={visitedNotes.has("020043corpses")} annotationSelect={() => {openNote("020043corpses"); addToVisited("020043corpses")}} activeAnnotationId={currentNoteId}>peep of day boy</Annotation>'s hat. <Annotation annotationId="020073fenians" visited={visitedNotes.has("020073fenians")} annotationSelect={() => {openNote("020073fenians"); addToVisited("020073fenians")}} activeAnnotationId={currentNoteId}>How the head centre got away</Annotation>,
+        facebones under his <Annotation annotationId="020043corpses">peep of day boy</Annotation>'s hat. <Annotation annotationId="020073fenians">How the head centre got away</Annotation>,
         authentic version. Got up as a young bride, man, veil, orangeblossoms,
-        drove out <Annotation annotationId="030150malahide" visited={visitedNotes.has("030150malahide")} annotationSelect={() => {openNote("030150malahide"); addToVisited("030150malahide")}} activeAnnotationId={currentNoteId}>the road to Malahide</Annotation>. Did, faith. Of lost leaders, the
+        drove out <Annotation annotationId="030150malahide">the road to Malahide</Annotation>. Did, faith. Of lost leaders, the
         betrayed, wild escapes. Disguises, clutched at, gone, not here.
       </p>
       <span data-edition="ed1939" data-page="34"> </span>
       <p>
-        Spurned lover. I was a strapping young <Annotation annotationId="030036slainte" visited={visitedNotes.has("030036slainte")} annotationSelect={() => {openNote("030036slainte"); addToVisited("030036slainte")}} activeAnnotationId={currentNoteId}>gossoon</Annotation> at that time, I tell you.
+        Spurned lover. I was a strapping young <Annotation annotationId="030036slainte">gossoon</Annotation> at that time, I tell you.
         I'll show you my likeness one day. I was, faith. Lover, for her love he
-        <Annotation annotationId="020073fenians" visited={visitedNotes.has("020073fenians")} annotationSelect={() => {openNote("020073fenians"); addToVisited("020073fenians")}} activeAnnotationId={currentNoteId}>prowled with colonel Richard Burke, tanist of his sept, under the walls
+        <Annotation annotationId="020073fenians">prowled with colonel Richard Burke, tanist of his sept, under the walls
         of Clerkenwell</Annotation> and, crouching, saw a flame of vengeance hurl them upward
-        in the fog. <Annotation annotationId="020003daughtersofmemory" visited={visitedNotes.has("020003daughtersofmemory")} annotationSelect={() => {openNote("020003daughtersofmemory"); addToVisited("020003daughtersofmemory")}} activeAnnotationId={currentNoteId}>Shattered glass and toppling masonry.</Annotation> In gay Paree he hides,
+        in the fog. <Annotation annotationId="020003daughtersofmemory">Shattered glass and toppling masonry.</Annotation> In gay Paree he hides,
         Egan of Paris, unsought by any save by me. Making his day's stations,
-        the dingy printingcase, his three taverns, <Annotation annotationId="030043flyblownfaces" visited={visitedNotes.has("030043flyblownfaces")} annotationSelect={() => {openNote("030043flyblownfaces"); addToVisited("030043flyblownfaces")}} activeAnnotationId={currentNoteId}>the Montmartre lair he sleeps
+        the dingy printingcase, his three taverns, <Annotation annotationId="030043flyblownfaces">the Montmartre lair he sleeps
         short night in, rue de la Goutte-d'Or, damascened with flyblown faces of
         the gone.</Annotation> Loveless, landless, wifeless. She is quite nicey comfy
         without her outcast man, madame in rue Git-le-Coeur, 
         <span data-edition="ed1922" data-page="43"></span>canary and two
         buck lodgers. Peachy cheeks, a zebra skirt, frisky as a young thing's.
         Spurned and undespairing. Tell Pat you saw me, won't you? I wanted <span data-edition="ed1961" data-page="43"> </span>to
-        get poor Pat a job one time. <Annotation annotationId="030022chaussons" visited={visitedNotes.has("030022chaussons")} annotationSelect={() => {openNote("030022chaussons"); addToVisited("030022chaussons")}} activeAnnotationId={currentNoteId}><i>Mon fils</i></Annotation>, <Annotation annotationId="030027wildgoose" visited={visitedNotes.has("030027wildgoose")} annotationSelect={() => {openNote("030027wildgoose"); addToVisited("030027wildgoose")}} activeAnnotationId={currentNoteId}>soldier of France</Annotation>. I taught him
-        to sing <Annotation annotationId="030105boysofkilkenny" visited={visitedNotes.has("030105boysofkilkenny")} annotationSelect={() => {openNote("030105boysofkilkenny"); addToVisited("030105boysofkilkenny")}} activeAnnotationId={currentNoteId}><i>The boys of Kilkenny are</i> <span data-edition="ed1986" data-page="36"> </span><i>stout roaring blades</i></Annotation>. Know that old
-        lay? I taught Patrice that. <Annotation annotationId="030067oldkilkenny" visited={visitedNotes.has("030067oldkilkenny")} annotationSelect={() => {openNote("030067oldkilkenny"); addToVisited("030067oldkilkenny")}} activeAnnotationId={currentNoteId}>Old Kilkenny: saint Canice, Strongbow's
-        castle on the Nore.</Annotation> Goes like this. O, O. <Annotation annotationId="030106nappertandy" visited={visitedNotes.has("030106nappertandy")} annotationSelect={() => {openNote("030106nappertandy"); addToVisited("030106nappertandy")}} activeAnnotationId={currentNoteId}>He takes me, Napper Tandy, by
+        get poor Pat a job one time. <Annotation annotationId="030022chaussons"><i>Mon fils</i></Annotation>, <Annotation annotationId="030027wildgoose">soldier of France</Annotation>. I taught him
+        to sing <Annotation annotationId="030105boysofkilkenny"><i>The boys of Kilkenny are</i> <span data-edition="ed1986" data-page="36"> </span><i>stout roaring blades</i></Annotation>. Know that old
+        lay? I taught Patrice that. <Annotation annotationId="030067oldkilkenny">Old Kilkenny: saint Canice, Strongbow's
+        castle on the Nore.</Annotation> Goes like this. O, O. <Annotation annotationId="030106nappertandy">He takes me, Napper Tandy, by
         the hand.</Annotation>
       </p>
       <p></p>
-      <p>     <Annotation annotationId="030105boysofkilkenny" visited={visitedNotes.has("030105boysofkilkenny")} annotationSelect={() => {openNote("030105boysofkilkenny"); addToVisited("030105boysofkilkenny")}} activeAnnotationId={currentNoteId}><i>O, O the boys of <br/>
+      <p>     <Annotation annotationId="030105boysofkilkenny"><i>O, O the boys of <br/>
         Kilkenny...</i></Annotation>
       </p>
       <p>
         Weak wasting hand on mine. They have forgotten Kevin Egan, not he them.
-        <Annotation annotationId="030107rememberingthee" visited={visitedNotes.has("030107rememberingthee")} annotationSelect={() => {openNote("030107rememberingthee"); addToVisited("030107rememberingthee")}} activeAnnotationId={currentNoteId}>Remembering thee, O Sion.</Annotation>
+        <Annotation annotationId="030107rememberingthee">Remembering thee, O Sion.</Annotation>
       </p>
       <p>
-        He had come nearer <Annotation annotationId="030004pigeonhouse" visited={visitedNotes.has("030004pigeonhouse")} annotationSelect={() => {openNote("030004pigeonhouse"); addToVisited("030004pigeonhouse")}} activeAnnotationId={currentNoteId}>the edge of the sea</Annotation> and wet sand slapped his boots.
+        He had come nearer <Annotation annotationId="030004pigeonhouse">the edge of the sea</Annotation> and wet sand slapped his boots.
         The new air greeted him, harping in wild nerves, wind of wild air <span data-edition="ed1932" data-page="40"> </span>of
-        seeds of brightness. Here, I am not walking out to <Annotation annotationId="030013kishlightship" visited={visitedNotes.has("030013kishlightship")} annotationSelect={() => {openNote("030013kishlightship"); addToVisited("030013kishlightship")}} activeAnnotationId={currentNoteId}>the Kish lightship</Annotation>,
+        seeds of brightness. Here, I am not walking out to <Annotation annotationId="030013kishlightship">the Kish lightship</Annotation>,
         am I? He stood suddenly, his feet beginning to sink slowly in the
         quaking soil. Turn back.
       </p>
       <p>
         Turning, he scanned the shore south, his feet sinking again slowly
-        in new sockets. The <Annotation annotationId="010085towerlivingroom" visited={visitedNotes.has("010085towerlivingroom")} annotationSelect={() => {openNote("010085towerlivingroom"); addToVisited("010085towerlivingroom")}} activeAnnotationId={currentNoteId}>cold domed room of the tower waits. Through the
+        in new sockets. The <Annotation annotationId="010085towerlivingroom">cold domed room of the tower waits. Through the
         barbacans the shafts of light are moving</Annotation> ever, slowly ever as my
         feet are sinking, creeping duskward over the dial floor. Blue dusk,
         nightfall, deep blue night. In the darkness of the dome they wait,
         their pushedback chairs, my obelisk valise, around a board of abandoned
-        platters. Who to clear it? <Annotation annotationId="010146hugekey" visited={visitedNotes.has("010146hugekey")} annotationSelect={() => {openNote("010146hugekey"); addToVisited("010146hugekey")}} activeAnnotationId={currentNoteId}>He has the key. I will not sleep there when
+        platters. Who to clear it? <Annotation annotationId="010146hugekey">He has the key. I will not sleep there when
         this night comes.</Annotation> A shut door of a silent tower, entombing their blind
-        bodies, <Annotation annotationId="010025blackpanther" visited={visitedNotes.has("010025blackpanther")} annotationSelect={() => {openNote("010025blackpanther"); addToVisited("010025blackpanther")}} activeAnnotationId={currentNoteId}>the panthersahib and his pointer</Annotation>. Call: no answer. He lifted his
-        feet up from the suck and turned back by the <Annotation annotationId="030004pigeonhouse" visited={visitedNotes.has("030004pigeonhouse")} annotationSelect={() => {openNote("030004pigeonhouse"); addToVisited("030004pigeonhouse")}} activeAnnotationId={currentNoteId}>mole</Annotation> of boulders. <Annotation annotationId="020013candescent" visited={visitedNotes.has("020013candescent")} annotationSelect={() => {openNote("020013candescent"); addToVisited("020013candescent")}} activeAnnotationId={currentNoteId}>Take
+        bodies, <Annotation annotationId="010025blackpanther">the panthersahib and his pointer</Annotation>. Call: no answer. He lifted his
+        feet up from the suck and turned back by the <Annotation annotationId="030004pigeonhouse">mole</Annotation> of boulders. <Annotation annotationId="020013candescent">Take
         all, keep all. My soul walks with me, form of forms.</Annotation> So in the moon's
-        midwatches I pace the path above the rocks, <Annotation annotationId="030041likeawhale" visited={visitedNotes.has("030041likeawhale")} annotationSelect={() => {openNote("030041likeawhale"); addToVisited("030041likeawhale")}} activeAnnotationId={currentNoteId}>in sable silvered, hearing
+        midwatches I pace the path above the rocks, <Annotation annotationId="030041likeawhale">in sable silvered, hearing
         Elsinore's tempting flood.</Annotation>
       </p>
       <p>
         The flood is following me. I can watch it flow past from here. Get back
-        then by the <Annotation annotationId="030004pigeonhouse" visited={visitedNotes.has("030004pigeonhouse")} annotationSelect={() => {openNote("030004pigeonhouse"); addToVisited("030004pigeonhouse")}} activeAnnotationId={currentNoteId}>Poolbeg road</Annotation> to the strand there. He climbed over the sedge
+        then by the <Annotation annotationId="030004pigeonhouse">Poolbeg road</Annotation> to the strand there. He climbed over the sedge
         and eely oarweeds and sat on a stool of rock, resting his ashplant in a
         grike.
       </p>
       <p>
         A bloated carcass of a dog lay lolled on bladderwrack. Before him the
-        gunwale of a boat, sunk in sand. <Annotation annotationId="030052gautiersprose" visited={visitedNotes.has("030052gautiersprose")} annotationSelect={() => {openNote("030052gautiersprose"); addToVisited("030052gautiersprose")}} activeAnnotationId={currentNoteId}><i>Un coche ensablé</i>, Louis Veuillot
+        gunwale of a boat, sunk in sand. <Annotation annotationId="030052gautiersprose"><i>Un coche ensablé</i>, Louis Veuillot
         called Gautier's prose.</Annotation> These heavy sands are language tide and wind
         have silted here. And these, the stoneheaps of dead builders, a warren
         of weasel rats. Hide gold there. Try it. You have some. Sands and
-        stones. Heavy of the past. <Annotation annotationId="030053sirlout" visited={visitedNotes.has("030053sirlout")} annotationSelect={() => {openNote("030053sirlout"); addToVisited("030053sirlout")}} activeAnnotationId={currentNoteId}>Sir Lout's toys.</Annotation> Mind you don't get one
+        stones. Heavy of the past. <Annotation annotationId="030053sirlout">Sir Lout's toys.</Annotation> Mind you don't get one
         bang on the ear. I'm the bloody well gigant rolls all
         <span data-edition="ed1922" data-page="44"></span>them bloody well
         boulders, <span data-edition="ed1961" data-page="44"> </span>bones for my steppingstones. Feefawfum. I zmellz de bloodz odz
@@ -458,45 +458,45 @@ const Proteus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       <p>
         A point, live dog, grew into sight running across the sweep of sand.
         Lord, is he going to attack me? Respect his liberty. You will not
-        be <Annotation annotationId="030141masterslave" visited={visitedNotes.has("030141masterslave")} annotationSelect={() => {openNote("030141masterslave"); addToVisited("030141masterslave")}} activeAnnotationId={currentNoteId}>master of others or their slave</Annotation>. I have my stick. Sit tight. From
+        be <Annotation annotationId="030141masterslave">master of others or their slave</Annotation>. I have my stick. Sit tight. From
         farther away, walking shoreward across from the crested tide, figures,
-        two. <Annotation annotationId="030093twomaries" visited={visitedNotes.has("030093twomaries")} annotationSelect={() => {openNote("030093twomaries"); addToVisited("030093twomaries")}} activeAnnotationId={currentNoteId}>The two maries. They have tucked it safe among the bulrushes.</Annotation>
+        two. <Annotation annotationId="030093twomaries">The two maries. They have tucked it safe among the bulrushes.</Annotation>
         Peekaboo. I see you. No, the dog. He is running back to them. Who?
       </p>
       <p>
-        <Annotation annotationId="030046lochlanns" visited={visitedNotes.has("030046lochlanns")} annotationSelect={() => {openNote("030046lochlanns"); addToVisited("030046lochlanns")}} activeAnnotationId={currentNoteId}>Galleys of the Lochlanns</Annotation> ran here to beach, in quest of prey, their
-        bloodbeaked prows riding low on a molten pewter surf. <Annotation annotationId="030046lochlanns" visited={visitedNotes.has("030046lochlanns")} annotationSelect={() => {openNote("030046lochlanns"); addToVisited("030046lochlanns")}} activeAnnotationId={currentNoteId}>Dane vikings,
-        torcs</Annotation> <span data-edition="ed1986" data-page="37"> </span><Annotation annotationId="030046lochlanns" visited={visitedNotes.has("030046lochlanns")} annotationSelect={() => {openNote("030046lochlanns"); addToVisited("030046lochlanns")}} activeAnnotationId={currentNoteId}>of tomahawks aglitter on their breasts</Annotation> <Annotation annotationId="030120collarofgold" visited={visitedNotes.has("030120collarofgold")} annotationSelect={() => {openNote("030120collarofgold"); addToVisited("030120collarofgold")}} activeAnnotationId={currentNoteId}>when Malachi wore the
-        collar of gold.</Annotation> A school of <Annotation annotationId="030082famineplagueslaughters" visited={visitedNotes.has("030082famineplagueslaughters")} annotationSelect={() => {openNote("030082famineplagueslaughters"); addToVisited("030082famineplagueslaughters")}} activeAnnotationId={currentNoteId}>turlehide whales</Annotation> stranded in hot noon,
+        <Annotation annotationId="030046lochlanns">Galleys of the Lochlanns</Annotation> ran here to beach, in quest of prey, their
+        bloodbeaked prows riding low on a molten pewter surf. <Annotation annotationId="030046lochlanns">Dane vikings,
+        torcs</Annotation> <span data-edition="ed1986" data-page="37"> </span><Annotation annotationId="030046lochlanns">of tomahawks aglitter on their breasts</Annotation> <Annotation annotationId="030120collarofgold">when Malachi wore the
+        collar of gold.</Annotation> A school of <Annotation annotationId="030082famineplagueslaughters">turlehide whales</Annotation> stranded in hot noon,
         spouting, hobbling in the shallows. Then from the starving cagework city
         a horde of jerkined dwarfs, my people, with flayers' knives, running,
-        scaling, hacking in green blubbery whalemeat. <Annotation annotationId="030082famineplagueslaughters" visited={visitedNotes.has("030082famineplagueslaughters")} annotationSelect={() => {openNote("030082famineplagueslaughters"); addToVisited("030082famineplagueslaughters")}} activeAnnotationId={currentNoteId}>Famine, plague and</Annotation>
-        <span data-edition="ed1932" data-page="41"> </span><Annotation annotationId="030082famineplagueslaughters" visited={visitedNotes.has("030082famineplagueslaughters")} annotationSelect={() => {openNote("030082famineplagueslaughters"); addToVisited("030082famineplagueslaughters")}} activeAnnotationId={currentNoteId}>slaughters.</Annotation> Their blood is in me, their lusts my waves. I moved among
-        them on the <Annotation annotationId="030082famineplagueslaughters" visited={visitedNotes.has("030082famineplagueslaughters")} annotationSelect={() => {openNote("030082famineplagueslaughters"); addToVisited("030082famineplagueslaughters")}} activeAnnotationId={currentNoteId}>frozen Liffey</Annotation>, that I, a <Annotation annotationId="030087pastlife" visited={visitedNotes.has("030087pastlife")} annotationSelect={() => {openNote("030087pastlife"); addToVisited("030087pastlife")}} activeAnnotationId={currentNoteId}>changeling</Annotation>, among the spluttering
-        resin fires. <Annotation annotationId="030119nonetome" visited={visitedNotes.has("030119nonetome")} annotationSelect={() => {openNote("030119nonetome"); addToVisited("030119nonetome")}} activeAnnotationId={currentNoteId}>I spoke to no-one: none to me.</Annotation>
+        scaling, hacking in green blubbery whalemeat. <Annotation annotationId="030082famineplagueslaughters">Famine, plague and</Annotation>
+        <span data-edition="ed1932" data-page="41"> </span><Annotation annotationId="030082famineplagueslaughters">slaughters.</Annotation> Their blood is in me, their lusts my waves. I moved among
+        them on the <Annotation annotationId="030082famineplagueslaughters">frozen Liffey</Annotation>, that I, a <Annotation annotationId="030087pastlife">changeling</Annotation>, among the spluttering
+        resin fires. <Annotation annotationId="030119nonetome">I spoke to no-one: none to me.</Annotation>
       </p>
       <p>
-        The dog's bark ran towards him, stopped, ran back. <Annotation annotationId="030136dogofmyenemy" visited={visitedNotes.has("030136dogofmyenemy")} annotationSelect={() => {openNote("030136dogofmyenemy"); addToVisited("030136dogofmyenemy")}} activeAnnotationId={currentNoteId}>Dog of my enemy.</Annotation> I
-        just simply stood pale, <Annotation annotationId="030123bayedabout" visited={visitedNotes.has("030123bayedabout")} annotationSelect={() => {openNote("030123bayedabout"); addToVisited("030123bayedabout")}} activeAnnotationId={currentNoteId}>silent, bayed</Annotation> about. <Annotation annotationId="030102viditdeus" visited={visitedNotes.has("030102viditdeus")} annotationSelect={() => {openNote("030102viditdeus"); addToVisited("030102viditdeus")}} activeAnnotationId={currentNoteId}><i>Terribilia meditans</i>.</Annotation> A
-        <Annotation annotationId="010103waistcoat" visited={visitedNotes.has("010103waistcoat")} annotationSelect={() => {openNote("010103waistcoat"); addToVisited("010103waistcoat")}} activeAnnotationId={currentNoteId}>primrose doublet</Annotation>, <Annotation annotationId="030135fortunesknave" visited={visitedNotes.has("030135fortunesknave")} annotationSelect={() => {openNote("030135fortunesknave"); addToVisited("030135fortunesknave")}} activeAnnotationId={currentNoteId}>fortune's knave</Annotation>, smiled on <Annotation annotationId="010133monthlywash" visited={visitedNotes.has("010133monthlywash")} annotationSelect={() => {openNote("010133monthlywash"); addToVisited("010133monthlywash")}} activeAnnotationId={currentNoteId}>my fear</Annotation>. For that are you
-        pining, the bark of their applause? <Annotation annotationId="030058pretenders" visited={visitedNotes.has("030058pretenders")} annotationSelect={() => {openNote("030058pretenders"); addToVisited("030058pretenders")}} activeAnnotationId={currentNoteId}>Pretenders: live their lives. The
+        The dog's bark ran towards him, stopped, ran back. <Annotation annotationId="030136dogofmyenemy">Dog of my enemy.</Annotation> I
+        just simply stood pale, <Annotation annotationId="030123bayedabout">silent, bayed</Annotation> about. <Annotation annotationId="030102viditdeus"><i>Terribilia meditans</i>.</Annotation> A
+        <Annotation annotationId="010103waistcoat">primrose doublet</Annotation>, <Annotation annotationId="030135fortunesknave">fortune's knave</Annotation>, smiled on <Annotation annotationId="010133monthlywash">my fear</Annotation>. For that are you
+        pining, the bark of their applause? <Annotation annotationId="030058pretenders">Pretenders: live their lives. The
         Bruce's brother, Thomas Fitzgerald, silken knight, Perkin Warbeck,
         York's false scion, in breeches of silk of whiterose ivory, wonder of
         a day, and Lambert Simnel, with a tail of nans and sutlers, a scullion
-        crowned.</Annotation> All <Annotation annotationId="020078kingssons" visited={visitedNotes.has("020078kingssons")} annotationSelect={() => {openNote("020078kingssons"); addToVisited("020078kingssons")}} activeAnnotationId={currentNoteId}>kings' sons</Annotation>. Paradise of pretenders then and now. <Annotation annotationId="010026lifeguard" visited={visitedNotes.has("010026lifeguard")} annotationSelect={() => {openNote("010026lifeguard"); addToVisited("010026lifeguard")}} activeAnnotationId={currentNoteId}>He saved
-        men from drowning</Annotation> and you shake at a cur's yelping. But <Annotation annotationId="030057ownhouse" visited={visitedNotes.has("030057ownhouse")} annotationSelect={() => {openNote("030057ownhouse"); addToVisited("030057ownhouse")}} activeAnnotationId={currentNoteId}>the courtiers
+        crowned.</Annotation> All <Annotation annotationId="020078kingssons">kings' sons</Annotation>. Paradise of pretenders then and now. <Annotation annotationId="010026lifeguard">He saved
+        men from drowning</Annotation> and you shake at a cur's yelping. But <Annotation annotationId="030057ownhouse">the courtiers
         who mocked Guido in Or san Michele were in their own house.</Annotation> House of...
         We don't want any of your medieval abstrusiosities. Would you do what he
-        did? A boat would be near, a lifebuoy. <Annotation annotationId="030033frauenzimmer" visited={visitedNotes.has("030033frauenzimmer")} annotationSelect={() => {openNote("030033frauenzimmer"); addToVisited("030033frauenzimmer")}} activeAnnotationId={currentNoteId}><i>Natürlich</i></Annotation>, put there for you.
-        Would you or would you not? The <Annotation annotationId="010124fivefathoms" visited={visitedNotes.has("010124fivefathoms")} annotationSelect={() => {openNote("010124fivefathoms"); addToVisited("010124fivefathoms")}} activeAnnotationId={currentNoteId}>man that was drowned nine days ago</Annotation> off
-        <Annotation annotationId="010135bullockharbour" visited={visitedNotes.has("010135bullockharbour")} annotationSelect={() => {openNote("010135bullockharbour"); addToVisited("010135bullockharbour")}} activeAnnotationId={currentNoteId}>Maiden's rock</Annotation>. They are waiting for him now. The truth, spit it out. I
+        did? A boat would be near, a lifebuoy. <Annotation annotationId="030033frauenzimmer"><i>Natürlich</i></Annotation>, put there for you.
+        Would you or would you not? The <Annotation annotationId="010124fivefathoms">man that was drowned nine days ago</Annotation> off
+        <Annotation annotationId="010135bullockharbour">Maiden's rock</Annotation>. They are waiting for him now. The truth, spit it out. I
         would want to. I would try. I am not a strong swimmer. Water cold soft.
-        When I put my face into it in the basin at <Annotation annotationId="010157clongowes" visited={visitedNotes.has("010157clongowes")} annotationSelect={() => {openNote("010157clongowes"); addToVisited("010157clongowes")}} activeAnnotationId={currentNoteId}>Clongowes</Annotation>. Can't see! Who's
-        behind me? Out quickly, quickly! Do you see the <Annotation annotationId="030017tideflowing" visited={visitedNotes.has("030017tideflowing")} annotationSelect={() => {openNote("030017tideflowing"); addToVisited("030017tideflowing")}} activeAnnotationId={currentNoteId}>tide flowing quickly in</Annotation>
+        When I put my face into it in the basin at <Annotation annotationId="010157clongowes">Clongowes</Annotation>. Can't see! Who's
+        behind me? Out quickly, quickly! Do you see the <Annotation annotationId="030017tideflowing">tide flowing quickly in</Annotation>
         on all sides, sheeting the lows of sand quickly, <span data-edition="ed1961" data-page="45"> </span>shellcocoacoloured? If
         I had land under my feet. I want his life still to be his, mine to be
         mine. A drowning man. His human eyes scream to me out of horror of his
-        death. I... With him together down... I could not save her. <Annotation annotationId="010159bitterwaters" visited={visitedNotes.has("010159bitterwaters")} annotationSelect={() => {openNote("010159bitterwaters"); addToVisited("010159bitterwaters")}} activeAnnotationId={currentNoteId}>Waters:
+        death. I... With him together down... I could not save her. <Annotation annotationId="010159bitterwaters">Waters:
         bitter death:</Annotation> lost.
       </p>
       <span data-edition="ed1922" data-page="45"></span>
@@ -505,18 +505,18 @@ const Proteus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <p>
         Their dog ambled about a bank of dwindling sand, trotting, sniffing on
-        all sides. Looking for something lost in a <Annotation annotationId="030087pastlife" visited={visitedNotes.has("030087pastlife")} annotationSelect={() => {openNote("030087pastlife"); addToVisited("030087pastlife")}} activeAnnotationId={currentNoteId}>past life</Annotation>. Suddenly he made
+        all sides. Looking for something lost in a <Annotation annotationId="030087pastlife">past life</Annotation>. Suddenly he made
         off like a bounding hare, ears flung back, chasing the shadow of a
         lowskimming gull. The man's shrieked whistle struck his limp ears. He
-        turned, bounded back, came nearer, trotted on twinkling shanks. <Annotation annotationId="030089bucktrippant" visited={visitedNotes.has("030089bucktrippant")} annotationSelect={() => {openNote("030089bucktrippant"); addToVisited("030089bucktrippant")}} activeAnnotationId={currentNoteId}>On a
+        turned, bounded back, came nearer, trotted on twinkling shanks. <Annotation annotationId="030089bucktrippant">On a
         field tenney a buck, trippant, proper, unattired.</Annotation> At the lacefringe of
         the tide he halted with stiff forehoofs, seawardpointed ears. His
-        snout lifted barked at the wavenoise, herds of <Annotation annotationId="030089bucktrippant" visited={visitedNotes.has("030089bucktrippant")} annotationSelect={() => {openNote("030089bucktrippant"); addToVisited("030089bucktrippant")}} activeAnnotationId={currentNoteId}>seamorse. They serpented</Annotation>
+        snout lifted barked at the wavenoise, herds of <Annotation annotationId="030089bucktrippant">seamorse. They serpented</Annotation>
         towards his feet, curling, unfurling many crests, every ninth, breaking,
         plashing, from far, from farther out, waves and waves.
       </p>
       <p>
-        <Annotation annotationId="030080cockles" visited={visitedNotes.has("030080cockles")} annotationSelect={() => {openNote("030080cockles"); addToVisited("030080cockles")}} activeAnnotationId={currentNoteId}>Cocklepickers.</Annotation> They waded a little way in the water and, stooping,
+        <Annotation annotationId="030080cockles">Cocklepickers.</Annotation> They waded a little way in the water and, stooping,
         soused their bags and, lifting them again, waded out. The dog yelped
         running to them, reared up and pawed them, dropping on all fours, again
         reared up at them with mute bearish fawning. Unheeded he kept <span data-edition="ed1932" data-page="42"> </span>by them as
@@ -527,55 +527,55 @@ const Proteus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         calf's gallop. The carcass lay on his path. He stopped, sniffed, stalked
         round it, brother, nosing closer, went round it, sniffling rapidly like
         a dog all over the dead dog's bedraggled fell. Dogskull, dogsniff, eyes
-        on the ground, <Annotation annotationId="020067onegreatgoal" visited={visitedNotes.has("020067onegreatgoal")} annotationSelect={() => {openNote("020067onegreatgoal"); addToVisited("020067onegreatgoal")}} activeAnnotationId={currentNoteId}>moves to one great goal</Annotation>. Ah, poor dogsbody! Here lies
-        <Annotation annotationId="010047dogsbody" visited={visitedNotes.has("010047dogsbody")} annotationSelect={() => {openNote("010047dogsbody"); addToVisited("010047dogsbody")}} activeAnnotationId={currentNoteId}>poor dogsbody's body</Annotation>.
+        on the ground, <Annotation annotationId="020067onegreatgoal">moves to one great goal</Annotation>. Ah, poor dogsbody! Here lies
+        <Annotation annotationId="010047dogsbody">poor dogsbody's body</Annotation>.
       </p>
       <p>
         —{" "}Tatters! Out of that, you mongrel!
       </p>
       <p>
         The cry brought him skulking back to his master and a blunt bootless
-        kick sent him unscathed across a spit of sand, <Annotation annotationId="030153crouched" visited={visitedNotes.has("030153crouched")} annotationSelect={() => {openNote("030153crouched"); addToVisited("030153crouched")}} activeAnnotationId={currentNoteId}>crouched in flight</Annotation>. He
+        kick sent him unscathed across a spit of sand, <Annotation annotationId="030153crouched">crouched in flight</Annotation>. He
         slunk back in a curve. Doesn't see me. Along by the edge of the mole he
         lolloped, dawdled, smelt a rock and from under a cocked hindleg pissed
         against it. He trotted forward and, lifting his hindleg, pissed
         quick short at an unsmelt rock. The simple pleasures of the poor. His
         hindpaws then scattered the sand: then his forepaws dabbled and delved.
-        Something he buried there, <Annotation annotationId="020009ghoststory" visited={visitedNotes.has("020009ghoststory")} annotationSelect={() => {openNote("020009ghoststory"); addToVisited("020009ghoststory")}} activeAnnotationId={currentNoteId}>his grandmother.</Annotation> He rooted in the sand,
+        Something he buried there, <Annotation annotationId="020009ghoststory">his grandmother.</Annotation> He rooted in the sand,
         <span data-edition="ed1961" data-page="46"> </span>dabbling, delving and stopped to listen to the air, scraped up the sand
-        again with a fury of his claws, soon ceasing, <Annotation annotationId="030089bucktrippant" visited={visitedNotes.has("030089bucktrippant")} annotationSelect={() => {openNote("030089bucktrippant"); addToVisited("030089bucktrippant")}} activeAnnotationId={currentNoteId}>a pard, a panther, got in
+        again with a fury of his claws, soon ceasing, <Annotation annotationId="030089bucktrippant">a pard, a panther, got in
         spousebreach</Annotation>, vulturing the dead.
       </p>
       <p>
-        After <Annotation annotationId="010025blackpanther" visited={visitedNotes.has("010025blackpanther")} annotationSelect={() => {openNote("010025blackpanther"); addToVisited("010025blackpanther")}} activeAnnotationId={currentNoteId}>he woke me up</Annotation> last night same dream or was it? Wait. Open hallway.
-        Street of harlots. Remember. <Annotation annotationId="030055samedream" visited={visitedNotes.has("030055samedream")} annotationSelect={() => {openNote("030055samedream"); addToVisited("030055samedream")}} activeAnnotationId={currentNoteId}>Haroun al Raschid. I am almosting it.</Annotation> That
+        After <Annotation annotationId="010025blackpanther">he woke me up</Annotation> last night same dream or was it? Wait. Open hallway.
+        Street of harlots. Remember. <Annotation annotationId="030055samedream">Haroun al Raschid. I am almosting it.</Annotation> That
         man led me, spoke. I was not afraid. The melon he had he held against my
         face. Smiled: creamfruit smell. That was the rule, said. In. Come. Red
         carpet spread. You will see who.
       </p>
       <span data-edition="ed1922" data-page="46"></span>
       <p>
-        Shouldering their bags they trudged, the <Annotation annotationId="030078tinkers" visited={visitedNotes.has("030078tinkers")} annotationSelect={() => {openNote("030078tinkers"); addToVisited("030078tinkers")}} activeAnnotationId={currentNoteId}>red Egyptians</Annotation>. His blued feet
+        Shouldering their bags they trudged, the <Annotation annotationId="030078tinkers">red Egyptians</Annotation>. His blued feet
         out of turnedup trousers slapped the clammy sand, a dull brick muffler
         strangling his unshaven neck. With woman steps she followed: the
-        ruffian and his <Annotation annotationId="030079strollingmort" visited={visitedNotes.has("030079strollingmort")} annotationSelect={() => {openNote("030079strollingmort"); addToVisited("030079strollingmort")}} activeAnnotationId={currentNoteId}>strolling mort</Annotation>. Spoils slung at her back. Loose sand and
+        ruffian and his <Annotation annotationId="030079strollingmort">strolling mort</Annotation>. Spoils slung at her back. Loose sand and
         shellgrit crusted her bare feet. About her windraw face her hair trailed.
-        Behind her lord, his helpmate, <Annotation annotationId="030079strollingmort" visited={visitedNotes.has("030079strollingmort")} annotationSelect={() => {openNote("030079strollingmort"); addToVisited("030079strollingmort")}} activeAnnotationId={currentNoteId}>bing awast to Romeville</Annotation>. When night hides
-        her body's flaws calling under her brown shawl from <Annotation annotationId="030024archway" visited={visitedNotes.has("030024archway")} annotationSelect={() => {openNote("030024archway"); addToVisited("030024archway")}} activeAnnotationId={currentNoteId}>an archway</Annotation>
-        where dogs have mired. Her fancyman is treating two <Annotation annotationId="030118royaldublins" visited={visitedNotes.has("030118royaldublins")} annotationSelect={() => {openNote("030118royaldublins"); addToVisited("030118royaldublins")}} activeAnnotationId={currentNoteId}>Royal Dublins</Annotation> in
-        <Annotation annotationId="030059blackpitts" visited={visitedNotes.has("030059blackpitts")} annotationSelect={() => {openNote("030059blackpitts"); addToVisited("030059blackpitts")}} activeAnnotationId={currentNoteId}>O'Loughlin's of Blackpitts</Annotation>. Buss her, wap in rogues' rum lingo, for, O,
+        Behind her lord, his helpmate, <Annotation annotationId="030079strollingmort">bing awast to Romeville</Annotation>. When night hides
+        her body's flaws calling under her brown shawl from <Annotation annotationId="030024archway">an archway</Annotation>
+        where dogs have mired. Her fancyman is treating two <Annotation annotationId="030118royaldublins">Royal Dublins</Annotation> in
+        <Annotation annotationId="030059blackpitts">O'Loughlin's of Blackpitts</Annotation>. Buss her, wap in rogues' rum lingo, for, O,
         my dimber wapping dell! A shefiend's whiteness under her rancid rags.
-        <Annotation annotationId="030059blackpitts" visited={visitedNotes.has("030059blackpitts")} annotationSelect={() => {openNote("030059blackpitts"); addToVisited("030059blackpitts")}} activeAnnotationId={currentNoteId}>Fumbally's lane that night: the tanyard smells.</Annotation>
+        <Annotation annotationId="030059blackpitts">Fumbally's lane that night: the tanyard smells.</Annotation>
       </p>
-      <p><Annotation annotationId="030079strollingmort" visited={visitedNotes.has("030079strollingmort")} annotationSelect={() => {openNote("030079strollingmort"); addToVisited("030079strollingmort")}} activeAnnotationId={currentNoteId}><i>White thy fambles, red thy gan <br/>
+      <p><Annotation annotationId="030079strollingmort"><i>White thy fambles, red thy gan <br/>
         And thy quarrons dainty is. <br/>
         Couch a hogshead with me then. <br/>
         In the darkmans clip and kiss.</i></Annotation>
       </p>
       <span data-edition="ed1932" data-page="43"> </span>
       <p>
-        <Annotation annotationId="010102aquinas" visited={visitedNotes.has("010102aquinas")} annotationSelect={() => {openNote("010102aquinas"); addToVisited("010102aquinas")}} activeAnnotationId={currentNoteId}>Morose delectation Aquinas tunbelly calls this</Annotation>, <Annotation annotationId="030031basta" visited={visitedNotes.has("030031basta")} annotationSelect={() => {openNote("030031basta"); addToVisited("030031basta")}} activeAnnotationId={currentNoteId}><i>frate porcospino</i></Annotation>.
-        <Annotation annotationId="030083nakedeve" visited={visitedNotes.has("030083nakedeve")} annotationSelect={() => {openNote("030083nakedeve"); addToVisited("030083nakedeve")}} activeAnnotationId={currentNoteId}>Unfallen Adam rode and not rutted.</Annotation> Call away let him: <i>thy quarrons
+        <Annotation annotationId="010102aquinas">Morose delectation Aquinas tunbelly calls this</Annotation>, <Annotation annotationId="030031basta"><i>frate porcospino</i></Annotation>.
+        <Annotation annotationId="030083nakedeve">Unfallen Adam rode and not rutted.</Annotation> Call away let him: <i>thy quarrons
         dainty is</i>. Language no whit worse than his. Monkwords, marybeads jabber
         on their girdles: roguewords, tough nuggets patter in their pockets.
       </p>
@@ -584,28 +584,28 @@ const Proteus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <span data-edition="ed1986" data-page="39"> </span>
       <p>
-        A side eye at my <Annotation annotationId="010097latinquarterhat" visited={visitedNotes.has("010097latinquarterhat")} annotationSelect={() => {openNote("010097latinquarterhat"); addToVisited("010097latinquarterhat")}} activeAnnotationId={currentNoteId}>Hamlet hat</Annotation>. If I were suddenly naked here as I sit? I
-        am not. Across the sands of all the world, followed by the sun's <Annotation annotationId="030117eveninglands" visited={visitedNotes.has("030117eveninglands")} annotationSelect={() => {openNote("030117eveninglands"); addToVisited("030117eveninglands")}} activeAnnotationId={currentNoteId}>flaming
-        sword, to the west, trekking to evening lands.</Annotation> <Annotation annotationId="030140trascines" visited={visitedNotes.has("030140trascines")} annotationSelect={() => {openNote("030140trascines"); addToVisited("030140trascines")}} activeAnnotationId={currentNoteId}>She trudges, schlepps,
+        A side eye at my <Annotation annotationId="010097latinquarterhat">Hamlet hat</Annotation>. If I were suddenly naked here as I sit? I
+        am not. Across the sands of all the world, followed by the sun's <Annotation annotationId="030117eveninglands">flaming
+        sword, to the west, trekking to evening lands.</Annotation> <Annotation annotationId="030140trascines">She trudges, schlepps,
         trains, drags, trascines her load.</Annotation> A tide westering, moondrawn, in
-        her wake. Tides, myriadislanded, within her, blood not mine, <Annotation annotationId="010033epioinopaponton" visited={visitedNotes.has("010033epioinopaponton")} annotationSelect={() => {openNote("010033epioinopaponton"); addToVisited("010033epioinopaponton")}} activeAnnotationId={currentNoteId}><i>oinopa
-        ponton</i>, a winedark sea</Annotation>. <Annotation annotationId="030144handmaid" visited={visitedNotes.has("030144handmaid")} annotationSelect={() => {openNote("030144handmaid"); addToVisited("030144handmaid")}} activeAnnotationId={currentNoteId}>Behold the handmaid of the</Annotation>
+        her wake. Tides, myriadislanded, within her, blood not mine, <Annotation annotationId="010033epioinopaponton"><i>oinopa
+        ponton</i>, a winedark sea</Annotation>. <Annotation annotationId="030144handmaid">Behold the handmaid of the</Annotation>
         <span data-edition="ed1939" data-page="37"> </span>
-        <Annotation annotationId="030144handmaid" visited={visitedNotes.has("030144handmaid")} annotationSelect={() => {openNote("030144handmaid"); addToVisited("030144handmaid")}} activeAnnotationId={currentNoteId}> moon.</Annotation> In sleep
-        the wet sign calls her hour, bids her rise. Bridebed, childbed, <Annotation annotationId="010081staringoutofdeath" visited={visitedNotes.has("010081staringoutofdeath")} annotationSelect={() => {openNote("010081staringoutofdeath"); addToVisited("010081staringoutofdeath")}} activeAnnotationId={currentNoteId}>bed of</Annotation>
-        <span data-edition="ed1961" data-page="47"> </span><Annotation annotationId="010081staringoutofdeath" visited={visitedNotes.has("010081staringoutofdeath")} annotationSelect={() => {openNote("010081staringoutofdeath"); addToVisited("010081staringoutofdeath")}} activeAnnotationId={currentNoteId}>death, ghostcandled.</Annotation> <Annotation annotationId="030102viditdeus" visited={visitedNotes.has("030102viditdeus")} annotationSelect={() => {openNote("030102viditdeus"); addToVisited("030102viditdeus")}} activeAnnotationId={currentNoteId}><i>Omnis caro ad te veniet</i>.</Annotation> He comes, pale <Annotation annotationId="030149vampire" visited={visitedNotes.has("030149vampire")} annotationSelect={() => {openNote("030149vampire"); addToVisited("030149vampire")}} activeAnnotationId={currentNoteId}>vampire,
-        through storm his eyes, his bat sails bloodying the sea</Annotation>, <Annotation annotationId="090003hyde" visited={visitedNotes.has("090003hyde")} annotationSelect={() => {openNote("090003hyde"); addToVisited("090003hyde")}} activeAnnotationId={currentNoteId}>mouth to her
-        mouth</Annotation>'s <Annotation annotationId="180006lordbyron" visited={visitedNotes.has("180006lordbyron")} annotationSelect={() => {openNote("180006lordbyron"); addToVisited("180006lordbyron")}} activeAnnotationId={currentNoteId}>kiss</Annotation>.
+        <Annotation annotationId="030144handmaid"> moon.</Annotation> In sleep
+        the wet sign calls her hour, bids her rise. Bridebed, childbed, <Annotation annotationId="010081staringoutofdeath">bed of</Annotation>
+        <span data-edition="ed1961" data-page="47"> </span><Annotation annotationId="010081staringoutofdeath">death, ghostcandled.</Annotation> <Annotation annotationId="030102viditdeus"><i>Omnis caro ad te veniet</i>.</Annotation> He comes, pale <Annotation annotationId="030149vampire">vampire,
+        through storm his eyes, his bat sails bloodying the sea</Annotation>, <Annotation annotationId="090003hyde">mouth to her
+        mouth</Annotation>'s <Annotation annotationId="180006lordbyron">kiss</Annotation>.
       </p>
       <p>
-        Here. Put a pin in that chap, will you? <Annotation annotationId="030041likeawhale" visited={visitedNotes.has("030041likeawhale")} annotationSelect={() => {openNote("030041likeawhale"); addToVisited("030041likeawhale")}} activeAnnotationId={currentNoteId}>My tablets.</Annotation> Mouth to her kiss.  
+        Here. Put a pin in that chap, will you? <Annotation annotationId="030041likeawhale">My tablets.</Annotation> Mouth to her kiss.  
         No. Must be two of em. Glue em well. Mouth to her mouth's kiss.
       </p>
       <p>
         His lips lipped and mouthed fleshless lips of air: mouth to her womb.
         Oomb, allwombing tomb. His mouth moulded issuing breath, unspeeched:
         ooeeehah: roar of cataractic planets, globed, blazing, roaring
-        wayawayawayawayawayaway. Paper. The banknotes, blast them. Old <Annotation annotationId="020064telegraph" visited={visitedNotes.has("020064telegraph")} annotationSelect={() => {openNote("020064telegraph"); addToVisited("020064telegraph")}} activeAnnotationId={currentNoteId}>Deasy's
+        wayawayawayawayawayaway. Paper. The banknotes, blast them. Old <Annotation annotationId="020064telegraph">Deasy's
         letter</Annotation>. Here. Thanking you for the hospitality tear the blank end off.
         Turning his back to the <span data-edition="ed1922" data-page="47"></span>
         sun he bent over far to a table of rock and
@@ -614,19 +614,19 @@ const Proteus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <p>
         His shadow lay over the rocks as he bent, ending. Why not endless till
-        the farthest star? Darkly they are there behind this light, <Annotation annotationId="020023darkness" visited={visitedNotes.has("020023darkness")} annotationSelect={() => {openNote("020023darkness"); addToVisited("020023darkness")}} activeAnnotationId={currentNoteId}>darkness
-        shining in the brightness</Annotation>, <Annotation annotationId="030152delta" visited={visitedNotes.has("030152delta")} annotationSelect={() => {openNote("030152delta"); addToVisited("030152delta")}} activeAnnotationId={currentNoteId}>delta of Cassiopeia</Annotation>, worlds. <Annotation annotationId="030087pastlife" visited={visitedNotes.has("030087pastlife")} annotationSelect={() => {openNote("030087pastlife"); addToVisited("030087pastlife")}} activeAnnotationId={currentNoteId}>Me sits there</Annotation>
-        with his <Annotation annotationId="030145augursrod" visited={visitedNotes.has("030145augursrod")} annotationSelect={() => {openNote("030145augursrod"); addToVisited("030145augursrod")}} activeAnnotationId={currentNoteId}>augur's rod</Annotation> of ash, in <Annotation annotationId="020076brogues" visited={visitedNotes.has("020076brogues")} annotationSelect={() => {openNote("020076brogues"); addToVisited("020076brogues")}} activeAnnotationId={currentNoteId}>borrowed sandals</Annotation>, by day beside a livid
+        the farthest star? Darkly they are there behind this light, <Annotation annotationId="020023darkness">darkness
+        shining in the brightness</Annotation>, <Annotation annotationId="030152delta">delta of Cassiopeia</Annotation>, worlds. <Annotation annotationId="030087pastlife">Me sits there</Annotation>
+        with his <Annotation annotationId="030145augursrod">augur's rod</Annotation> of ash, in <Annotation annotationId="020076brogues">borrowed sandals</Annotation>, by day beside a livid
         sea, unbeheld, in violet night walking beneath a reign of uncouth stars.
         I throw this ended shadow from me, manshape ineluctable, call it back.
         Endless, would it be mine, form of my form? Who watches me here? Who
         ever anywhere will read these written words? Signs on a white field.
-        Somewhere to someone in your flutiest voice. <Annotation annotationId="030030colouredsigns" visited={visitedNotes.has("030030colouredsigns")} annotationSelect={() => {openNote("030030colouredsigns"); addToVisited("030030colouredsigns")}} activeAnnotationId={currentNoteId}>The good bishop of Cloyne
+        Somewhere to someone in your flutiest voice. <Annotation annotationId="030030colouredsigns">The good bishop of Cloyne
         took the veil of the temple out of his shovel hat: veil of space with
         coloured emblems hatched on its field.</Annotation> Hold hard. Coloured on a flat:
         yes, that's right. Flat I see, then think distance, near, far, flat
         I see, east, back. Ah, see now! Falls back suddenly, frozen in
-        <Annotation annotationId="030128stereoscope" visited={visitedNotes.has("030128stereoscope")} annotationSelect={() => {openNote("030128stereoscope"); addToVisited("030128stereoscope")}} activeAnnotationId={currentNoteId}>stereoscope</Annotation>. Click does the trick. You find my words dark. Darkness is
+        <Annotation annotationId="030128stereoscope">stereoscope</Annotation>. Click does the trick. You find my words dark. Darkness is
         in our souls do you not think? Flutier. Our souls, shamewounded by our
         sins, cling to us yet more, a woman to her lover clinging, the more the
         more.
@@ -635,51 +635,51 @@ const Proteus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       <p>
         She trusts me, her hand gentle, the longlashed eyes. Now where the blue
         hell am I bringing her beyond the veil? Into the ineluctable modality of
-        the ineluctable visuality. She, she, she. What she? The virgin at <Annotation annotationId="030049hodgesfiggis" visited={visitedNotes.has("030049hodgesfiggis")} annotationSelect={() => {openNote("030049hodgesfiggis"); addToVisited("030049hodgesfiggis")}} activeAnnotationId={currentNoteId}>Hodges
+        the ineluctable visuality. She, she, she. What she? The virgin at <Annotation annotationId="030049hodgesfiggis">Hodges
         Figgis'</Annotation> window on Monday looking in for one of the alphabet books you
         were going to write. Keen glance you gave her. Wrist through the
-        braided jesse of her sunshade. She lives in <Annotation annotationId="030130leesonpark" visited={visitedNotes.has("030130leesonpark")} annotationSelect={() => {openNote("030130leesonpark"); addToVisited("030130leesonpark")}} activeAnnotationId={currentNoteId}>Leeson park</Annotation> with a grief
-        and <Annotation annotationId="030131kickshaws" visited={visitedNotes.has("030131kickshaws")} annotationSelect={() => {openNote("030131kickshaws"); addToVisited("030131kickshaws")}} activeAnnotationId={currentNoteId}>kickshaws</Annotation>, a lady of letters. <Annotation annotationId="030132pickmeup" visited={visitedNotes.has("030132pickmeup")} annotationSelect={() => {openNote("030132pickmeup"); addToVisited("030132pickmeup")}} activeAnnotationId={currentNoteId}>Talk that to someone else, Stevie:</Annotation> <span data-edition="ed1961" data-page="48"> </span><Annotation annotationId="030132pickmeup" visited={visitedNotes.has("030132pickmeup")} annotationSelect={() => {openNote("030132pickmeup"); addToVisited("030132pickmeup")}} activeAnnotationId={currentNoteId}>a
+        braided jesse of her sunshade. She lives in <Annotation annotationId="030130leesonpark">Leeson park</Annotation> with a grief
+        and <Annotation annotationId="030131kickshaws">kickshaws</Annotation>, a lady of letters. <Annotation annotationId="030132pickmeup">Talk that to someone else, Stevie:</Annotation> <span data-edition="ed1961" data-page="48"> </span><Annotation annotationId="030132pickmeup">a
         pickmeup.</Annotation> Bet she wears those curse of God stays suspenders and
-        <Annotation annotationId="030131kickshaws" visited={visitedNotes.has("030131kickshaws")} annotationSelect={() => {openNote("030131kickshaws"); addToVisited("030131kickshaws")}} activeAnnotationId={currentNoteId}>yellow stockings</Annotation>, darned with lumpy wool. Talk about apple dumplings,
-        <Annotation annotationId="030031basta" visited={visitedNotes.has("030031basta")} annotationSelect={() => {openNote("030031basta"); addToVisited("030031basta")}} activeAnnotationId={currentNoteId}><i>piuttosto</i></Annotation>. Where are your wits?
+        <Annotation annotationId="030131kickshaws">yellow stockings</Annotation>, darned with lumpy wool. Talk about apple dumplings,
+        <Annotation annotationId="030031basta"><i>piuttosto</i></Annotation>. Where are your wits?
       </p>
       <span data-edition="ed1986" data-page="40"> </span>
       <p>
-        <Annotation annotationId="180006lordbyron" visited={visitedNotes.has("180006lordbyron")} annotationSelect={() => {openNote("180006lordbyron"); addToVisited("180006lordbyron")}} activeAnnotationId={currentNoteId}>Touch me. Soft eyes. Soft soft soft hand.</Annotation> I am lonely here. O, touch me
-        soon, now. What is <Annotation annotationId="010044painfretted" visited={visitedNotes.has("010044painfretted")} annotationSelect={() => {openNote("010044painfretted"); addToVisited("010044painfretted")}} activeAnnotationId={currentNoteId}>that word known to all men?</Annotation> I am quiet here alone.
+        <Annotation annotationId="180006lordbyron">Touch me. Soft eyes. Soft soft soft hand.</Annotation> I am lonely here. O, touch me
+        soon, now. What is <Annotation annotationId="010044painfretted">that word known to all men?</Annotation> I am quiet here alone.
         Sad too. Touch, touch me.
       </p>
       <p>
         He lay back at full stretch over the sharp rocks, cramming the scribbled
         note and pencil into a pocket, his hat tilted down on his eyes. That is
-        <Annotation annotationId="030010hislegs" visited={visitedNotes.has("030010hislegs")} annotationSelect={() => {openNote("030010hislegs"); addToVisited("030010hislegs")}} activeAnnotationId={currentNoteId}>Kevin Egan's movement</Annotation> I made, nodding for his nap, <Annotation annotationId="030102viditdeus" visited={visitedNotes.has("030102viditdeus")} annotationSelect={() => {openNote("030102viditdeus"); addToVisited("030102viditdeus")}} activeAnnotationId={currentNoteId}>sabbath sleep. <i>Et
-        vidit Deus. Et erant valde bona</i>.</Annotation> Alo! <Annotation annotationId="030138petitpied" visited={visitedNotes.has("030138petitpied")} annotationSelect={() => {openNote("030138petitpied"); addToVisited("030138petitpied")}} activeAnnotationId={currentNoteId}><i>Bonjour</i>.</Annotation> <Annotation annotationId="030112flowersinmay" visited={visitedNotes.has("030112flowersinmay")} annotationSelect={() => {openNote("030112flowersinmay"); addToVisited("030112flowersinmay")}} activeAnnotationId={currentNoteId}>Welcome as the flowers
+        <Annotation annotationId="030010hislegs">Kevin Egan's movement</Annotation> I made, nodding for his nap, <Annotation annotationId="030102viditdeus">sabbath sleep. <i>Et
+        vidit Deus. Et erant valde bona</i>.</Annotation> Alo! <Annotation annotationId="030138petitpied"><i>Bonjour</i>.</Annotation> <Annotation annotationId="030112flowersinmay">Welcome as the flowers
         in May.</Annotation> Under its leaf he watched through peacocktwittering lashes the
-        southing sun. <Annotation annotationId="030116panshour" visited={visitedNotes.has("030116panshour")} annotationSelect={() => {openNote("030116panshour"); addToVisited("030116panshour")}} activeAnnotationId={currentNoteId}>I am caught in this burning scene. Pan's hour, the faunal
+        southing sun. <Annotation annotationId="030116panshour">I am caught in this burning scene. Pan's hour, the faunal
         noon.</Annotation> Among gumheavy serpentplants, milkoozing fruits, where on the
         tawny waters leaves lie wide. Pain is far.
       </p>
       <span data-edition="ed1922" data-page="48"></span>
       <p>
-        <Annotation annotationId="010072bittermystery" visited={visitedNotes.has("010072bittermystery")} annotationSelect={() => {openNote("010072bittermystery"); addToVisited("010072bittermystery")}} activeAnnotationId={currentNoteId}><i>And no more turn aside and brood.</i></Annotation>
+        <Annotation annotationId="010072bittermystery"><i>And no more turn aside and brood.</i></Annotation>
       </p>
       <span data-edition="ed1939" data-page="38"> </span>
       <p>
-        His gaze brooded on his broadtoed boots, <Annotation annotationId="030010hislegs" visited={visitedNotes.has("030010hislegs")} annotationSelect={() => {openNote("030010hislegs"); addToVisited("030010hislegs")}} activeAnnotationId={currentNoteId}>a buck's castoffs</Annotation>,
+        His gaze brooded on his broadtoed boots, <Annotation annotationId="030010hislegs">a buck's castoffs</Annotation>,
         <i>nebeneinander</i>. He counted the creases of rucked leather wherein
         another's foot had nested warm. The foot that beat the ground in
-        <Annotation annotationId="030102viditdeus" visited={visitedNotes.has("030102viditdeus")} annotationSelect={() => {openNote("030102viditdeus"); addToVisited("030102viditdeus")}} activeAnnotationId={currentNoteId}>tripudium</Annotation>, foot I dislove. But you were delighted when Esther Osvalt's
-        shoe went on you: girl I knew in Paris. <Annotation annotationId="030138petitpied" visited={visitedNotes.has("030138petitpied")} annotationSelect={() => {openNote("030138petitpied"); addToVisited("030138petitpied")}} activeAnnotationId={currentNoteId}><i>Tiens, quel petit pied!</i></Annotation>
-        Staunch friend, a brother soul: <Annotation annotationId="030114darenotspeak" visited={visitedNotes.has("030114darenotspeak")} annotationSelect={() => {openNote("030114darenotspeak"); addToVisited("030114darenotspeak")}} activeAnnotationId={currentNoteId}>Wilde's love that dare not speak its
-        name.</Annotation> He now will leave me. And the blame? <Annotation annotationId="030115allornotatall" visited={visitedNotes.has("030115allornotatall")} annotationSelect={() => {openNote("030115allornotatall"); addToVisited("030115allornotatall")}} activeAnnotationId={currentNoteId}>As I
+        <Annotation annotationId="030102viditdeus">tripudium</Annotation>, foot I dislove. But you were delighted when Esther Osvalt's
+        shoe went on you: girl I knew in Paris. <Annotation annotationId="030138petitpied"><i>Tiens, quel petit pied!</i></Annotation>
+        Staunch friend, a brother soul: <Annotation annotationId="030114darenotspeak">Wilde's love that dare not speak its
+        name.</Annotation> He now will leave me. And the blame? <Annotation annotationId="030115allornotatall">As I
         am. As I am. All or not at all.</Annotation>
       </p>
       <p>
-        In long lassoes from the <Annotation annotationId="030011cocklake" visited={visitedNotes.has("030011cocklake")} annotationSelect={() => {openNote("030011cocklake"); addToVisited("030011cocklake")}} activeAnnotationId={currentNoteId}>Cock lake</Annotation> the water flowed full, covering
+        In long lassoes from the <Annotation annotationId="030011cocklake">Cock lake</Annotation> the water flowed full, covering
         greengoldenly lagoons of sand, rising, flowing. My ashplant will float
         away. I shall wait. No, they will pass on, passing, chafing against the
-        low rocks, swirling, passing. <Annotation annotationId="030012thisjob" visited={visitedNotes.has("030012thisjob")} annotationSelect={() => {openNote("030012thisjob"); addToVisited("030012thisjob")}} activeAnnotationId={currentNoteId}>Better get this job over quick.</Annotation> Listen: a
+        low rocks, swirling, passing. <Annotation annotationId="030012thisjob">Better get this job over quick.</Annotation> Listen: a
         fourworded wavespeech: seesoo, hrss, rsseeiss, ooos. Vehement breath of
         waters amid seasnakes, rearing horses, rocks. In cups of rocks it slops:
         flop, slop, slap: bounded in barrels. And, spent, its speech ceases. It
@@ -687,58 +687,58 @@ const Proteus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <p>
         Under the upswelling tide he saw the writhing weeds lift languidly and
-        sway reluctant arms, <Annotation annotationId="010086maryann" visited={visitedNotes.has("010086maryann")} annotationSelect={() => {openNote("010086maryann"); addToVisited("010086maryann")}} activeAnnotationId={currentNoteId}>hising up their petticoats</Annotation>, in whispering water
+        sway reluctant arms, <Annotation annotationId="010086maryann">hising up their petticoats</Annotation>, in whispering water
         swaying and upturning coy silver fronds. Day by day: night by night:
         <span data-edition="ed1932" data-page="45"> </span>lifted, flooded and let fall. Lord, they are weary; and, whispered to,
         they sigh. Saint Ambrose heard it, sigh of leaves and waves, waiting,
-        <Annotation annotationId="030068ingemiscit" visited={visitedNotes.has("030068ingemiscit")} annotationSelect={() => {openNote("030068ingemiscit"); addToVisited("030068ingemiscit")}} activeAnnotationId={currentNoteId}>awaiting the fullness of their times, <i>diebus ac noctibus iniurias
+        <Annotation annotationId="030068ingemiscit">awaiting the fullness of their times, <i>diebus ac noctibus iniurias
         patiens ingemiscit</i>.</Annotation> To no end gathered; vainly then released,
         forth <span data-edition="ed1961" data-page="49"> </span>flowing, wending back: loom of the moon. Weary too in sight of
-        lovers, <Annotation annotationId="030075licentious" visited={visitedNotes.has("030075licentious")} annotationSelect={() => {openNote("030075licentious"); addToVisited("030075licentious")}} activeAnnotationId={currentNoteId}>lascivious men</Annotation>, a <Annotation annotationId="030108hercourts" visited={visitedNotes.has("030108hercourts")} annotationSelect={() => {openNote("030108hercourts"); addToVisited("030108hercourts")}} activeAnnotationId={currentNoteId}>naked woman shining in her courts</Annotation>, she draws a
+        lovers, <Annotation annotationId="030075licentious">lascivious men</Annotation>, a <Annotation annotationId="030108hercourts">naked woman shining in her courts</Annotation>, she draws a
         toil of waters.
       </p>
       <p>
-        Five fathoms out there. <Annotation annotationId="010124fivefathoms" visited={visitedNotes.has("010124fivefathoms")} annotationSelect={() => {openNote("010124fivefathoms"); addToVisited("010124fivefathoms")}} activeAnnotationId={currentNoteId}>Full fathom five thy father lies.</Annotation> <Annotation annotationId="010125hightide" visited={visitedNotes.has("010125hightide")} annotationSelect={() => {openNote("010125hightide"); addToVisited("010125hightide")}} activeAnnotationId={currentNoteId}>At one, he
-        said.</Annotation> <Annotation annotationId="030069founddrowned" visited={visitedNotes.has("030069founddrowned")} annotationSelect={() => {openNote("030069founddrowned"); addToVisited("030069founddrowned")}} activeAnnotationId={currentNoteId}>Found drowned. High water at Dublin bar.</Annotation> Driving before it a loose
+        Five fathoms out there. <Annotation annotationId="010124fivefathoms">Full fathom five thy father lies.</Annotation> <Annotation annotationId="010125hightide">At one, he
+        said.</Annotation> <Annotation annotationId="030069founddrowned">Found drowned. High water at Dublin bar.</Annotation> Driving before it a loose
         drift of rubble, fanshoals of fishes, silly shells. A corpse rising
         saltwhite from the undertow, bobbing landward, a pace a pace a porpoise.
-        There he is. Hook it quick. <Annotation annotationId="020010lycidas" visited={visitedNotes.has("020010lycidas")} annotationSelect={() => {openNote("020010lycidas"); addToVisited("020010lycidas")}} activeAnnotationId={currentNoteId}>Sunk though he be beneath the watery
+        There he is. Hook it quick. <Annotation annotationId="020010lycidas">Sunk though he be beneath the watery
         floor.</Annotation> We have him. Easy now.
       </p>
       <p>
         Bag of corpsegas sopping in foul brine. A quiver of minnows, fat of a
-        spongy <Annotation annotationId="040019titbits" visited={visitedNotes.has("040019titbits")} annotationSelect={() => {openNote("040019titbits"); addToVisited("040019titbits")}} activeAnnotationId={currentNoteId}>titbit</Annotation>, flash through the slits of his buttoned trouserfly.
-        <Annotation annotationId="030129barnaclegoose" visited={visitedNotes.has("030129barnaclegoose")} annotationSelect={() => {openNote("030129barnaclegoose"); addToVisited("030129barnaclegoose")}} activeAnnotationId={currentNoteId}>God</Annotation> <span data-edition="ed1986" data-page="41"> </span><Annotation annotationId="030129barnaclegoose" visited={visitedNotes.has("030129barnaclegoose")} annotationSelect={() => {openNote("030129barnaclegoose"); addToVisited("030129barnaclegoose")}} activeAnnotationId={currentNoteId}>becomes man becomes fish becomes barnacle goose becomes</Annotation> <Annotation annotationId="010010mountains" visited={visitedNotes.has("010010mountains")} annotationSelect={() => {openNote("010010mountains"); addToVisited("010010mountains")}} activeAnnotationId={currentNoteId}>featherbed
+        spongy <Annotation annotationId="040019titbits">titbit</Annotation>, flash through the slits of his buttoned trouserfly.
+        <Annotation annotationId="030129barnaclegoose">God</Annotation> <span data-edition="ed1986" data-page="41"> </span><Annotation annotationId="030129barnaclegoose">becomes man becomes fish becomes barnacle goose becomes</Annotation> <Annotation annotationId="010010mountains">featherbed
         mountain</Annotation>. Dead breaths I living breathe, tread dead dust, devour a
         urinous offal from all dead. Hauled stark over the gunwale he breathes
-        upward the stench of <Annotation annotationId="010159bitterwaters" visited={visitedNotes.has("010159bitterwaters")} annotationSelect={() => {openNote("010159bitterwaters"); addToVisited("010159bitterwaters")}} activeAnnotationId={currentNoteId}>his green grave</Annotation>, his leprous nosehole snoring to
+        upward the stench of <Annotation annotationId="010159bitterwaters">his green grave</Annotation>, his leprous nosehole snoring to
         the sun.
       </p>
       <p>
-        A <Annotation annotationId="010124fivefathoms" visited={visitedNotes.has("010124fivefathoms")} annotationSelect={() => {openNote("010124fivefathoms"); addToVisited("010124fivefathoms")}} activeAnnotationId={currentNoteId}>seachange</Annotation> this, brown eyes saltblue. Seadeath, <Annotation annotationId="030028seadeath" visited={visitedNotes.has("030028seadeath")} annotationSelect={() => {openNote("030028seadeath"); addToVisited("030028seadeath")}} activeAnnotationId={currentNoteId}>mildest of all deaths</Annotation><span data-edition="ed1922" data-page="49"></span>
-        <Annotation annotationId="030028seadeath" visited={visitedNotes.has("030028seadeath")} annotationSelect={() => {openNote("030028seadeath"); addToVisited("030028seadeath")}} activeAnnotationId={currentNoteId}>known to man. Old Father Ocean.</Annotation> <Annotation annotationId="030029prixdeparis" visited={visitedNotes.has("030029prixdeparis")} annotationSelect={() => {openNote("030029prixdeparis"); addToVisited("030029prixdeparis")}} activeAnnotationId={currentNoteId}><i>Prix de Paris</i>: beware of imitations.
+        A <Annotation annotationId="010124fivefathoms">seachange</Annotation> this, brown eyes saltblue. Seadeath, <Annotation annotationId="030028seadeath">mildest of all deaths</Annotation><span data-edition="ed1922" data-page="49"></span>
+        <Annotation annotationId="030028seadeath">known to man. Old Father Ocean.</Annotation> <Annotation annotationId="030029prixdeparis"><i>Prix de Paris</i>: beware of imitations.
         Just you give it a fair trial. We enjoyed ourselves immensely.</Annotation>
       </p>
       <p>
-        Come. <Annotation annotationId="030109luciferdico" visited={visitedNotes.has("030109luciferdico")} annotationSelect={() => {openNote("030109luciferdico"); addToVisited("030109luciferdico")}} activeAnnotationId={currentNoteId}>I thirst.</Annotation> <Annotation annotationId="010074cloudcover" visited={visitedNotes.has("010074cloudcover")} annotationSelect={() => {openNote("010074cloudcover"); addToVisited("010074cloudcover")}} activeAnnotationId={currentNoteId}>Clouding over.</Annotation> No black clouds anywhere, are there?
-        Thunderstorm. <Annotation annotationId="030109luciferdico" visited={visitedNotes.has("030109luciferdico")} annotationSelect={() => {openNote("030109luciferdico"); addToVisited("030109luciferdico")}} activeAnnotationId={currentNoteId}>Allbright he falls, proud lightning of the intellect,
-        <i>Lucifer, dico, qui nescit occasum</i>.</Annotation> No. <Annotation annotationId="030081sandalshoon" visited={visitedNotes.has("030081sandalshoon")} annotationSelect={() => {openNote("030081sandalshoon"); addToVisited("030081sandalshoon")}} activeAnnotationId={currentNoteId}>My cockle hat and staff and
-        hismy sandal shoon.</Annotation> Where? <Annotation annotationId="030117eveninglands" visited={visitedNotes.has("030117eveninglands")} annotationSelect={() => {openNote("030117eveninglands"); addToVisited("030117eveninglands")}} activeAnnotationId={currentNoteId}>To evening lands.</Annotation> Evening will find itself.
+        Come. <Annotation annotationId="030109luciferdico">I thirst.</Annotation> <Annotation annotationId="010074cloudcover">Clouding over.</Annotation> No black clouds anywhere, are there?
+        Thunderstorm. <Annotation annotationId="030109luciferdico">Allbright he falls, proud lightning of the intellect,
+        <i>Lucifer, dico, qui nescit occasum</i>.</Annotation> No. <Annotation annotationId="030081sandalshoon">My cockle hat and staff and
+        hismy sandal shoon.</Annotation> Where? <Annotation annotationId="030117eveninglands">To evening lands.</Annotation> Evening will find itself.
       </p>
       <p>
-        He took the <Annotation annotationId="010099ashplant" visited={visitedNotes.has("010099ashplant")} annotationSelect={() => {openNote("010099ashplant"); addToVisited("010099ashplant")}} activeAnnotationId={currentNoteId}>hilt of his ashplant</Annotation>, lunging with it softly, dallying
+        He took the <Annotation annotationId="010099ashplant">hilt of his ashplant</Annotation>, lunging with it softly, dallying
         still. Yes, evening will find itself in me, without me. All days make
-        their end. By the way next when is it Tuesday will be <Annotation annotationId="030072longestday" visited={visitedNotes.has("030072longestday")} annotationSelect={() => {openNote("030072longestday"); addToVisited("030072longestday")}} activeAnnotationId={currentNoteId}>the longest
-        day</Annotation>. <Annotation annotationId="030088tennyson" visited={visitedNotes.has("030088tennyson")} annotationSelect={() => {openNote("030088tennyson"); addToVisited("030088tennyson")}} activeAnnotationId={currentNoteId}>Of all the glad new year, mother, the rum tum tiddledy tum. Lawn
-        Tennyson, gentleman poet.</Annotation> <Annotation annotationId="030031basta" visited={visitedNotes.has("030031basta")} annotationSelect={() => {openNote("030031basta"); addToVisited("030031basta")}} activeAnnotationId={currentNoteId}><i>Già</i></Annotation>. For the old hag with the yellow teeth.
+        their end. By the way next when is it Tuesday will be <Annotation annotationId="030072longestday">the longest
+        day</Annotation>. <Annotation annotationId="030088tennyson">Of all the glad new year, mother, the rum tum tiddledy tum. Lawn
+        Tennyson, gentleman poet.</Annotation> <Annotation annotationId="030031basta"><i>Già</i></Annotation>. For the old hag with the yellow teeth.
         And Monsieur Drumont, gentleman journalist. <i>Già</i>. My teeth are very
-        bad. Why, I wonder. Feel. That one is going too. <Annotation annotationId="030103shellgrit" visited={visitedNotes.has("030103shellgrit")} annotationSelect={() => {openNote("030103shellgrit"); addToVisited("030103shellgrit")}} activeAnnotationId={currentNoteId}>Shells.</Annotation> Ought I go to 
+        bad. Why, I wonder. Feel. That one is going too. <Annotation annotationId="030103shellgrit">Shells.</Annotation> Ought I go to 
         <span data-edition="ed1939" data-page="39"> </span>
-        a dentist, I wonder, with that money? That one. <Annotation annotationId="010130toothless" visited={visitedNotes.has("010130toothless")} annotationSelect={() => {openNote("010130toothless"); addToVisited("010130toothless")}} activeAnnotationId={currentNoteId}>Toothless</Annotation> Kinch, the
-        <Annotation annotationId="010129ubermensch" visited={visitedNotes.has("010129ubermensch")} annotationSelect={() => {openNote("010129ubermensch"); addToVisited("010129ubermensch")}} activeAnnotationId={currentNoteId}>superman.</Annotation> Why is that, I wonder, or does it mean something perhaps?
+        a dentist, I wonder, with that money? That one. <Annotation annotationId="010130toothless">Toothless</Annotation> Kinch, the
+        <Annotation annotationId="010129ubermensch">superman.</Annotation> Why is that, I wonder, or does it mean something perhaps?
       </p>
       <p>
-        My handkerchief. He threw it. I remember. <Annotation annotationId="030147takeitup" visited={visitedNotes.has("030147takeitup")} annotationSelect={() => {openNote("030147takeitup"); addToVisited("030147takeitup")}} activeAnnotationId={currentNoteId}>Did I not take it up?</Annotation>
+        My handkerchief. He threw it. I remember. <Annotation annotationId="030147takeitup">Did I not take it up?</Annotation>
       </p>
       <p>
         His hand groped vainly in his pockets. No, I didn't. Better buy one.
@@ -753,9 +753,9 @@ const Proteus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <span data-edition="ed1932" data-page="46"> </span>
       <p>
-        He turned his face over a shoulder, <Annotation annotationId="030089bucktrippant" visited={visitedNotes.has("030089bucktrippant")} annotationSelect={() => {openNote("030089bucktrippant"); addToVisited("030089bucktrippant")}} activeAnnotationId={currentNoteId}>rere regardant</Annotation>. <Annotation annotationId="030071threemaster" visited={visitedNotes.has("030071threemaster")} annotationSelect={() => {openNote("030071threemaster"); addToVisited("030071threemaster")}} activeAnnotationId={currentNoteId}>Moving through the
-        air high spars of a threemaster,</Annotation> her sails brailed up on the <Annotation annotationId="030070crosstrees" visited={visitedNotes.has("030070crosstrees")} annotationSelect={() => {openNote("030070crosstrees"); addToVisited("030070crosstrees")}} activeAnnotationId={currentNoteId}>crosstrees</Annotation>,
-        <Annotation annotationId="030137silentship" visited={visitedNotes.has("030137silentship")} annotationSelect={() => {openNote("030137silentship"); addToVisited("030137silentship")}} activeAnnotationId={currentNoteId}>homing, upstream, silently moving, a silent ship</Annotation>. 
+        He turned his face over a shoulder, <Annotation annotationId="030089bucktrippant">rere regardant</Annotation>. <Annotation annotationId="030071threemaster">Moving through the
+        air high spars of a threemaster,</Annotation> her sails brailed up on the <Annotation annotationId="030070crosstrees">crosstrees</Annotation>,
+        <Annotation annotationId="030137silentship">homing, upstream, silently moving, a silent ship</Annotation>. 
       </p>
       <br/><br/><br/>
       <span data-edition="ed1922" data-page="50"></span>

--- a/src/content/chapters/ScyllaAndCharybdis.js
+++ b/src/content/chapters/ScyllaAndCharybdis.js
@@ -2,13 +2,13 @@ import gloria from '../../assets/images/gloria.jpeg';
 import Annotation from "../../components/Annotation";
 
 
-const ScyllaAndCharybdis = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
+const ScyllaAndCharybdis = () => {
   return (
     <div>
       <p></p>
       <center><font size="+2">[9]</font></center>
       <br/>
-      Urbane, to comfort them, <Annotation annotationId="090004quakerlibrarian" visited={visitedNotes.has("090004quakerlibrarian")} annotationSelect={() => {openNote("090004quakerlibrarian"); addToVisited("090004quakerlibrarian")}} activeAnnotationId={currentNoteId}>the quaker librarian</Annotation> purred:
+      Urbane, to comfort them, <Annotation annotationId="090004quakerlibrarian">the quaker librarian</Annotation> purred:
       <p></p>
       <p>
         —{" "}And we have, have we not, those priceless pages of <i>Wilhelm Meister</i>?
@@ -77,7 +77,7 @@ const ScyllaAndCharybdis = ({openNote, currentNoteId, visitedNotes, addToVisited
       </p>
       <p>
         Cranly's eleven true Wicklowmen to free their sireland. Gaptoothed
-        Kathleen, her four beautiful green fields, <Annotation annotationId="010024stranger" visited={visitedNotes.has("010024stranger")} annotationSelect={() => {openNote("010024stranger"); addToVisited("010024stranger")}} activeAnnotationId={currentNoteId}>the stranger</Annotation> <span data-edition="ed1961" data-page="184">  </span>in her house.
+        Kathleen, her four beautiful green fields, <Annotation annotationId="010024stranger">the stranger</Annotation> <span data-edition="ed1961" data-page="184">  </span>in her house.
         And one more to hail him: <i>ave, rabbi</i>: the Tinahely twelve. In the
         shadow of the glen he cooees for them. My soul's youth I gave him, night
         by night. Godspeed. Good hunting.
@@ -164,7 +164,7 @@ const ScyllaAndCharybdis = ({openNote, currentNoteId, visitedNotes, addToVisited
       <span data-edition="ed1939" data-page="136"> </span>
       <p>
         Unsheathe your dagger definitions. Horseness is the whatness of
-        allhorse. Streams of tendency and <Annotation annotationId="010039mightymother" visited={visitedNotes.has("010039mightymother")} annotationSelect={() => {openNote("010039mightymother"); addToVisited("010039mightymother")}} activeAnnotationId={currentNoteId}>eons</Annotation> they worship. <Annotation annotationId="020069streetshout" visited={visitedNotes.has("020069streetshout")} annotationSelect={() => {openNote("020069streetshout"); addToVisited("020069streetshout")}} activeAnnotationId={currentNoteId}>God: noise in the
+        allhorse. Streams of tendency and <Annotation annotationId="010039mightymother">eons</Annotation> they worship. <Annotation annotationId="020069streetshout">God: noise in the
         street</Annotation>: very peripatetic. Space: what you damn well have to see. Through
         spaces smaller than red globules of man's blood they creepycrawl after
         Blake's buttocks into eternity of which this vegetable world is but a
@@ -183,29 +183,29 @@ const ScyllaAndCharybdis = ({openNote, currentNoteId, visitedNotes, addToVisited
       </p>
       <p>
         —{" "}I was showing him Jubainville's book. He's quite enthusiastic, don't
-        you know, about <Annotation annotationId="090003hyde" visited={visitedNotes.has("090003hyde")} annotationSelect={() => {openNote("090003hyde"); addToVisited("090003hyde")}} activeAnnotationId={currentNoteId}>Hyde's <i>Lovesongs of Connacht.</i></Annotation> I couldn't bring him in
+        you know, about <Annotation annotationId="090003hyde">Hyde's <i>Lovesongs of Connacht.</i></Annotation> I couldn't bring him in
         to hear the discussion. He's gone to Gill's to buy it.
       </p>
       <span data-edition="ed1922" data-page="178"> </span>
-      <p> <Annotation annotationId="090003hyde" visited={visitedNotes.has("090003hyde")} annotationSelect={() => {openNote("090003hyde"); addToVisited("090003hyde")}} activeAnnotationId={currentNoteId}> <i>Bound thee forth, my booklet, quick <br/>
+      <p> <Annotation annotationId="090003hyde"> <i>Bound thee forth, my booklet, quick <br/>
         To greet the callous public. <br/>
         Writ, I ween, 'twas not my wish <br/>
         In lean unlovely English.</i></Annotation>
       </p>
       <p>
-        —{" "}The <Annotation annotationId="060036bogs" visited={visitedNotes.has("060036bogs")} annotationSelect={() => {openNote("060036bogs"); addToVisited("060036bogs")}} activeAnnotationId={currentNoteId}>peatsmoke</Annotation> is going to his head, John Eglinton opined.
+        —{" "}The <Annotation annotationId="060036bogs">peatsmoke</Annotation> is going to his head, John Eglinton opined.
       </p>
       <p>
-        <Annotation annotationId="010141blamehistory" visited={visitedNotes.has("010141blamehistory")} annotationSelect={() => {openNote("010141blamehistory"); addToVisited("010141blamehistory")}} activeAnnotationId={currentNoteId}>We feel in England. Penitent thief.</Annotation> Gone. <Annotation annotationId="010142greenstone" visited={visitedNotes.has("010142greenstone")} annotationSelect={() => {openNote("010142greenstone"); addToVisited("010142greenstone")}} activeAnnotationId={currentNoteId}>I smoked his baccy. Green
+        <Annotation annotationId="010141blamehistory">We feel in England. Penitent thief.</Annotation> Gone. <Annotation annotationId="010142greenstone">I smoked his baccy. Green
         twinkling stone. An emerald set in the ring of the sea.</Annotation>
       </p>
       <p>
         —{" "}People do not know how dangerous lovesongs can be, the auric egg of
         Russell warned occultly. The movements which work revolutions in the
         world are born out of the dreams and visions in a peasant's heart on the
-        hillside. For them the earth <span data-edition="ed1961" data-page="186">  </span>is not an exploitable ground but <Annotation annotationId="010039mightymother" visited={visitedNotes.has("010039mightymother")} annotationSelect={() => {openNote("010039mightymother"); addToVisited("010039mightymother")}} activeAnnotationId={currentNoteId}>the
+        hillside. For them the earth <span data-edition="ed1961" data-page="186">  </span>is not an exploitable ground but <Annotation annotationId="010039mightymother">the
         living mother</Annotation>. The rarefied air of the academy and the arena produce the
-        sixshilling novel, <Annotation annotationId="040076musichall" visited={visitedNotes.has("040076musichall")} annotationSelect={() => {openNote("040076musichall"); addToVisited("040076musichall")}} activeAnnotationId={currentNoteId}>the musichall song</Annotation>. France produces the finest flower
+        sixshilling novel, <Annotation annotationId="040076musichall">the musichall song</Annotation>. France produces the finest flower
         of corruption in Mallarmé but the desirable life is revealed only to the
         poor of heart, the life of Homer's Phæacians.
       </p>
@@ -237,7 +237,7 @@ const ScyllaAndCharybdis = ({openNote, currentNoteId, visitedNotes, addToVisited
         point of view. <i>Hamlet ou</i>...
       </p>
       <p>
-        —{" "}The <Annotation annotationId="090001absentminded" visited={visitedNotes.has("090001absentminded")} annotationSelect={() => {openNote("090001absentminded"); addToVisited("090001absentminded")}} activeAnnotationId={currentNoteId}>absentminded beggar</Annotation>, Stephen ended.
+        —{" "}The <Annotation annotationId="090001absentminded">absentminded beggar</Annotation>, Stephen ended.
       </p>
       <p>
         John Eglinton laughed.
@@ -249,14 +249,14 @@ const ScyllaAndCharybdis = ({openNote, currentNoteId, visitedNotes, addToVisited
       </p>
       <span data-edition="ed1932" data-page="167">  </span>
       <p>
-        <Annotation annotationId="090001absentminded" visited={visitedNotes.has("090001absentminded")} annotationSelect={() => {openNote("090001absentminded"); addToVisited("090001absentminded")}} activeAnnotationId={currentNoteId}>Sumptuous and stagnant exaggeration of murder.</Annotation>
+        <Annotation annotationId="090001absentminded">Sumptuous and stagnant exaggeration of murder.</Annotation>
       </p>
       <span data-edition="ed1922" data-page="179"> </span>
       <p>
         —{" "}A deathsman of the soul Robert Greene called him, Stephen said. Not
         for nothing was he a butcher's son, wielding the sledded poleaxe and
         spitting in his palm. Nine lives are taken off for his father's one.
-        <Annotation annotationId="040077ourfather" visited={visitedNotes.has("040077ourfather")} annotationSelect={() => {openNote("040077ourfather"); addToVisited("040077ourfather")}} activeAnnotationId={currentNoteId}>Our Father who art in purgatory.</Annotation> Khaki Hamlets don't hesitate to
+        <Annotation annotationId="040077ourfather">Our Father who art in purgatory.</Annotation> Khaki Hamlets don't hesitate to
         shoot. The bloodboltered shambles in act five is a forecast of the
         concentration camp sung by Mr Swinburne.
       </p>
@@ -264,7 +264,7 @@ const ScyllaAndCharybdis = ({openNote, currentNoteId, visitedNotes, addToVisited
         Cranly, I his mute orderly, following battles from afar.
       </p>
       <p>
-        <Annotation annotationId="090008whelpsdams" visited={visitedNotes.has("090008whelpsdams")} annotationSelect={() => {openNote("090008whelpsdams"); addToVisited("090008whelpsdams")}} activeAnnotationId={currentNoteId}> <i>Whelps and dams of murderous foes whom none<br/> 
+        <Annotation annotationId="090008whelpsdams"> <i>Whelps and dams of murderous foes whom none<br/> 
         But we had spared...</i></Annotation>
       </p>
       <p>
@@ -314,7 +314,7 @@ const ScyllaAndCharybdis = ({openNote, currentNoteId, visitedNotes, addToVisited
         has other thoughts.
       </p>
       <p>
-        <Annotation annotationId="090013composition" visited={visitedNotes.has("090013composition")} annotationSelect={() => {openNote("090013composition"); addToVisited("090013composition")}} activeAnnotationId={currentNoteId}>Composition of place.</Annotation> <Annotation annotationId="010008jesuit" visited={visitedNotes.has("010008jesuit")} annotationSelect={() => {openNote("010008jesuit"); addToVisited("010008jesuit")}} activeAnnotationId={currentNoteId}>Ignatius Loyola</Annotation>, make haste to help me!
+        <Annotation annotationId="090013composition">Composition of place.</Annotation> <Annotation annotationId="010008jesuit">Ignatius Loyola</Annotation>, make haste to help me!
       </p>
       <span data-edition="ed1922" data-page="180"> </span>
       <p>
@@ -362,7 +362,7 @@ const ScyllaAndCharybdis = ({openNote, currentNoteId, visitedNotes, addToVisited
       <p>
         Mr Best's face, appealed to, agreed.
       </p>
-      <p style={{textIndent:"0px"}}> <Annotation annotationId="030042mananaan" visited={visitedNotes.has("030042mananaan")} annotationSelect={() => {openNote("030042mananaan"); addToVisited("030042mananaan")}} activeAnnotationId={currentNoteId}><i>Flow over them with your waves and with your waters, Mananaan,</i><br/>
+      <p style={{textIndent:"0px"}}> <Annotation annotationId="030042mananaan"><i>Flow over them with your waves and with your waters, Mananaan,</i><br/>
         <i>Mananaan MacLir...</i></Annotation>
       </p>
       <p>
@@ -376,7 +376,7 @@ const ScyllaAndCharybdis = ({openNote, currentNoteId, visitedNotes, addToVisited
       </p>
       <p>
         Go to! You spent most of it in Georgina Johnson's bed, clergyman's
-        daughter. <Annotation annotationId="010094agenbite" visited={visitedNotes.has("010094agenbite")} annotationSelect={() => {openNote("010094agenbite"); addToVisited("010094agenbite")}} activeAnnotationId={currentNoteId}>Agenbite of inwit.</Annotation>
+        daughter. <Annotation annotationId="010094agenbite">Agenbite of inwit.</Annotation>
       </p>
       <span data-edition="ed1922" data-page="181"> </span>
       <p>
@@ -418,10 +418,10 @@ const ScyllaAndCharybdis = ({openNote, currentNoteId, visitedNotes, addToVisited
       </p>
       <span data-edition="ed1961" data-page="189">  </span>
       <p>
-        <Annotation annotationId="050052conmee" visited={visitedNotes.has("050052conmee")} annotationSelect={() => {openNote("050052conmee"); addToVisited("050052conmee")}} activeAnnotationId={currentNoteId}>A child Conmee saved from pandies.</Annotation>
+        <Annotation annotationId="050052conmee">A child Conmee saved from pandies.</Annotation>
       </p>
       <p>
-        <Annotation annotationId="090002iiandi" visited={visitedNotes.has("090002iiandi")} annotationSelect={() => {openNote("090002iiandi"); addToVisited("090002iiandi")}} activeAnnotationId={currentNoteId}>I, I and I. I.</Annotation>
+        <Annotation annotationId="090002iiandi">I, I and I. I.</Annotation>
       </p>
       <p>
         A.E.I.O.U.
@@ -440,7 +440,7 @@ const ScyllaAndCharybdis = ({openNote, currentNoteId, visitedNotes, addToVisited
       <span data-edition="ed1939" data-page="139"> </span>
       <p>
         Mother's deathbed. Candle. The sheeted mirror. Who brought me into
-        this world lies there, bronzelidded, under few cheap flowers. <Annotation annotationId="010082liliatarutilantium" visited={visitedNotes.has("010082liliatarutilantium")} annotationSelect={() => {openNote("010082liliatarutilantium"); addToVisited("010082liliatarutilantium")}} activeAnnotationId={currentNoteId}><i>Liliata
+        this world lies there, bronzelidded, under few cheap flowers. <Annotation annotationId="010082liliatarutilantium"><i>Liliata
         rutilantium.</i></Annotation>
       </p>
       <p>
@@ -458,13 +458,13 @@ const ScyllaAndCharybdis = ({openNote, currentNoteId, visitedNotes, addToVisited
         errors are volitional and are the portals of discovery.
       </p>
       <p>
-        <Annotation annotationId="060006toadeyes" visited={visitedNotes.has("060006toadeyes")} annotationSelect={() => {openNote("060006toadeyes"); addToVisited("060006toadeyes")}} activeAnnotationId={currentNoteId}>Portals of discovery opened</Annotation> to let in the quaker librarian,
+        <Annotation annotationId="060006toadeyes">Portals of discovery opened</Annotation> to let in the quaker librarian,
         softcreakfooted, bald, eared and assiduous.
       </p>
       <p>
         —{" "}A shrew, John Eglinton said shrewdly, is not a useful portal of
         discovery, one should imagine. What useful discovery did Socrates learn
-        from <Annotation annotationId="090005shrewridden" visited={visitedNotes.has("090005shrewridden")} annotationSelect={() => {openNote("090005shrewridden"); addToVisited("090005shrewridden")}} activeAnnotationId={currentNoteId}>Xanthippe?</Annotation>
+        from <Annotation annotationId="090005shrewridden">Xanthippe?</Annotation>
       </p>
       <span data-edition="ed1922" data-page="182"> </span>
       <p>
@@ -472,7 +472,7 @@ const ScyllaAndCharybdis = ({openNote, currentNoteId, visitedNotes, addToVisited
         into the world. What he learnt from his other wife Myrto (<i>absit
         nomen!</i>), Socratididion's Epipsychidion, no man, not a woman, will ever
         know. But neither the midwife's lore nor the caudlelectures saved him
-        from the archons of Sinn Fein and their <Annotation annotationId="040090naggin" visited={visitedNotes.has("040090naggin")} annotationSelect={() => {openNote("040090naggin"); addToVisited("040090naggin")}} activeAnnotationId={currentNoteId}>naggin</Annotation> of hemlock.
+        from the archons of Sinn Fein and their <Annotation annotationId="040090naggin">naggin</Annotation> of hemlock.
       </p>
       <p>
         —{" "}But Ann Hathaway? Mr Best's quiet voice said forgetfully. Yes, we seem
@@ -490,7 +490,7 @@ const ScyllaAndCharybdis = ({openNote, currentNoteId, visitedNotes, addToVisited
         <i>The</i> <span data-edition="ed1986" data-page="156"> </span><i>girl I left behind me.</i> If the earthquake did not time it we should
         know where to place poor Wat, sitting in his form, the cry of hounds,
         the studded bridle and her blue windows. That memory, <i>Venus and
-        Adonis</i>, lay in the bedchamber of every <Annotation annotationId="090006lightoflove" visited={visitedNotes.has("090006lightoflove")} annotationSelect={() => {openNote("090006lightoflove"); addToVisited("090006lightoflove")}} activeAnnotationId={currentNoteId}>light-of-love</Annotation> in London.
+        Adonis</i>, lay in the bedchamber of every <Annotation annotationId="090006lightoflove">light-of-love</Annotation> in London.
         Is Katharine the shrew illfavoured? Hortensio calls her young and
         beautiful. Do you think the writer of <i>Antony and Cleopatra</i>, a
         passionate pilgrim, had his eyes in the back of his head that he chose
@@ -529,7 +529,7 @@ const ScyllaAndCharybdis = ({openNote, currentNoteId, visitedNotes, addToVisited
         cooperative watch.
       </p>
       <p>
-        —{" "}I am afraid I am due at the <Annotation annotationId="020077homestead" visited={visitedNotes.has("020077homestead")} annotationSelect={() => {openNote("020077homestead"); addToVisited("020077homestead")}} activeAnnotationId={currentNoteId}><i>Homestead</i></Annotation>.
+        —{" "}I am afraid I am due at the <Annotation annotationId="020077homestead"><i>Homestead</i></Annotation>.
       </p>
       <span data-edition="ed1939" data-page="140"> </span>
       <p>
@@ -598,7 +598,7 @@ const ScyllaAndCharybdis = ({openNote, currentNoteId, visitedNotes, addToVisited
         I hope you'll be able to come tonight. Malachi
         Mulligan is coming too. Moore asked him to bring Haines. Did you hear
         Miss Mitchell's joke about Moore and Martyn? That Moore is Martyn's
-        wild oats? Awfully clever, isn't it? <Annotation annotationId="090009donquixote" visited={visitedNotes.has("090009donquixote")} annotationSelect={() => {openNote("090009donquixote"); addToVisited("090009donquixote")}} activeAnnotationId={currentNoteId}>They remind one of Don Quixote and
+        wild oats? Awfully clever, isn't it? <Annotation annotationId="090009donquixote">They remind one of Don Quixote and
         Sancho Panza. Our national epic has yet to be written</Annotation>, Dr Sigerson says.
         Moore is the man for it. A knight of the rueful countenance here in
         Dublin. With a saffron kilt? O'Neill Russell? O, yes, he must speak the
@@ -613,7 +613,7 @@ const ScyllaAndCharybdis = ({openNote, currentNoteId, visitedNotes, addToVisited
       </p>
       <p>
         —{" "}Thank you very much, Mr Russell, Stephen said, rising. If you will be
-        so kind as to give the letter to <Annotation annotationId="020077homestead" visited={visitedNotes.has("020077homestead")} annotationSelect={() => {openNote("020077homestead"); addToVisited("020077homestead")}} activeAnnotationId={currentNoteId}>Mr Norman</Annotation>...
+        so kind as to give the letter to <Annotation annotationId="020077homestead">Mr Norman</Annotation>...
       </p>
       <span data-edition="ed1932" data-page="172">  </span>
       <p>
@@ -625,11 +625,11 @@ const ScyllaAndCharybdis = ({openNote, currentNoteId, visitedNotes, addToVisited
         —{" "}I understand, Stephen said. Thanks.
       </p>
       <p>
-        God ild you. The pigs' paper. <Annotation annotationId="020065bullockbefriending" visited={visitedNotes.has("020065bullockbefriending")} annotationSelect={() => {openNote("020065bullockbefriending"); addToVisited("020065bullockbefriending")}} activeAnnotationId={currentNoteId}>Bullockbefriending.</Annotation>
+        God ild you. The pigs' paper. <Annotation annotationId="020065bullockbefriending">Bullockbefriending.</Annotation>
       </p>
       <span data-edition="ed1939" data-page="141"> </span>
       <p>
-        <Annotation annotationId="090011synge" visited={visitedNotes.has("090011synge")} annotationSelect={() => {openNote("090011synge"); addToVisited("090011synge")}} activeAnnotationId={currentNoteId}>Synge</Annotation> has promised me an article for <i>Dana</i> too. Are we going to be
+        <Annotation annotationId="090011synge">Synge</Annotation> has promised me an article for <i>Dana</i> too. Are we going to be
         read? I feel we are. The Gaelic league wants something in Irish. I hope
         you will come round tonight. Bring Starkey.
       </p>
@@ -867,7 +867,7 @@ const ScyllaAndCharybdis = ({openNote, currentNoteId, visitedNotes, addToVisited
         <i>Romeo and Juliet</i>. Why? Belief in himself has been untimely killed. He
         was overborne in a cornfield first (ryefield, I should say) and he will
         never be a victor in his own eyes after nor play victoriously the game
-        of laugh and lie down. <Annotation annotationId="040025lacidarem" visited={visitedNotes.has("040025lacidarem")} annotationSelect={() => {openNote("040025lacidarem"); addToVisited("040025lacidarem")}} activeAnnotationId={currentNoteId}>Assumed dongiovannism</Annotation> will not save him. No later
+        of laugh and lie down. <Annotation annotationId="040025lacidarem">Assumed dongiovannism</Annotation> will not save him. No later
         undoing will undo the first undoing. The tusk of the boar has wounded
         him there where love lies ableeding. If the shrew is worsted yet there
         remains to her woman's invisible weapon. There is, I feel in the words,
@@ -903,7 +903,7 @@ const ScyllaAndCharybdis = ({openNote, currentNoteId, visitedNotes, addToVisited
       </p>
       <span data-edition="ed1939" data-page="144"> </span>
       <p>
-        Hast thou found me, <Annotation annotationId="010049shiptavern" visited={visitedNotes.has("010049shiptavern")} annotationSelect={() => {openNote("010049shiptavern"); addToVisited("010049shiptavern")}} activeAnnotationId={currentNoteId}>O mine enemy</Annotation>?
+        Hast thou found me, <Annotation annotationId="010049shiptavern">O mine enemy</Annotation>?
       </p>
       <p>
         <i>Entr'acte</i>.
@@ -917,18 +917,18 @@ const ScyllaAndCharybdis = ({openNote, currentNoteId, visitedNotes, addToVisited
         asked of Stephen.
       </p>
       <p>
-        <Annotation annotationId="010103waistcoat" visited={visitedNotes.has("010103waistcoat")} annotationSelect={() => {openNote("010103waistcoat"); addToVisited("010103waistcoat")}} activeAnnotationId={currentNoteId}>Primrosevested</Annotation> he greeted gaily with his doffed Panama as with a bauble.
+        <Annotation annotationId="010103waistcoat">Primrosevested</Annotation> he greeted gaily with his doffed Panama as with a bauble.
       </p>
       <p>
         They make him welcome. <i>Was Du verlachst wirst Du noch dienen.</i>
       </p>
       <p>
-        <Annotation annotationId="010119trinity" visited={visitedNotes.has("010119trinity")} annotationSelect={() => {openNote("010119trinity"); addToVisited("010119trinity")}} activeAnnotationId={currentNoteId}>Brood of mockers: Photius</Annotation>, pseudomalachi, Johann Most.
+        <Annotation annotationId="010119trinity">Brood of mockers: Photius</Annotation>, pseudomalachi, Johann Most.
       </p>
       <p>
         He Who Himself begot middler the Holy Ghost and Himself sent Himself,
         Agenbuyer, between Himself and others, Who, put upon by His fiends,
-        <Annotation annotationId="010095stripped" visited={visitedNotes.has("010095stripped")} annotationSelect={() => {openNote("010095stripped"); addToVisited("010095stripped")}} activeAnnotationId={currentNoteId}>stripped and whipped</Annotation>, was nailed like bat to barndoor, starved on
+        <Annotation annotationId="010095stripped">stripped and whipped</Annotation>, was nailed like bat to barndoor, starved on
         crosstree, Who let Him bury, stood up, harrowed hell, fared into heaven
         and there <span data-edition="ed1961" data-page="197">  </span>these nineteen hundred years sitteth on the right hand of His
         Own Self but yet shall come in the latter day to doom the quick and dead
@@ -963,7 +963,7 @@ const ScyllaAndCharybdis = ({openNote, currentNoteId, visitedNotes, addToVisited
       </p>
       <span data-edition="ed1932" data-page="177">  </span>
       <p>
-        —{" "}To be sure, he said, remembering brightly. <Annotation annotationId="090011synge" visited={visitedNotes.has("090011synge")} annotationSelect={() => {openNote("090011synge"); addToVisited("090011synge")}} activeAnnotationId={currentNoteId}>The chap that writes like
+        —{" "}To be sure, he said, remembering brightly. <Annotation annotationId="090011synge">The chap that writes like
         Synge.</Annotation>
       </p>
       <p>
@@ -1054,25 +1054,25 @@ const ScyllaAndCharybdis = ({openNote, currentNoteId, visitedNotes, addToVisited
         immense debtorship for a thing done.</i> Signed: Dedalus. Where did you
         launch it from? The kips? No. College Green. Have you drunk the four
         quid? The aunt is going to call on your unsubstantial father. Telegram!
-        Malachi Mulligan, <Annotation annotationId="010049shiptavern" visited={visitedNotes.has("010049shiptavern")} annotationSelect={() => {openNote("010049shiptavern"); addToVisited("010049shiptavern")}} activeAnnotationId={currentNoteId}>The Ship, lower Abbey street</Annotation>. <Annotation annotationId="010043mummer" visited={visitedNotes.has("010043mummer")} annotationSelect={() => {openNote("010043mummer"); addToVisited("010043mummer")}} activeAnnotationId={currentNoteId}>O, you peerless mummer!</Annotation>
+        Malachi Mulligan, <Annotation annotationId="010049shiptavern">The Ship, lower Abbey street</Annotation>. <Annotation annotationId="010043mummer">O, you peerless mummer!</Annotation>
         O, you priestified kinchite!
       </p>
       <p>
-        Joyfully he thrust message and envelope into a pocket but <Annotation annotationId="090012brogue" visited={visitedNotes.has("090012brogue")} annotationSelect={() => {openNote("090012brogue"); addToVisited("090012brogue")}} activeAnnotationId={currentNoteId}>keened</Annotation> <Annotation annotationId="090012brogue" visited={visitedNotes.has("090012brogue")} annotationSelect={() => {openNote("090012brogue"); addToVisited("090012brogue")}} activeAnnotationId={currentNoteId}>in a
+        Joyfully he thrust message and envelope into a pocket but <Annotation annotationId="090012brogue">keened</Annotation> <Annotation annotationId="090012brogue">in a
         querulous brogue:</Annotation>
       </p>
       <p>
-        <Annotation annotationId="090012brogue" visited={visitedNotes.has("090012brogue")} annotationSelect={() => {openNote("090012brogue"); addToVisited("090012brogue")}} activeAnnotationId={currentNoteId}>—{" "}It's what I'm telling you, mister honey, it's queer and sick we were,
+        <Annotation annotationId="090012brogue">—{" "}It's what I'm telling you, mister honey, it's queer and sick we were,
         Haines and myself, the time himself brought it in. 'Twas murmur we did
         for a gallus potion</Annotation> would rouse a friar, I'm thinking, and he limp with
-        leching. And we one hour and two hours and three hours in <Annotation annotationId="010049shiptavern" visited={visitedNotes.has("010049shiptavern")} annotationSelect={() => {openNote("010049shiptavern"); addToVisited("010049shiptavern")}} activeAnnotationId={currentNoteId}>Connery's</Annotation>
+        leching. And we one hour and two hours and three hours in <Annotation annotationId="010049shiptavern">Connery's</Annotation>
         sitting civil waiting for pints apiece.
       </p>
       <p>
         He wailed:
       </p>
       <p>
-        <Annotation annotationId="090012brogue" visited={visitedNotes.has("090012brogue")} annotationSelect={() => {openNote("090012brogue"); addToVisited("090012brogue")}} activeAnnotationId={currentNoteId}>—{" "}And we to be there, mavrone, and you to be unbeknownst sending us your
+        <Annotation annotationId="090012brogue">—{" "}And we to be there, mavrone, and you to be unbeknownst sending us your
         conglomerations the way we to have our tongues out a yard long like the
         drouthy clerics do be fainting for a pussful.</Annotation>
       </p>
@@ -1084,7 +1084,7 @@ const ScyllaAndCharybdis = ({openNote, currentNoteId, visitedNotes, addToVisited
         Quickly, warningfully Buck Mulligan bent down.
       </p>
       <p>
-        —{" "}<Annotation annotationId="090011synge" visited={visitedNotes.has("090011synge")} annotationSelect={() => {openNote("090011synge"); addToVisited("090011synge")}} activeAnnotationId={currentNoteId}>The tramper Synge is looking for you, he said, to murder you. He
+        —{" "}<Annotation annotationId="090011synge">The tramper Synge is looking for you, he said, to murder you. He
         heard you pissed on his halldoor in Glasthule. He's out in pampooties to
         murder you.</Annotation>
       </p>
@@ -1100,11 +1100,11 @@ const ScyllaAndCharybdis = ({openNote, currentNoteId, visitedNotes, addToVisited
       </p>
       <span data-edition="ed1939" data-page="146"> </span>
       <p>
-        <Annotation annotationId="090011synge" visited={visitedNotes.has("090011synge")} annotationSelect={() => {openNote("090011synge"); addToVisited("090011synge")}} activeAnnotationId={currentNoteId}>Harsh gargoyle face that warred against me over our mess of hash of</Annotation> 
-        <Annotation annotationId="090011synge" visited={visitedNotes.has("090011synge")} annotationSelect={() => {openNote("090011synge"); addToVisited("090011synge")}} activeAnnotationId={currentNoteId}> <span data-edition="ed1922" data-page="191"> </span>
+        <Annotation annotationId="090011synge">Harsh gargoyle face that warred against me over our mess of hash of</Annotation> 
+        <Annotation annotationId="090011synge"> <span data-edition="ed1922" data-page="191"> </span>
         lights in rue Saint-André-des-Arts.</Annotation> In words of words for words,
-        palabras. <Annotation annotationId="050036saintpatrick" visited={visitedNotes.has("050036saintpatrick")} annotationSelect={() => {openNote("050036saintpatrick"); addToVisited("050036saintpatrick")}} activeAnnotationId={currentNoteId}>Oisin with Patrick.</Annotation> Faunman he met in Clamart woods,
-        brandishing a winebottle. <i>C'est vendredi saint!</i> Murthering Irish. <Annotation annotationId="090011synge" visited={visitedNotes.has("090011synge")} annotationSelect={() => {openNote("090011synge"); addToVisited("090011synge")}} activeAnnotationId={currentNoteId}>His
+        palabras. <Annotation annotationId="050036saintpatrick">Oisin with Patrick.</Annotation> Faunman he met in Clamart woods,
+        brandishing a winebottle. <i>C'est vendredi saint!</i> Murthering Irish. <Annotation annotationId="090011synge">His
         image, wandering, he met. I mine.</Annotation> I met a fool i'the forest.
       </p>
       <p>
@@ -1165,14 +1165,14 @@ const ScyllaAndCharybdis = ({openNote, currentNoteId, visitedNotes, addToVisited
       </p>
       <span data-edition="ed1961" data-page="200">  </span>
       <p>
-        —{" "}What's his name? <Annotation annotationId="040050ikeymo" visited={visitedNotes.has("040050ikeymo")} annotationSelect={() => {openNote("040050ikeymo"); addToVisited("040050ikeymo")}} activeAnnotationId={currentNoteId}>Ikey Moses?</Annotation> Bloom.
+        —{" "}What's his name? <Annotation annotationId="040050ikeymo">Ikey Moses?</Annotation> Bloom.
       </p>
       <p>
         He rattled on:
       </p>
       <p>
-        —{" "}<Annotation annotationId="010087prepuces" visited={visitedNotes.has("010087prepuces")} annotationSelect={() => {openNote("010087prepuces"); addToVisited("010087prepuces")}} activeAnnotationId={currentNoteId}>Jehovah, collector of prepuces</Annotation>, is no more. <Annotation annotationId="010144nationallibrary" visited={visitedNotes.has("010144nationallibrary")} annotationSelect={() => {openNote("010144nationallibrary"); addToVisited("010144nationallibrary")}} activeAnnotationId={currentNoteId}>I found him over in the
-        museum</Annotation> where I went to hail the foamborn Aphrodite. <Annotation annotationId="010022hellenise" visited={visitedNotes.has("010022hellenise")} annotationSelect={() => {openNote("010022hellenise"); addToVisited("010022hellenise")}} activeAnnotationId={currentNoteId}>The Greek mouth that
+        —{" "}<Annotation annotationId="010087prepuces">Jehovah, collector of prepuces</Annotation>, is no more. <Annotation annotationId="010144nationallibrary">I found him over in the
+        museum</Annotation> where I went to hail the foamborn Aphrodite. <Annotation annotationId="010022hellenise">The Greek mouth that
         has never been twisted in prayer.</Annotation> Every day we must do homage to her.
         <i>Life of life, thy lips enkindle.</i>
       </p>
@@ -1180,10 +1180,10 @@ const ScyllaAndCharybdis = ({openNote, currentNoteId, visitedNotes, addToVisited
         Suddenly he turned to Stephen:
       </p>
       <p>
-        —{" "}He knows you. He knows your old fellow. O, I fear me, he is <Annotation annotationId="010022hellenise" visited={visitedNotes.has("010022hellenise")} annotationSelect={() => {openNote("010022hellenise"); addToVisited("010022hellenise")}} activeAnnotationId={currentNoteId}>Greeker
+        —{" "}He knows you. He knows your old fellow. O, I fear me, he is <Annotation annotationId="010022hellenise">Greeker
         than the Greeks. His pale Galilean eyes were upon her mesial groove.</Annotation>
         Venus <span data-edition="ed1922" data-page="192"> </span>
-        <Annotation annotationId="080005venus" visited={visitedNotes.has("080005venus")} annotationSelect={() => {openNote("080005venus"); addToVisited("080005venus")}} activeAnnotationId={currentNoteId}>Kallipyge.</Annotation> O, the thunder of those loins! <i>The god pursuing the
+        <Annotation annotationId="080005venus">Kallipyge.</Annotation> O, the thunder of those loins! <i>The god pursuing the
         maiden hid</i>.
       </p>
       <p>
@@ -1231,7 +1231,7 @@ const ScyllaAndCharybdis = ({openNote, currentNoteId, visitedNotes, addToVisited
         —{" "}Blessed Margaret Mary Anycock!
       </p>
       <p>
-        —{" "}And Harry of six wives' daughter. And other <Annotation annotationId="030088tennyson" visited={visitedNotes.has("030088tennyson")} annotationSelect={() => {openNote("030088tennyson"); addToVisited("030088tennyson")}} activeAnnotationId={currentNoteId}>lady friends from
+        —{" "}And Harry of six wives' daughter. And other <Annotation annotationId="030088tennyson">lady friends from
         neighbour seats as Lawn Tennyson, gentleman poet, sings.</Annotation> But all those
         twenty years what do you suppose poor Penelope in Stratford was doing
         behind the diamond panes?
@@ -1254,7 +1254,7 @@ const ScyllaAndCharybdis = ({openNote, currentNoteId, visitedNotes, addToVisited
         spurned. But the court wanton spurned him for a lord, his dearmylove.
       </p>
       <p>
-        <Annotation annotationId="030114darenotspeak" visited={visitedNotes.has("030114darenotspeak")} annotationSelect={() => {openNote("030114darenotspeak"); addToVisited("030114darenotspeak")}} activeAnnotationId={currentNoteId}>Love that dare not speak its name.</Annotation>
+        <Annotation annotationId="030114darenotspeak">Love that dare not speak its name.</Annotation>
       </p>
       <p>
         —{" "}As an Englishman, you mean, John sturdy Eglinton put in, he loved a
@@ -1360,7 +1360,7 @@ const ScyllaAndCharybdis = ({openNote, currentNoteId, visitedNotes, addToVisited
         —{" "}Antiquity mentions that Stagyrite schoolurchin and bald heathen sage,
         Stephen said, who when dying in exile frees and endows his slaves, pays
         tribute to his elders, wills to be laid in earth near the bones of his
-        dead wife and <Annotation annotationId="090005shrewridden" visited={visitedNotes.has("090005shrewridden")} annotationSelect={() => {openNote("090005shrewridden"); addToVisited("090005shrewridden")}} activeAnnotationId={currentNoteId}>bids his friends be kind to an old mistress (don't forget
+        dead wife and <Annotation annotationId="090005shrewridden">bids his friends be kind to an old mistress (don't forget
         Nell Gwynn Herpyllis) and let her live in his villa</Annotation>.
       </p>
       <span data-edition="ed1922" data-page="195"> </span><span data-edition="ed1986" data-page="167"> </span>
@@ -1386,7 +1386,7 @@ const ScyllaAndCharybdis = ({openNote, currentNoteId, visitedNotes, addToVisited
         Lovely!
       </p>
       <p>
-        <Annotation annotationId="010152linkedarm" visited={visitedNotes.has("010152linkedarm")} annotationSelect={() => {openNote("010152linkedarm"); addToVisited("010152linkedarm")}} activeAnnotationId={currentNoteId}>Catamite.</Annotation>
+        <Annotation annotationId="010152linkedarm">Catamite.</Annotation>
       </p>
       <p>
         —{" "}The sense of beauty leads us astray, said beautifulinsadness Best to
@@ -1413,11 +1413,11 @@ const ScyllaAndCharybdis = ({openNote, currentNoteId, visitedNotes, addToVisited
         Aubrey's ostler and callboy get rich quick? All events brought grist to
         his mill. Shylock chimes with the jewbaiting that followed the hanging
         and quartering of the queen's leech Lopez, his jew's heart being plucked
-        forth while <Annotation annotationId="040050ikeymo" visited={visitedNotes.has("040050ikeymo")} annotationSelect={() => {openNote("040050ikeymo"); addToVisited("040050ikeymo")}} activeAnnotationId={currentNoteId}>the sheeny</Annotation> was yet alive: <i>Hamlet</i> and <i>Macbeth</i> with
+        forth while <Annotation annotationId="040050ikeymo">the sheeny</Annotation> was yet alive: <i>Hamlet</i> and <i>Macbeth</i> with
         the coming <span data-edition="ed1961" data-page="204">  </span>to the throne of a Scotch philosophaster with a turn for
         witchroasting. The lost armada is his jeer in <i>Love's Labour Lost</i>.
         His pageants, the histories, sail fullbellied on a tide of Mafeking
-        enthusiasm. <Annotation annotationId="010008jesuit" visited={visitedNotes.has("010008jesuit")} annotationSelect={() => {openNote("010008jesuit"); addToVisited("010008jesuit")}} activeAnnotationId={currentNoteId}>Warwickshire jesuits are tried and we have a porter's theory
+        enthusiasm. <Annotation annotationId="010008jesuit">Warwickshire jesuits are tried and we have a porter's theory
         of equivocation.</Annotation> The <i>Sea Venture</i> comes home from Bermudas and the play
         Renan admired is written with Patsy Caliban, our American cousin.
         The sugared sonnets follow Sidney's. As for fay Elizabeth, otherwise
@@ -1426,7 +1426,7 @@ const ScyllaAndCharybdis = ({openNote, currentNoteId, visitedNotes, addToVisited
         meanings in the depths of the buckbasket.
       </p>
       <p>
-        I think you're getting on very nicely. <Annotation annotationId="090010nothoughts" visited={visitedNotes.has("090010nothoughts")} annotationSelect={() => {openNote("090010nothoughts"); addToVisited("090010nothoughts")}} activeAnnotationId={currentNoteId}>Just mix up a mixture of
+        I think you're getting on very nicely. <Annotation annotationId="090010nothoughts">Just mix up a mixture of
         theolologicophilolological. <i>Mingo, minxi, mictum, mingere.</i></Annotation>
       </p>
       <span data-edition="ed1922" data-page="196"> </span>
@@ -1460,7 +1460,7 @@ const ScyllaAndCharybdis = ({openNote, currentNoteId, visitedNotes, addToVisited
         There he keened a wailing rune.
       </p>
       <p>
-        —{" "}<i>Pogue mahone! Acushla machree!</i> <Annotation annotationId="090012brogue" visited={visitedNotes.has("090012brogue")} annotationSelect={() => {openNote("090012brogue"); addToVisited("090012brogue")}} activeAnnotationId={currentNoteId}>It's destroyed we are from this day!
+        —{" "}<i>Pogue mahone! Acushla machree!</i> <Annotation annotationId="090012brogue">It's destroyed we are from this day!
         It's destroyed we are surely!</Annotation>
       </p>
       <p>
@@ -1468,7 +1468,7 @@ const ScyllaAndCharybdis = ({openNote, currentNoteId, visitedNotes, addToVisited
       </p>
       <span data-edition="ed1939" data-page="150"> </span>
       <p>
-        —{" "}Saint Thomas, Stephen smiling said, whose <Annotation annotationId="010102aquinas" visited={visitedNotes.has("010102aquinas")} annotationSelect={() => {openNote("010102aquinas"); addToVisited("010102aquinas")}} activeAnnotationId={currentNoteId}>gorbellied works</Annotation> I enjoy
+        —{" "}Saint Thomas, Stephen smiling said, whose <Annotation annotationId="010102aquinas">gorbellied works</Annotation> I enjoy
         reading in the original, writing of incest from a standpoint different
         from that of the new Viennese school Mr Magee spoke of, likens it in his
         wise and curious way to an avarice of the emotions. He means that the
@@ -1515,7 +1515,7 @@ const ScyllaAndCharybdis = ({openNote, currentNoteId, visitedNotes, addToVisited
         Wives</i> and, loosing her nightly waters on the jordan, she thought
         over <i>Hooks and Eyes for Believers' Breeches</i> and <i>The most Spiritual
         Snuffbox to Make the Most Devout Souls Sneeze</i>. Venus has twisted her
-        lips in prayer. <Annotation annotationId="010094agenbite" visited={visitedNotes.has("010094agenbite")} annotationSelect={() => {openNote("010094agenbite"); addToVisited("010094agenbite")}} activeAnnotationId={currentNoteId}>Agenbite of inwit: remorse of conscience.</Annotation> It is an age
+        lips in prayer. <Annotation annotationId="010094agenbite">Agenbite of inwit: remorse of conscience.</Annotation> It is an age
         of exhausted whoredom groping for its god.
       </p>
       <p>
@@ -1562,7 +1562,7 @@ const ScyllaAndCharybdis = ({openNote, currentNoteId, visitedNotes, addToVisited
         mystery and not on the madonna which the cunning Italian intellect
         flung to the mob of Europe the church is founded and founded irremovably
         because founded, like the world, macro and microcosm, upon the void.
-        Upon incertitude, upon unlikelihood. <Annotation annotationId="020024amormatris" visited={visitedNotes.has("020024amormatris")} annotationSelect={() => {openNote("020024amormatris"); addToVisited("020024amormatris")}} activeAnnotationId={currentNoteId}><i>Amor matris</i>, subjective and
+        Upon incertitude, upon unlikelihood. <Annotation annotationId="020024amormatris"><i>Amor matris</i>, subjective and
         objective genitive, may be the only true thing in life</Annotation>. Paternity may be
         a legal fiction. Who is the father of any son that any son should love
         him or he any son?
@@ -1574,7 +1574,7 @@ const ScyllaAndCharybdis = ({openNote, currentNoteId, visitedNotes, addToVisited
         I know. Shut up. Blast you. I have reasons.
       </p>
       <p>
-        <Annotation annotationId="090010nothoughts" visited={visitedNotes.has("090010nothoughts")} annotationSelect={() => {openNote("090010nothoughts"); addToVisited("090010nothoughts")}} activeAnnotationId={currentNoteId}>Just <i>Amplius. Adhuc. Iterum. Postea.</i></Annotation>
+        <Annotation annotationId="090010nothoughts">Just <i>Amplius. Adhuc. Iterum. Postea.</i></Annotation>
       </p>
       <p>
         Are you condemned to do this?
@@ -1584,7 +1584,7 @@ const ScyllaAndCharybdis = ({openNote, currentNoteId, visitedNotes, addToVisited
         annals of the world, stained with all other incests and bestialities,
         hardly record its breach. Sons with mothers, sires with daughters,
         lesbic sisters, loves that dare not speak their name, nephews with
-        grandmothers, jailbirds with keyholes, <Annotation annotationId="010020ancientgreek" visited={visitedNotes.has("010020ancientgreek")} annotationSelect={() => {openNote("010020ancientgreek"); addToVisited("010020ancientgreek")}} activeAnnotationId={currentNoteId}>queens with prize bulls</Annotation>. The son
+        grandmothers, jailbirds with keyholes, <Annotation annotationId="010020ancientgreek">queens with prize bulls</Annotation>. The son
         unborn mars beauty: born, he brings pain, divides affection, increases
         care. He is a <span data-edition="ed1961" data-page="207">  </span>male: his growth is his father's decline, his youth
         his father's envy, his friend his father's enemy.
@@ -1737,9 +1737,9 @@ const ScyllaAndCharybdis = ({openNote, currentNoteId, visitedNotes, addToVisited
         sable a spear or steeled argent, honorificabilitudinitatibus, dearer
         than his glory of greatest shakescene in the country. What's in a name?
         That is what we ask ourselves in childhood when we write the name that
-        we are told is ours. <Annotation annotationId="030152delta" visited={visitedNotes.has("030152delta")} annotationSelect={() => {openNote("030152delta"); addToVisited("030152delta")}} activeAnnotationId={currentNoteId}>A star, a daystar, a firedrake, rose at his birth.
+        we are told is ours. <Annotation annotationId="030152delta">A star, a daystar, a firedrake, rose at his birth.
         It shone by day in the heavens alone, brighter than Venus in the
-        night, and by night it shone</Annotation> <span data-edition="ed1932" data-page="188">  </span><Annotation annotationId="030152delta" visited={visitedNotes.has("030152delta")} annotationSelect={() => {openNote("030152delta"); addToVisited("030152delta")}} activeAnnotationId={currentNoteId}>over delta in Cassiopeia, the recumbent
+        night, and by night it shone</Annotation> <span data-edition="ed1932" data-page="188">  </span><Annotation annotationId="030152delta">over delta in Cassiopeia, the recumbent
         constellation which is the signature of his initial among the stars.</Annotation> His
         eyes watched it, lowlying on the horizon, eastward of the bear, as
         he walked by the slumberous summer fields at midnight returning from
@@ -1769,7 +1769,7 @@ const ScyllaAndCharybdis = ({openNote, currentNoteId, visitedNotes, addToVisited
         celestial phenomenon?
       </p>
       <p>
-        —{" "}<Annotation annotationId="030152delta" visited={visitedNotes.has("030152delta")} annotationSelect={() => {openNote("030152delta"); addToVisited("030152delta")}} activeAnnotationId={currentNoteId}>A star by night, Stephen said. A pillar of the cloud by day.</Annotation>
+        —{" "}<Annotation annotationId="030152delta">A star by night, Stephen said. A pillar of the cloud by day.</Annotation>
       </p>
       <p>
         What more's to speak?
@@ -1789,7 +1789,7 @@ const ScyllaAndCharybdis = ({openNote, currentNoteId, visitedNotes, addToVisited
         Me, Magee and Mulligan.
       </p>
       <p>
-        <Annotation annotationId="010020ancientgreek" visited={visitedNotes.has("010020ancientgreek")} annotationSelect={() => {openNote("010020ancientgreek"); addToVisited("010020ancientgreek")}} activeAnnotationId={currentNoteId}>Fabulous artificer. The hawklike man. You flew. Whereto?
+        <Annotation annotationId="010020ancientgreek">Fabulous artificer. The hawklike man. You flew. Whereto?
         Newhaven-Dieppe, steerage passenger. Paris and back. Lapwing. Icarus.
         <i>Pater, ait.</i> Seabedabbled, fallen, weltering. Lapwing you are. Lapwing
         be.</Annotation>
@@ -1907,7 +1907,7 @@ const ScyllaAndCharybdis = ({openNote, currentNoteId, visitedNotes, addToVisited
       </p>
       <span data-edition="ed1939" data-page="155"> </span>
       <p>
-        <Annotation annotationId="090010nothoughts" visited={visitedNotes.has("090010nothoughts")} annotationSelect={() => {openNote("090010nothoughts"); addToVisited("090010nothoughts")}} activeAnnotationId={currentNoteId}>He laughed to free his mind from his mind's bondage.</Annotation>
+        <Annotation annotationId="090010nothoughts">He laughed to free his mind from his mind's bondage.</Annotation>
       </p>
       <p>
         Judge Eglinton summed up.
@@ -1925,7 +1925,7 @@ const ScyllaAndCharybdis = ({openNote, currentNoteId, visitedNotes, addToVisited
       </p>
       <span data-edition="ed1986" data-page="174"> </span>
       <p>
-        —{" "} <Annotation annotationId="130005cuckoo" visited={visitedNotes.has("130005cuckoo")} annotationSelect={() => {openNote("130005cuckoo"); addToVisited("130005cuckoo")}} activeAnnotationId={currentNoteId}> Cuckoo! Cuckoo! Cuck Mulligan clucked lewdly. O word of fear!</Annotation>
+        —{" "} <Annotation annotationId="130005cuckoo"> Cuckoo! Cuckoo! Cuck Mulligan clucked lewdly. O word of fear!</Annotation>
       </p>
       <p>
         Dark dome received, reverbed.
@@ -1956,8 +1956,8 @@ const ScyllaAndCharybdis = ({openNote, currentNoteId, visitedNotes, addToVisited
         widows, brothers-in-love, but always meeting ourselves. The playwright
         who wrote the folio of this world and wrote it badly (He gave us light
         first <span data-edition="ed1932" data-page="191">  </span>and the sun two days later), the lord of things as they are whom
-        the most Roman of catholics call <Annotation annotationId="010041killergod" visited={visitedNotes.has("010041killergod")} annotationSelect={() => {openNote("010041killergod"); addToVisited("010041killergod")}} activeAnnotationId={currentNoteId}><i>dio boia</i>, hangman god</Annotation>, is doubtless
-        <Annotation annotationId="020069streetshout" visited={visitedNotes.has("020069streetshout")} annotationSelect={() => {openNote("020069streetshout"); addToVisited("020069streetshout")}} activeAnnotationId={currentNoteId}>all in all in all of us</Annotation>, ostler and butcher, and would be bawd and
+        the most Roman of catholics call <Annotation annotationId="010041killergod"><i>dio boia</i>, hangman god</Annotation>, is doubtless
+        <Annotation annotationId="020069streetshout">all in all in all of us</Annotation>, ostler and butcher, and would be bawd and
         <span data-edition="ed1922" data-page="204"> </span>
         cuckold too but that in the economy of heaven, foretold by Hamlet, there
         are no more marriages, glorified man, an androgynous angel, being a wife
@@ -1971,7 +1971,7 @@ const ScyllaAndCharybdis = ({openNote, currentNoteId, visitedNotes, addToVisited
         desk.
       </p>
       <p>
-        —{" "}May I? he said. <Annotation annotationId="010021malachi" visited={visitedNotes.has("010021malachi")} annotationSelect={() => {openNote("010021malachi"); addToVisited("010021malachi")}} activeAnnotationId={currentNoteId}>The Lord has spoken to Malachi.</Annotation>
+        —{" "}May I? he said. <Annotation annotationId="010021malachi">The Lord has spoken to Malachi.</Annotation>
       </p>
       <p>
         He began to scribble on a slip of paper.
@@ -2019,7 +2019,7 @@ const ScyllaAndCharybdis = ({openNote, currentNoteId, visitedNotes, addToVisited
         believes his theory.
       </p>
       <p>
-        <Annotation annotationId="090010nothoughts" visited={visitedNotes.has("090010nothoughts")} annotationSelect={() => {openNote("090010nothoughts"); addToVisited("090010nothoughts")}} activeAnnotationId={currentNoteId}>I believe, O Lord, help my unbelief. That is, help me to believe or help
+        <Annotation annotationId="090010nothoughts">I believe, O Lord, help my unbelief. That is, help me to believe or help
         me to unbelieve? Who helps to believe? <i>Egomen.</i> Who to unbelieve? Other
         chap.</Annotation>
       </p>
@@ -2041,8 +2041,8 @@ const ScyllaAndCharybdis = ({openNote, currentNoteId, visitedNotes, addToVisited
       </p>
       <span data-edition="ed1922" data-page="205"> </span>
       <p>
-        —{" "}I called upon the bard Kinch at his summer residence in <Annotation annotationId="150005nighttown" visited={visitedNotes.has("150005nighttown")} annotationSelect={() => {openNote("150005nighttown"); addToVisited("150005nighttown")}} activeAnnotationId={currentNoteId}>upper
-        Mecklenburgh street</Annotation> and found him deep in the study of the <Annotation annotationId="010102aquinas" visited={visitedNotes.has("010102aquinas")} annotationSelect={() => {openNote("010102aquinas"); addToVisited("010102aquinas")}} activeAnnotationId={currentNoteId}><i>Summa contra
+        —{" "}I called upon the bard Kinch at his summer residence in <Annotation annotationId="150005nighttown">upper
+        Mecklenburgh street</Annotation> and found him deep in the study of the <Annotation annotationId="010102aquinas"><i>Summa contra
         Gentiles</i></Annotation> in the company of two gonorrheal ladies, Fresh Nelly and
         Rosalie, the coalquay whore.
       </p>
@@ -2053,7 +2053,7 @@ const ScyllaAndCharybdis = ({openNote, currentNoteId, visitedNotes, addToVisited
         —{" "}Come, Kinch. Come, wandering Ængus of the birds.
       </p>
       <p>
-        <Annotation annotationId="010138eatenall" visited={visitedNotes.has("010138eatenall")} annotationSelect={() => {openNote("010138eatenall"); addToVisited("010138eatenall")}} activeAnnotationId={currentNoteId}>Come, Kinch. You have eaten all we left. Ay. I will serve you your orts and offals.</Annotation>
+        <Annotation annotationId="010138eatenall">Come, Kinch. You have eaten all we left. Ay. I will serve you your orts and offals.</Annotation>
       </p>
       <p>
         Stephen rose.
@@ -2091,7 +2091,7 @@ const ScyllaAndCharybdis = ({openNote, currentNoteId, visitedNotes, addToVisited
       </p>
       <p>
         Stephen, greeting, then all amort, followed a lubber jester, a wellkempt
-        head, newbarbered, out of the vaulted cell into <Annotation annotationId="090010nothoughts" visited={visitedNotes.has("090010nothoughts")} annotationSelect={() => {openNote("090010nothoughts"); addToVisited("090010nothoughts")}} activeAnnotationId={currentNoteId}>a shattering daylight of
+        head, newbarbered, out of the vaulted cell into <Annotation annotationId="090010nothoughts">a shattering daylight of
         no thoughts</Annotation>.
       </p>
       <p>
@@ -2102,7 +2102,7 @@ const ScyllaAndCharybdis = ({openNote, currentNoteId, visitedNotes, addToVisited
       </p>
       <span data-edition="ed1986" data-page="176"> </span>
       <p>
-        The constant <Annotation annotationId="010144nationallibrary" visited={visitedNotes.has("010144nationallibrary")} annotationSelect={() => {openNote("010144nationallibrary"); addToVisited("010144nationallibrary")}} activeAnnotationId={currentNoteId}>readers' room</Annotation>. In the readers' book Cashel Boyle O'Connor
+        The constant <Annotation annotationId="010144nationallibrary">readers' room</Annotation>. In the readers' book Cashel Boyle O'Connor
         Fitzmaurice Tisdall Farrell parafes his polysyllables. Item: was Hamlet
         mad? The quaker's pate godlily with a priesteen in booktalk.
       </p>
@@ -2123,7 +2123,7 @@ const ScyllaAndCharybdis = ({openNote, currentNoteId, visitedNotes, addToVisited
         Is that?... Blueribboned hat... Idly writing... What? Looked?...
       </p>
       <p>
-        The curving balustrade:  <Annotation annotationId="020010lycidas" visited={visitedNotes.has("020010lycidas")} annotationSelect={() => {openNote("020010lycidas"); addToVisited("020010lycidas")}} activeAnnotationId={currentNoteId}>smoothsliding Mincius</Annotation>.
+        The curving balustrade:  <Annotation annotationId="020010lycidas">smoothsliding Mincius</Annotation>.
       </p>
       <span data-edition="ed1922" data-page="206"> </span>
       <p>
@@ -2186,7 +2186,7 @@ const ScyllaAndCharybdis = ({openNote, currentNoteId, visitedNotes, addToVisited
         Halted, below me, a quizzer looks at me. I halt.
       </p>
       <p>
-        —{" "}Mournful mummer, Buck Mulligan moaned. <Annotation annotationId="090011synge" visited={visitedNotes.has("090011synge")} annotationSelect={() => {openNote("090011synge"); addToVisited("090011synge")}} activeAnnotationId={currentNoteId}>Synge has left off wearing
+        —{" "}Mournful mummer, Buck Mulligan moaned. <Annotation annotationId="090011synge">Synge has left off wearing
         black</Annotation> to be like nature. Only crows, priests and English coal are black.
       </p>
       <p>
@@ -2211,11 +2211,11 @@ const ScyllaAndCharybdis = ({openNote, currentNoteId, visitedNotes, addToVisited
         He stopped at the stairfoot.
       </p>
       <p>
-        —{" "}I have conceived <Annotation annotationId="010043mummer" visited={visitedNotes.has("010043mummer")} annotationSelect={() => {openNote("010043mummer"); addToVisited("010043mummer")}} activeAnnotationId={currentNoteId}>a play for the mummers</Annotation>, he said solemnly.
+        —{" "}I have conceived <Annotation annotationId="010043mummer">a play for the mummers</Annotation>, he said solemnly.
       </p>
       <span data-edition="ed1939" data-page="158"> </span>
       <p>
-        <Annotation annotationId="010144nationallibrary" visited={visitedNotes.has("010144nationallibrary")} annotationSelect={() => {openNote("010144nationallibrary"); addToVisited("010144nationallibrary")}} activeAnnotationId={currentNoteId}>The pillared Moorish hall</Annotation>, shadows entwined. Gone <Annotation annotationId="020020morrice" visited={visitedNotes.has("020020morrice")} annotationSelect={() => {openNote("020020morrice"); addToVisited("020020morrice")}} activeAnnotationId={currentNoteId}>the nine men's morrice
+        <Annotation annotationId="010144nationallibrary">The pillared Moorish hall</Annotation>, shadows entwined. Gone <Annotation annotationId="020020morrice">the nine men's morrice
         with caps of indices</Annotation>.
       </p>
       <p>
@@ -2249,7 +2249,7 @@ const ScyllaAndCharybdis = ({openNote, currentNoteId, visitedNotes, addToVisited
         {" "}{" "}{" "}{" "}{" "}{" "}{" "}{" "}and
         {" "}{" "}{" "}{" "}{" "}{" "}{" "}{" "}{" "}{" "}{" "}{" "}{" "}{" "}){" "} (two birds with one stone).<br/>
         <span style={{fontVariant:"small-caps"}}>Medical Davy</span>{" "}{" "} )<br/>
-        <span style={{fontVariant:"small-caps"}}><Annotation annotationId="010134mothergrogan" visited={visitedNotes.has("010134mothergrogan")} annotationSelect={() => {openNote("010134mothergrogan"); addToVisited("010134mothergrogan")}} activeAnnotationId={currentNoteId}>Mother Grogan</Annotation></span> (a watercarrier)<br/>
+        <span style={{fontVariant:"small-caps"}}><Annotation annotationId="010134mothergrogan">Mother Grogan</Annotation></span> (a watercarrier)<br/>
         <span style={{fontVariant:"small-caps"}}>Fresh Nelly</span> <br/>
         {" "}{" "}{" "}{" "}{" "}{" "}{" "}and<br/>
         <span style={{fontVariant:"small-caps"}}>Rosalie</span> (the coalquay whore).
@@ -2259,9 +2259,9 @@ const ScyllaAndCharybdis = ({openNote, currentNoteId, visitedNotes, addToVisited
         and mirthfully he told the shadows, souls of men:
       </p>
       <p>
-        —{" "}<Annotation annotationId="090011synge" visited={visitedNotes.has("090011synge")} annotationSelect={() => {openNote("090011synge"); addToVisited("090011synge")}} activeAnnotationId={currentNoteId}>O, the night in the Camden hall when the daughters of Erin had to lift</Annotation> 
+        —{" "}<Annotation annotationId="090011synge">O, the night in the Camden hall when the daughters of Erin had to lift</Annotation> 
         <span data-edition="ed1922" data-page="208"> </span>
-        <Annotation annotationId="090011synge" visited={visitedNotes.has("090011synge")} annotationSelect={() => {openNote("090011synge"); addToVisited("090011synge")}} activeAnnotationId={currentNoteId}> their skirts to step over you as you lay in your mulberrycoloured,
+        <Annotation annotationId="090011synge"> their skirts to step over you as you lay in your mulberrycoloured,
         multicoloured, multitudinous vomit!</Annotation>
       </p>
       <p>
@@ -2287,15 +2287,15 @@ const ScyllaAndCharybdis = ({openNote, currentNoteId, visitedNotes, addToVisited
         —{" "}Good day again, Buck Mulligan said.
       </p>
       <p>
-        <Annotation annotationId="010144nationallibrary" visited={visitedNotes.has("010144nationallibrary")} annotationSelect={() => {openNote("010144nationallibrary"); addToVisited("010144nationallibrary")}} activeAnnotationId={currentNoteId}>The portico.</Annotation>
+        <Annotation annotationId="010144nationallibrary">The portico.</Annotation>
       </p>
       <p>
-        Here <Annotation annotationId="030145augursrod" visited={visitedNotes.has("030145augursrod")} annotationSelect={() => {openNote("030145augursrod"); addToVisited("030145augursrod")}} activeAnnotationId={currentNoteId}>I watched the birds for augury</Annotation>. Ængus of the birds. They go, they
-        come. <Annotation annotationId="030055samedream" visited={visitedNotes.has("030055samedream")} annotationSelect={() => {openNote("030055samedream"); addToVisited("030055samedream")}} activeAnnotationId={currentNoteId}>Last night I flew. Easily flew. Men wondered. Street of harlots
+        Here <Annotation annotationId="030145augursrod">I watched the birds for augury</Annotation>. Ængus of the birds. They go, they
+        come. <Annotation annotationId="030055samedream">Last night I flew. Easily flew. Men wondered. Street of harlots
         after.</Annotation> A creamfruit melon he held to me. In. You will see.
       </p>
       <p>
-        —{" "}<Annotation annotationId="020061wanderers" visited={visitedNotes.has("020061wanderers")} annotationSelect={() => {openNote("020061wanderers"); addToVisited("020061wanderers")}} activeAnnotationId={currentNoteId}>The wandering jew</Annotation>, Buck Mulligan whispered with clown's awe. Did you
+        —{" "}<Annotation annotationId="020061wanderers">The wandering jew</Annotation>, Buck Mulligan whispered with clown's awe. Did you
         see his eye? He looked upon you to lust after you. I fear thee, ancient
         mariner. O, Kinch, thou art in peril. Get thee a breechpad.
       </p>
@@ -2308,7 +2308,7 @@ const ScyllaAndCharybdis = ({openNote, currentNoteId, visitedNotes, addToVisited
       <span data-edition="ed1939" data-page="159"> </span>
       <span data-edition="ed1961" data-page="217">  </span>
       <p>
-        A dark back went before them, step of a pard, down, <Annotation annotationId="010144nationallibrary" visited={visitedNotes.has("010144nationallibrary")} annotationSelect={() => {openNote("010144nationallibrary"); addToVisited("010144nationallibrary")}} activeAnnotationId={currentNoteId}>out by the gateway,
+        A dark back went before them, step of a pard, down, <Annotation annotationId="010144nationallibrary">out by the gateway,
         under portcullis barbs</Annotation>.
       </p>
       <p>
@@ -2318,12 +2318,12 @@ const ScyllaAndCharybdis = ({openNote, currentNoteId, visitedNotes, addToVisited
         Offend me still. Speak on.
       </p>
       <p>
-        <Annotation annotationId="030016coignofvantage" visited={visitedNotes.has("030016coignofvantage")} annotationSelect={() => {openNote("030016coignofvantage"); addToVisited("030016coignofvantage")}} activeAnnotationId={currentNoteId}>Kind air defined the coigns of houses in Kildare street. No birds.</Annotation> Frail
+        <Annotation annotationId="030016coignofvantage">Kind air defined the coigns of houses in Kildare street. No birds.</Annotation> Frail
         from the housetops two plumes of smoke ascended, pluming, and in a flaw
         of softness softly were blown.
       </p>
       <p>
-        Cease to strive. Peace of the <Annotation annotationId="010018druids" visited={visitedNotes.has("010018druids")} annotationSelect={() => {openNote("010018druids"); addToVisited("010018druids")}} activeAnnotationId={currentNoteId}>druid priests</Annotation> of Cymbeline, hierophantic:
+        Cease to strive. Peace of the <Annotation annotationId="010018druids">druid priests</Annotation> of Cymbeline, hierophantic:
         from wide earth an altar.
       </p>
       <p style={{textIndent:"85px"}}> <i>Laud we the gods <br/>

--- a/src/content/chapters/Sirens.js
+++ b/src/content/chapters/Sirens.js
@@ -1,13 +1,13 @@
 import Annotation from "../../components/Annotation";
 
 
-const Sirens = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
+const Sirens = () => {
   return (
     <div>
       <p></p>
       <center><font size="+2">[11]</font></center>
       <br/>
-      <Annotation annotationId="110009bronzegold" visited={visitedNotes.has("110009bronzegold")} annotationSelect={() => {openNote("110009bronzegold"); addToVisited("110009bronzegold")}} activeAnnotationId={currentNoteId}>Bronze by gold heard the hoofirons, steelyringing.</Annotation>
+      <Annotation annotationId="110009bronzegold">Bronze by gold heard the hoofirons, steelyringing.</Annotation>
       <p></p>
       <p>
         Imperthnthn thnthnthn.
@@ -44,19 +44,19 @@ const Sirens = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         And a call, pure, long and throbbing. Longindying call.
       </p>
       <p>
-        Decoy. Soft word. But look! <Annotation annotationId="110006goodbyesweetheart" visited={visitedNotes.has("110006goodbyesweetheart")} annotationSelect={() => {openNote("110006goodbyesweetheart"); addToVisited("110006goodbyesweetheart")}} activeAnnotationId={currentNoteId}>The bright stars fade.</Annotation> O rose! Notes chirruping
+        Decoy. Soft word. But look! <Annotation annotationId="110006goodbyesweetheart">The bright stars fade.</Annotation> O rose! Notes chirruping
         answer.
-        Castile. <Annotation annotationId="110006goodbyesweetheart" visited={visitedNotes.has("110006goodbyesweetheart")} annotationSelect={() => {openNote("110006goodbyesweetheart"); addToVisited("110006goodbyesweetheart")}} activeAnnotationId={currentNoteId}>The morn is breaking.</Annotation>
+        Castile. <Annotation annotationId="110006goodbyesweetheart">The morn is breaking.</Annotation>
       </p>
       <p>
-        <Annotation annotationId="040091jingle" visited={visitedNotes.has("040091jingle")} annotationSelect={() => {openNote("040091jingle"); addToVisited("040091jingle")}} activeAnnotationId={currentNoteId}>Jingle jingle jaunted jingling.</Annotation>
+        <Annotation annotationId="040091jingle">Jingle jingle jaunted jingling.</Annotation>
       </p>
       <p>
         Coin rang. Clock clacked.
       </p>
       <p>
-        Avowal. <Annotation annotationId="040091jingle" visited={visitedNotes.has("040091jingle")} annotationSelect={() => {openNote("040091jingle"); addToVisited("040091jingle")}} activeAnnotationId={currentNoteId}><i>Sonnez.</i></Annotation> <Annotation annotationId="110006goodbyesweetheart" visited={visitedNotes.has("110006goodbyesweetheart")} annotationSelect={() => {openNote("110006goodbyesweetheart"); addToVisited("110006goodbyesweetheart")}} activeAnnotationId={currentNoteId}>I could.</Annotation> Rebound of garter. <Annotation annotationId="110006goodbyesweetheart" visited={visitedNotes.has("110006goodbyesweetheart")} annotationSelect={() => {openNote("110006goodbyesweetheart"); addToVisited("110006goodbyesweetheart")}} activeAnnotationId={currentNoteId}>Not leave thee.</Annotation> <Annotation annotationId="040091jingle" visited={visitedNotes.has("040091jingle")} annotationSelect={() => {openNote("040091jingle"); addToVisited("040091jingle")}} activeAnnotationId={currentNoteId}>Smack. <i>La
-        cloche!</i> Thigh smack.</Annotation> Avowal. Warm. <Annotation annotationId="110006goodbyesweetheart" visited={visitedNotes.has("110006goodbyesweetheart")} annotationSelect={() => {openNote("110006goodbyesweetheart"); addToVisited("110006goodbyesweetheart")}} activeAnnotationId={currentNoteId}>Sweetheart, goodbye!</Annotation>
+        Avowal. <Annotation annotationId="040091jingle"><i>Sonnez.</i></Annotation> <Annotation annotationId="110006goodbyesweetheart">I could.</Annotation> Rebound of garter. <Annotation annotationId="110006goodbyesweetheart">Not leave thee.</Annotation> <Annotation annotationId="040091jingle">Smack. <i>La
+        cloche!</i> Thigh smack.</Annotation> Avowal. Warm. <Annotation annotationId="110006goodbyesweetheart">Sweetheart, goodbye!</Annotation>
       </p>
       <p>
         Jingle. Bloo.
@@ -99,7 +99,7 @@ const Sirens = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         A moonlit nightcall: far, far.
       </p>
       <p>
-        I feel so sad. P. S. <Annotation annotationId="050026henryflower" visited={visitedNotes.has("050026henryflower")} annotationSelect={() => {openNote("050026henryflower"); addToVisited("050026henryflower")}} activeAnnotationId={currentNoteId}>So lonely blooming.</Annotation>
+        I feel so sad. P. S. <Annotation annotationId="050026henryflower">So lonely blooming.</Annotation>
       </p>
       <p>
         Listen!
@@ -134,13 +134,13 @@ const Sirens = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         Low in dark middle earth. Embedded ore.
       </p>
       <p>
-        <Annotation annotationId="110007croppyboy" visited={visitedNotes.has("110007croppyboy")} annotationSelect={() => {openNote("110007croppyboy"); addToVisited("110007croppyboy")}} activeAnnotationId={currentNoteId}>Naminedamine. All gone. All fallen.</Annotation>
+        <Annotation annotationId="110007croppyboy">Naminedamine. All gone. All fallen.</Annotation>
       </p>
       <p>
         Tiny, her tremulous fernfoils of maidenhair.
       </p>
       <p>
-        <Annotation annotationId="110007croppyboy" visited={visitedNotes.has("110007croppyboy")} annotationSelect={() => {openNote("110007croppyboy"); addToVisited("110007croppyboy")}} activeAnnotationId={currentNoteId}>Amen! He gnashed in fury.</Annotation>
+        <Annotation annotationId="110007croppyboy">Amen! He gnashed in fury.</Annotation>
       </p>
       <p>
         Fro. To, fro. A baton cool protruding.
@@ -149,7 +149,7 @@ const Sirens = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         Bronzelydia by Minagold.
       </p>
       <p>
-        <Annotation annotationId="110009bronzegold" visited={visitedNotes.has("110009bronzegold")} annotationSelect={() => {openNote("110009bronzegold"); addToVisited("110009bronzegold")}} activeAnnotationId={currentNoteId}>By bronze, by gold, in oceangreen of shadow.</Annotation> Bloom. Old Bloom.
+        <Annotation annotationId="110009bronzegold">By bronze, by gold, in oceangreen of shadow.</Annotation> Bloom. Old Bloom.
       </p>
       <p>
         One rapped, one tapped, with a carra, with a cock.
@@ -196,14 +196,14 @@ const Sirens = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       <p>
         Bronze by gold, Miss Douce's head by Miss Kennedy's head, over the 
         <span data-edition="ed1922" data-page="246"> </span>
-        crossblind of <Annotation annotationId="110010ormondbar" visited={visitedNotes.has("110010ormondbar")} annotationSelect={() => {openNote("110010ormondbar"); addToVisited("110010ormondbar")}} activeAnnotationId={currentNoteId}>the Ormond bar</Annotation> heard the viceregal hoofs go by, ringing
+        crossblind of <Annotation annotationId="110010ormondbar">the Ormond bar</Annotation> heard the viceregal hoofs go by, ringing
         steel.
       </p>
       <p>
         —{" "}Is that her? asked Miss Kennedy.
       </p>
       <p>
-        Miss Douce said yes, sitting with his ex, pearl grey and <Annotation annotationId="110009bronzegold" visited={visitedNotes.has("110009bronzegold")} annotationSelect={() => {openNote("110009bronzegold"); addToVisited("110009bronzegold")}} activeAnnotationId={currentNoteId}><i>eau de Nil.</i></Annotation>
+        Miss Douce said yes, sitting with his ex, pearl grey and <Annotation annotationId="110009bronzegold"><i>eau de Nil.</i></Annotation>
       </p>
       <p>
         —{" "}Exquisite contrast, Miss Kennedy said.
@@ -226,7 +226,7 @@ const Sirens = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <p>
         She darted, bronze, to the backmost corner, flattening her face against
-        the pane in <Annotation annotationId="110009bronzegold" visited={visitedNotes.has("110009bronzegold")} annotationSelect={() => {openNote("110009bronzegold"); addToVisited("110009bronzegold")}} activeAnnotationId={currentNoteId}>a halo</Annotation> of hurried breath.
+        the pane in <Annotation annotationId="110009bronzegold">a halo</Annotation> of hurried breath.
       </p>
       <p>
         Her wet lips tittered:
@@ -248,7 +248,7 @@ const Sirens = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <p>
         Miss Kennedy sauntered sadly from bright light, twining a loose hair
-        behind an ear. Sauntering sadly, <Annotation annotationId="110009bronzegold" visited={visitedNotes.has("110009bronzegold")} annotationSelect={() => {openNote("110009bronzegold"); addToVisited("110009bronzegold")}} activeAnnotationId={currentNoteId}>gold no more</Annotation>, she twisted twined a
+        behind an ear. Sauntering sadly, <Annotation annotationId="110009bronzegold">gold no more</Annotation>, she twisted twined a
         hair.
       </p>
       <p>
@@ -256,7 +256,7 @@ const Sirens = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <span data-edition="ed1939" data-page="188"> </span>
       <p>
-        —{" "}<Annotation annotationId="050049comehometoma" visited={visitedNotes.has("050049comehometoma")} annotationSelect={() => {openNote("050049comehometoma"); addToVisited("050049comehometoma")}} activeAnnotationId={currentNoteId}>It's them has the fine times, sadly then she said.</Annotation>
+        —{" "}<Annotation annotationId="050049comehometoma">It's them has the fine times, sadly then she said.</Annotation>
       </p>
       <p>
         A man.
@@ -276,7 +276,7 @@ const Sirens = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <p>
         Miss Kennedy with manners transposed the teatray down to an upturned
-        <Annotation annotationId="030063lithiawater" visited={visitedNotes.has("030063lithiawater")} annotationSelect={() => {openNote("030063lithiawater"); addToVisited("030063lithiawater")}} activeAnnotationId={currentNoteId}>lithia crate</Annotation>, safe from eyes, low.
+        <Annotation annotationId="030063lithiawater">lithia crate</Annotation>, safe from eyes, low.
       </p>
       <p>
         —{" "}What is it? loud boots unmannerly asked.
@@ -344,7 +344,7 @@ const Sirens = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         midst a shell.
       </p>
       <p>
-        —{" "}<Annotation annotationId="110008leavetohands" visited={visitedNotes.has("110008leavetohands")} annotationSelect={() => {openNote("110008leavetohands"); addToVisited("110008leavetohands")}} activeAnnotationId={currentNoteId}>And leave it to my hands</Annotation>, she said.
+        —{" "}<Annotation annotationId="110008leavetohands">And leave it to my hands</Annotation>, she said.
       </p>
       <p>
         —{" "}Try it with the glycerine, Miss Kennedy advised.
@@ -393,7 +393,7 @@ const Sirens = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <p>
         —{" "}Don't let me think of him or I'll expire. The hideous old wretch! That
-        night in <Annotation annotationId="060021concertrooms" visited={visitedNotes.has("060021concertrooms")} annotationSelect={() => {openNote("060021concertrooms"); addToVisited("060021concertrooms")}} activeAnnotationId={currentNoteId}>the Antient Concert Rooms</Annotation>.
+        night in <Annotation annotationId="060021concertrooms">the Antient Concert Rooms</Annotation>.
       </p>
       <span data-edition="ed1922" data-page="248"> </span>
       <p>
@@ -469,7 +469,7 @@ const Sirens = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         panting, sweating (O!), all breathless.
       </p>
       <p>
-        <Annotation annotationId="060006toadeyes" visited={visitedNotes.has("060006toadeyes")} annotationSelect={() => {openNote("060006toadeyes"); addToVisited("060006toadeyes")}} activeAnnotationId={currentNoteId}>Married to Bloom, to greaseaseabloom.</Annotation>
+        <Annotation annotationId="060006toadeyes">Married to Bloom, to greaseaseabloom.</Annotation>
       </p>
       <span data-edition="ed1922" data-page="249"> </span>
       <p>
@@ -484,12 +484,12 @@ const Sirens = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <span data-edition="ed1939" data-page="190"> </span>
       <p>
-        By Cantwell's offices roved Greaseabloom, by <Annotation annotationId="070019nannetti" visited={visitedNotes.has("070019nannetti")} annotationSelect={() => {openNote("070019nannetti"); addToVisited("070019nannetti")}} activeAnnotationId={currentNoteId}>Ceppi's virgins, bright of
+        By Cantwell's offices roved Greaseabloom, by <Annotation annotationId="070019nannetti">Ceppi's virgins, bright of
         their oils. Nannetti's father hawked those things about, wheedling at
         doors as I.</Annotation> Religion pays. Must see him about Keyes's par. Eat first. I want.
-        Not yet. <Annotation annotationId="110002atfourshe" visited={visitedNotes.has("110002atfourshe")} annotationSelect={() => {openNote("110002atfourshe"); addToVisited("110002atfourshe")}} activeAnnotationId={currentNoteId}>At four, she said.</Annotation> Time ever passing. Clockhands turning. On.
+        Not yet. <Annotation annotationId="110002atfourshe">At four, she said.</Annotation> Time ever passing. Clockhands turning. On.
         Where eat? The Clarence, Dolphin. On. For Raoul. Eat. If I net five
-        guineas <span data-edition="ed1961" data-page="260"> </span>with those ads. <Annotation annotationId="020080mauve" visited={visitedNotes.has("020080mauve")} annotationSelect={() => {openNote("020080mauve"); addToVisited("020080mauve")}} activeAnnotationId={currentNoteId}>The violet silk petticoats.</Annotation> Not yet. The sweets
+        guineas <span data-edition="ed1961" data-page="260"> </span>with those ads. <Annotation annotationId="020080mauve">The violet silk petticoats.</Annotation> Not yet. The sweets
         of sin.
       </p>
       <p>
@@ -552,7 +552,7 @@ const Sirens = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         —{" "}With the greatest alacrity, Miss Douce agreed.
       </p>
       <p>
-        With grace of alacrity towards <Annotation annotationId="050030cantrellcochrane" visited={visitedNotes.has("050030cantrellcochrane")} annotationSelect={() => {openNote("050030cantrellcochrane"); addToVisited("050030cantrellcochrane")}} activeAnnotationId={currentNoteId}>the mirror gilt Cantrell and Cochrane's</Annotation>
+        With grace of alacrity towards <Annotation annotationId="050030cantrellcochrane">the mirror gilt Cantrell and Cochrane's</Annotation>
         she turned herself. With grace she tapped a measure of gold whisky from
         her crystal keg. Forth from the skirt of his coat Mr Dedalus brought
         pouch and pipe. Alacrity she served. He blew through the flue two husky
@@ -697,7 +697,7 @@ const Sirens = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         glass.
       </p>
       <p>
-        He looked towards <Annotation annotationId="110010ormondbar" visited={visitedNotes.has("110010ormondbar")} annotationSelect={() => {openNote("110010ormondbar"); addToVisited("110010ormondbar")}} activeAnnotationId={currentNoteId}>the saloon door</Annotation>.
+        He looked towards <Annotation annotationId="110010ormondbar">the saloon door</Annotation>.
       </p>
       <p>
         —{" "}I see you have moved the piano.
@@ -728,7 +728,7 @@ const Sirens = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         God's curse on bitch's bastard.
       </p>
       <p>
-        Tink to her pity cried a diner's bell. To <Annotation annotationId="110010ormondbar" visited={visitedNotes.has("110010ormondbar")} annotationSelect={() => {openNote("110010ormondbar"); addToVisited("110010ormondbar")}} activeAnnotationId={currentNoteId}>the door of the
+        Tink to her pity cried a diner's bell. To <Annotation annotationId="110010ormondbar">the door of the
         diningroom</Annotation> came bald Pat, came bothered Pat, came Pat, waiter of Ormond.
         Lager for diner. Lager without alacrity she served.
       </p>
@@ -751,7 +751,7 @@ const Sirens = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         Respectable girl meet after mass. Thanks awfully muchly. Wise Bloom eyed
         on the door a poster, a swaying mermaid smoking mid nice waves. Smoke
         mermaids, <span data-edition="ed1986" data-page="216"> </span>coolest whiff of all. Hair streaming: lovelorn. For some man.
-        For Raoul. He eyed and saw afar on Essex bridge a gay hat riding on a <Annotation annotationId="050013jauntingcar" visited={visitedNotes.has("050013jauntingcar")} annotationSelect={() => {openNote("050013jauntingcar"); addToVisited("050013jauntingcar")}} activeAnnotationId={currentNoteId}>jaunting car</Annotation>. It is. Third time. Coincidence.
+        For Raoul. He eyed and saw afar on Essex bridge a gay hat riding on a <Annotation annotationId="050013jauntingcar">jaunting car</Annotation>. It is. Third time. Coincidence.
       </p>
       <span data-edition="ed1961" data-page="263"> </span>
       <p>
@@ -785,13 +785,13 @@ const Sirens = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         popcorked bottle ere he went he whispered, bald and bothered, with Miss Douce.
       </p>
       <p>
-        <Annotation annotationId="110006goodbyesweetheart" visited={visitedNotes.has("110006goodbyesweetheart")} annotationSelect={() => {openNote("110006goodbyesweetheart"); addToVisited("110006goodbyesweetheart")}} activeAnnotationId={currentNoteId}>—{" "}<i>The bright stars fade</i>...</Annotation>
+        <Annotation annotationId="110006goodbyesweetheart">—{" "}<i>The bright stars fade</i>...</Annotation>
       </p>
       <p>
-        <Annotation annotationId="110006goodbyesweetheart" visited={visitedNotes.has("110006goodbyesweetheart")} annotationSelect={() => {openNote("110006goodbyesweetheart"); addToVisited("110006goodbyesweetheart")}} activeAnnotationId={currentNoteId}>A voiceless song sang from within, singing:</Annotation>
+        <Annotation annotationId="110006goodbyesweetheart">A voiceless song sang from within, singing:</Annotation>
       </p>
       <p>
-        <Annotation annotationId="110006goodbyesweetheart" visited={visitedNotes.has("110006goodbyesweetheart")} annotationSelect={() => {openNote("110006goodbyesweetheart"); addToVisited("110006goodbyesweetheart")}} activeAnnotationId={currentNoteId}>—{" "}... <i>the morn is breaking.</i></Annotation>
+        <Annotation annotationId="110006goodbyesweetheart">—{" "}... <i>the morn is breaking.</i></Annotation>
       </p>
       <p>
         A duodene of birdnotes chirruped bright treble answer under sensitive <span data-edition="ed1932" data-page="237"> </span>hands. Brightly the keys, all twinkling, linked, all harpsichording,
@@ -799,7 +799,7 @@ const Sirens = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         leavetaking, life's, love's morn.
       </p>
       <p>
-        <Annotation annotationId="110006goodbyesweetheart" visited={visitedNotes.has("110006goodbyesweetheart")} annotationSelect={() => {openNote("110006goodbyesweetheart"); addToVisited("110006goodbyesweetheart")}} activeAnnotationId={currentNoteId}>—{" "}<i>The dewdrops pearl</i>...</Annotation>
+        <Annotation annotationId="110006goodbyesweetheart">—{" "}<i>The dewdrops pearl</i>...</Annotation>
       </p>
       <p>
         Lenehan's lips over the counter lisped a low whistle of decoy.
@@ -839,10 +839,10 @@ const Sirens = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       <p>
         Between the car and window, warily walking, went Bloom, unconquered
         hero. See me he might. The seat he sat on: warm. <span data-edition="ed1961" data-page="264"> </span>Black wary hecat walked
-        towards <Annotation annotationId="030113richiegoulding" visited={visitedNotes.has("030113richiegoulding")} annotationSelect={() => {openNote("030113richiegoulding"); addToVisited("030113richiegoulding")}} activeAnnotationId={currentNoteId}>Richie Goulding's legal bag</Annotation>, lifted aloft, saluting.
+        towards <Annotation annotationId="030113richiegoulding">Richie Goulding's legal bag</Annotation>, lifted aloft, saluting.
       </p>
       <p>
-        —{" "}<Annotation annotationId="110006goodbyesweetheart" visited={visitedNotes.has("110006goodbyesweetheart")} annotationSelect={() => {openNote("110006goodbyesweetheart"); addToVisited("110006goodbyesweetheart")}} activeAnnotationId={currentNoteId}><i>And I from thee</i></Annotation>...
+        —{" "}<Annotation annotationId="110006goodbyesweetheart"><i>And I from thee</i></Annotation>...
       </p>
       <p>
         —{" "}I heard you were round, said Blazes Boylan.
@@ -871,7 +871,7 @@ const Sirens = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <p>
         Hello. Where off to? Something to eat? I too was just. In here. What,
-        Ormond? <Annotation annotationId="110001bestvalue" visited={visitedNotes.has("110001bestvalue")} annotationSelect={() => {openNote("110001bestvalue"); addToVisited("110001bestvalue")}} activeAnnotationId={currentNoteId}>Best value in Dublin</Annotation>. Is that so? <Annotation annotationId="110010ormondbar" visited={visitedNotes.has("110010ormondbar")} annotationSelect={() => {openNote("110010ormondbar"); addToVisited("110010ormondbar")}} activeAnnotationId={currentNoteId}>Diningroom. Sit tight there.
+        Ormond? <Annotation annotationId="110001bestvalue">Best value in Dublin</Annotation>. Is that so? <Annotation annotationId="110010ormondbar">Diningroom. Sit tight there.
         See, not be seen.</Annotation> I think I'll join you. Come on. Richie led on. Bloom
         followed bag. Dinner fit for a prince.
       </p>
@@ -954,7 +954,7 @@ const Sirens = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <span data-edition="ed1986" data-page="218"> </span>
       <p>
-        <Annotation annotationId="110010ormondbar" visited={visitedNotes.has("110010ormondbar")} annotationSelect={() => {openNote("110010ormondbar"); addToVisited("110010ormondbar")}} activeAnnotationId={currentNoteId}>The bag of Goulding, Collis, Ward led Bloom by ryebloom flowered tables.
+        <Annotation annotationId="110010ormondbar">The bag of Goulding, Collis, Ward led Bloom by ryebloom flowered tables.
         Aimless he chose with agitated aim, bald Pat attending, a table near
         the door. Be near.</Annotation> At four. Has he forgotten? Perhaps a trick. Not come:
         whet appetite. I couldn't do. Wait, wait. Pat, waiter, waited.
@@ -966,7 +966,7 @@ const Sirens = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         —{" "}Go on, pressed Lenehan. There's no-one. He never heard.
       </p>
       <p>
-        —{" "}... <Annotation annotationId="110006goodbyesweetheart" visited={visitedNotes.has("110006goodbyesweetheart")} annotationSelect={() => {openNote("110006goodbyesweetheart"); addToVisited("110006goodbyesweetheart")}} activeAnnotationId={currentNoteId}><i>Flora's lips did hie.</i></Annotation>
+        —{" "}... <Annotation annotationId="110006goodbyesweetheart"><i>Flora's lips did hie.</i></Annotation>
       </p>
       <p>
         High, a high note pealed in the treble clear.
@@ -982,14 +982,14 @@ const Sirens = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         He pleaded over returning phrases of avowal.
       </p>
       <p>
-        —{" "}<Annotation annotationId="110006goodbyesweetheart" visited={visitedNotes.has("110006goodbyesweetheart")} annotationSelect={() => {openNote("110006goodbyesweetheart"); addToVisited("110006goodbyesweetheart")}} activeAnnotationId={currentNoteId}><i>I could not leave thee</i></Annotation>...
+        —{" "}<Annotation annotationId="110006goodbyesweetheart"><i>I could not leave thee</i></Annotation>...
       </p>
       <span data-edition="ed1932" data-page="239"> </span>
       <p>
         —{" "}Afterwits, Miss Douce promised coyly.
       </p>
       <p>
-        —{" "}No, now, urged Lenehan. <Annotation annotationId="040091jingle" visited={visitedNotes.has("040091jingle")} annotationSelect={() => {openNote("040091jingle"); addToVisited("040091jingle")}} activeAnnotationId={currentNoteId}><i>Sonnez la cloche!</i></Annotation> O do! There's no-one.
+        —{" "}No, now, urged Lenehan. <Annotation annotationId="040091jingle"><i>Sonnez la cloche!</i></Annotation> O do! There's no-one.
       </p>
       <p>
         She looked. Quick. Miss Kenn out of earshot. Sudden bent. Two kindling
@@ -1037,7 +1037,7 @@ const Sirens = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         Yes, bronze from anearby.
       </p>
       <p>
-        <Annotation annotationId="110006goodbyesweetheart" visited={visitedNotes.has("110006goodbyesweetheart")} annotationSelect={() => {openNote("110006goodbyesweetheart"); addToVisited("110006goodbyesweetheart")}} activeAnnotationId={currentNoteId}>—{" "}... <i>Sweetheart, goodbye!</i></Annotation>
+        <Annotation annotationId="110006goodbyesweetheart">—{" "}... <i>Sweetheart, goodbye!</i></Annotation>
       </p>
       <p>
         —{" "}I'm off, said Boylan with impatience.
@@ -1125,7 +1125,7 @@ const Sirens = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         Nil.</i>
       </p>
       <p>
-        —{" "}<Annotation annotationId="040092professorgoodwin" visited={visitedNotes.has("040092professorgoodwin")} annotationSelect={() => {openNote("040092professorgoodwin"); addToVisited("040092professorgoodwin")}} activeAnnotationId={currentNoteId}>Poor old Goodwin was the pianist that night</Annotation>, Father Cowley reminded
+        —{" "}<Annotation annotationId="040092professorgoodwin">Poor old Goodwin was the pianist that night</Annotation>, Father Cowley reminded
         them. There was a slight difference of opinion between himself and the
         Collard grand.
       </p>
@@ -1200,7 +1200,7 @@ const Sirens = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         Liver and bacon. Steak and kidney pie. Right, sir. Right, Pat.
       </p>
       <p>
-        Mrs Marion <Annotation annotationId="030087pastlife" visited={visitedNotes.has("030087pastlife")} annotationSelect={() => {openNote("030087pastlife"); addToVisited("030087pastlife")}} activeAnnotationId={currentNoteId}>met him pike hoses</Annotation>. Smell of burn. <Annotation annotationId="040003nicename" visited={visitedNotes.has("040003nicename")} annotationSelect={() => {openNote("040003nicename"); addToVisited("040003nicename")}} activeAnnotationId={currentNoteId}>Of Paul de Kock. Nice
+        Mrs Marion <Annotation annotationId="030087pastlife">met him pike hoses</Annotation>. Smell of burn. <Annotation annotationId="040003nicename">Of Paul de Kock. Nice
         name he.</Annotation>
       </p>
       <p>
@@ -1273,7 +1273,7 @@ const Sirens = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         —{" "}<i>When love absorbs my ardent soul</i>...
       </p>
       <p>
-        Roll of Bensoulbenjamin rolled to the quivery loveshivery <Annotation annotationId="110010ormondbar" visited={visitedNotes.has("110010ormondbar")} annotationSelect={() => {openNote("110010ormondbar"); addToVisited("110010ormondbar")}} activeAnnotationId={currentNoteId}>roofpanes</Annotation>.
+        Roll of Bensoulbenjamin rolled to the quivery loveshivery <Annotation annotationId="110010ormondbar">roofpanes</Annotation>.
       </p>
       <p>
         —{" "}War! War! cried Father Cowley. You're the warrior.
@@ -1303,7 +1303,7 @@ const Sirens = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         They drank cool stout. Did she know where the lord lieutenant was going?
         And heard steelhoofs ringhoof ring. No, she couldn't say. But it would
         be in the paper. O, she needn't trouble. No trouble. She waved about
-        her outspread <Annotation annotationId="120009irishindependent" visited={visitedNotes.has("120009irishindependent")} annotationSelect={() => {openNote("120009irishindependent"); addToVisited("120009irishindependent")}} activeAnnotationId={currentNoteId}><i>Independent</i></Annotation>, searching, the lord lieutenant, her
+        her outspread <Annotation annotationId="120009irishindependent"><i>Independent</i></Annotation>, searching, the lord lieutenant, her
         pinnacles of hair slowmoving, lord lieuten. Too much trouble,
         first gentleman said. O, not in the least. Way he looked that. Lord
         lieutenant. Gold by bronze heard iron steel.
@@ -1317,7 +1317,7 @@ const Sirens = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         Ben Dollard's famous. Night he ran round to us to borrow a dress suit
         for that concert. Trousers tight as a drum on him. Musical porkers.
         Molly did laugh when he went out. Threw herself back across the bed,
-        screaming, kicking. <Annotation annotationId="170008precedingseries" visited={visitedNotes.has("170008precedingseries")} annotationSelect={() => {openNote("170008precedingseries"); addToVisited("170008precedingseries")}} activeAnnotationId={currentNoteId}>With all his belongings on show.</Annotation> O saints above,
+        screaming, kicking. <Annotation annotationId="170008precedingseries">With all his belongings on show.</Annotation> O saints above,
         I'm drenched! O, the women in the front row! O, I never laughed so <span data-edition="ed1932" data-page="243"> </span>many!
         Well, of course that's what gives him the base barreltone. For instance
         eunuchs. Wonder who's playing. Nice touch. Must be Cowley. Musical.
@@ -1373,9 +1373,9 @@ const Sirens = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         —{" "}<i>M'appari,</i> Simon, Father Cowley said.
       </p>
       <p>
-        <Annotation annotationId="110010ormondbar" visited={visitedNotes.has("110010ormondbar")} annotationSelect={() => {openNote("110010ormondbar"); addToVisited("110010ormondbar")}} activeAnnotationId={currentNoteId}>Down stage</Annotation> he strode some paces, grave, tall in affliction, his long
+        <Annotation annotationId="110010ormondbar">Down stage</Annotation> he strode some paces, grave, tall in affliction, his long
         arms outheld. Hoarsely the apple of his throat hoarsed softly. Softly he
-        sang to <Annotation annotationId="110010ormondbar" visited={visitedNotes.has("110010ormondbar")} annotationSelect={() => {openNote("110010ormondbar"); addToVisited("110010ormondbar")}} activeAnnotationId={currentNoteId}>a dusty seascape there</Annotation>: <i>A Last Farewell.</i> A headland, a ship, a
+        sang to <Annotation annotationId="110010ormondbar">a dusty seascape there</Annotation>: <i>A Last Farewell.</i> A headland, a ship, a
         sail upon the billows. Farewell. A lovely girl, her veil awave upon the
         wind upon the headland, wind aroundfr her.
       </p>
@@ -1416,7 +1416,7 @@ const Sirens = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         —{" "}Here, Simon, I'll accompany you, he said. Get up.
       </p>
       <p>
-        By Graham Lemon's pineapple rock, by <Annotation annotationId="060009elveryselephant" visited={visitedNotes.has("060009elveryselephant")} annotationSelect={() => {openNote("060009elveryselephant"); addToVisited("060009elveryselephant")}} activeAnnotationId={currentNoteId}>Elvery's elephant</Annotation> jingle jogged.
+        By Graham Lemon's pineapple rock, by <Annotation annotationId="060009elveryselephant">Elvery's elephant</Annotation> jingle jogged.
       </p>
       <p>
         Steak, kidney, liver, mashed, at meat fit for princes sat princes Bloom
@@ -1431,17 +1431,17 @@ const Sirens = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       <span data-edition="ed1986" data-page="223"> </span>
       <p>
         Tenderly Bloom over liverless bacon saw the tightened features strain.
-        <Annotation annotationId="030076backachepills" visited={visitedNotes.has("030076backachepills")} annotationSelect={() => {openNote("030076backachepills"); addToVisited("030076backachepills")}} activeAnnotationId={currentNoteId}>Backache he. Bright's bright eye. Next item on the programme. Paying the
+        <Annotation annotationId="030076backachepills">Backache he. Bright's bright eye. Next item on the programme. Paying the
         piper. Pills, pounded bread, worth a guinea a box. Stave it off awhile.</Annotation>
         Sings too: <i>Down among the dead men.</i> Appropriate. Kidney pie. Sweets to
         the. Not making much hand of it. Best value in. Characteristic of him.
-        Power. Particular about his drink. Flaw in the glass, <Annotation annotationId="010010mountains" visited={visitedNotes.has("010010mountains")} annotationSelect={() => {openNote("010010mountains"); addToVisited("010010mountains")}} activeAnnotationId={currentNoteId}>fresh Vartry
+        Power. Particular about his drink. Flaw in the glass, <Annotation annotationId="010010mountains">fresh Vartry
         water</Annotation>. Fecking matches from counters to save. Then squander a sovereign
-        in dribs and drabs. And when he's wanted <Annotation annotationId="010019money" visited={visitedNotes.has("010019money")} annotationSelect={() => {openNote("010019money"); addToVisited("010019money")}} activeAnnotationId={currentNoteId}>not a farthing</Annotation>. Screwed
+        in dribs and drabs. And when he's wanted <Annotation annotationId="010019money">not a farthing</Annotation>. Screwed
         refusing to pay his fare. Curious types.
       </p>
       <p>
-        Never would Richie forget that night. As long as he lived: never. <Annotation annotationId="110005theatreroyal" visited={visitedNotes.has("110005theatreroyal")} annotationSelect={() => {openNote("110005theatreroyal"); addToVisited("110005theatreroyal")}} activeAnnotationId={currentNoteId}>In the
+        Never would Richie forget that night. As long as he lived: never. <Annotation annotationId="110005theatreroyal">In the
         gods of the old Royal</Annotation> with little Peake. And when the first note.
       </p>
       <p>
@@ -1539,7 +1539,7 @@ const Sirens = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       <p>
         Braintipped, cheek touched with flame, they listened feeling that flow
         endearing flow over skin limbs human heart soul spine. Bloom signed to
-        Pat, bald Pat is a waiter hard of hearing, to set ajar <Annotation annotationId="110010ormondbar" visited={visitedNotes.has("110010ormondbar")} annotationSelect={() => {openNote("110010ormondbar"); addToVisited("110010ormondbar")}} activeAnnotationId={currentNoteId}>the door of the
+        Pat, bald Pat is a waiter hard of hearing, to set ajar <Annotation annotationId="110010ormondbar">the door of the
         bar</Annotation>. The door of the bar. So. That will do. Pat, waiter, waited, waiting
         to hear, for he was hard of hear by the door.
       </p>
@@ -1557,7 +1557,7 @@ const Sirens = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         it in the least, her first merciful lovesoft oftloved word.
       </p>
       <p>
-        Love that is singing: <Annotation annotationId="040035oldsweetsong" visited={visitedNotes.has("040035oldsweetsong")} annotationSelect={() => {openNote("040035oldsweetsong"); addToVisited("040035oldsweetsong")}} activeAnnotationId={currentNoteId}>love's old sweet song</Annotation>. Bloom unwound slowly the
+        Love that is singing: <Annotation annotationId="040035oldsweetsong">love's old sweet song</Annotation>. Bloom unwound slowly the
         elastic band of his packet. Love's old sweet <i>sonnez la</i> gold. Bloom
         wound a skein round four forkfingers, stretched it, relaxed, and wound
         it round his troubled double, fourfold, in octave, gyved them fast.
@@ -1567,7 +1567,7 @@ const Sirens = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <p>
         Tenors get women by the score. Increase their flow. Throw flower at his
-        feet. When will we meet? <Annotation annotationId="040069seasidegirls" visited={visitedNotes.has("040069seasidegirls")} annotationSelect={() => {openNote("040069seasidegirls"); addToVisited("040069seasidegirls")}} activeAnnotationId={currentNoteId}>My head it simply.</Annotation> Jingle all delighted. He
+        feet. When will we meet? <Annotation annotationId="040069seasidegirls">My head it simply.</Annotation> Jingle all delighted. He
         can't sing for tall hats. Your head it simply swurls. Perfumed for him.
         What perfume does your wife? I want to know. Jing. Stop. Knock. Last
         look at mirror always before she answers the door. The hall. There? How
@@ -1602,7 +1602,7 @@ const Sirens = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         Bloom looped, unlooped, noded, disnoded.
       </p>
       <p>
-        Bloom. <Annotation annotationId="040063happywarmth" visited={visitedNotes.has("040063happywarmth")} annotationSelect={() => {openNote("040063happywarmth"); addToVisited("040063happywarmth")}} activeAnnotationId={currentNoteId}>Flood of warm jimjam lickitup secretness</Annotation> flowed to flow in music
+        Bloom. <Annotation annotationId="040063happywarmth">Flood of warm jimjam lickitup secretness</Annotation> flowed to flow in music
         out, in desire, dark to lick flow invading. Tipping her tepping her
         tapping her topping her. Tup. Pores to dilate dilating. Tup. The joy
         the feel the warm the. Tup. To pour o'er sluices pouring gushes. Flood,
@@ -1706,10 +1706,10 @@ const Sirens = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <p>
         Blazes Boylan's smart tan shoes creaked on the barfloor, said before.
-        Jingle by monuments of <Annotation annotationId="060008sirjohngray" visited={visitedNotes.has("060008sirjohngray")} annotationSelect={() => {openNote("060008sirjohngray"); addToVisited("060008sirjohngray")}} activeAnnotationId={currentNoteId}>sir John Gray</Annotation>, Horatio onehandled Nelson,
-        reverend <Annotation annotationId="060010fathermathew" visited={visitedNotes.has("060010fathermathew")} annotationSelect={() => {openNote("060010fathermathew"); addToVisited("060010fathermathew")}} activeAnnotationId={currentNoteId}>father Theobald Mathew</Annotation>, jaunted, as said before just now.
+        Jingle by monuments of <Annotation annotationId="060008sirjohngray">sir John Gray</Annotation>, Horatio onehandled Nelson,
+        reverend <Annotation annotationId="060010fathermathew">father Theobald Mathew</Annotation>, jaunted, as said before just now.
         Atrot, in heat, heatseated. <i>Cloche. Sonnez la. Cloche. Sonnez la.</i>
-        Slower the mare went up the hill by <Annotation annotationId="060011therotunda" visited={visitedNotes.has("060011therotunda")} annotationSelect={() => {openNote("060011therotunda"); addToVisited("060011therotunda")}} activeAnnotationId={currentNoteId}>the Rotunda, Rutland square</Annotation>. Too
+        Slower the mare went up the hill by <Annotation annotationId="060011therotunda">the Rotunda, Rutland square</Annotation>. Too
         slow for Boylan, blazes Boylan, impatience Boylan, joggled the mare.
       </p>
       <p>
@@ -1767,7 +1767,7 @@ const Sirens = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         slender catgut thong. He drew and plucked. It buzzed, it twanged. 
         <span data-edition="ed1939" data-page="202"> </span>
         While
-        Goulding talked of Barraclough's voice production, while <Annotation annotationId="060030retrospective" visited={visitedNotes.has("060030retrospective")} annotationSelect={() => {openNote("060030retrospective"); addToVisited("060030retrospective")}} activeAnnotationId={currentNoteId}>Tom Kernan,
+        Goulding talked of Barraclough's voice production, while <Annotation annotationId="060030retrospective">Tom Kernan,
         harking back in a retrospective sort of arrangement</Annotation> talked to listening
         Father Cowley, who played a voluntary, who nodded as he played. While
         big Ben Dollard talked with Simon Dedalus, lighting, who nodded as he
@@ -1788,7 +1788,7 @@ const Sirens = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         your? Twang. It snapped.
       </p>
       <p>
-        Jingle into <Annotation annotationId="040007dorsetstreet" visited={visitedNotes.has("040007dorsetstreet")} annotationSelect={() => {openNote("040007dorsetstreet"); addToVisited("040007dorsetstreet")}} activeAnnotationId={currentNoteId}>Dorset street</Annotation>.
+        Jingle into <Annotation annotationId="040007dorsetstreet">Dorset street</Annotation>.
       </p>
       <p>
         Miss Douce withdrew her satiny arm, reproachful, pleased.
@@ -1869,7 +1869,7 @@ const Sirens = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         moonlight nightcall, clear from anear, a call from afar, replying.
       </p>
       <p>
-        Down the edge of <Annotation annotationId="050021freeman" visited={visitedNotes.has("050021freeman")} annotationSelect={() => {openNote("050021freeman"); addToVisited("050021freeman")}} activeAnnotationId={currentNoteId}>his <i>Freeman</i> baton</Annotation> ranged Bloom's, your other eye,
+        Down the edge of <Annotation annotationId="050021freeman">his <i>Freeman</i> baton</Annotation> ranged Bloom's, your other eye,
         scanning for where did I see that. Callan, Coleman, Dignam Patrick.
         Heigho! Heigho! Fawcett. Aha! Just I was looking...
       </p>
@@ -1888,7 +1888,7 @@ const Sirens = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       <p>
         On. Know what I mean. No, change that ee. Accept my poor little pres
         enclos. Ask her no answ. Hold on. Five Dig. Two about here. Penny the
-        gulls. Elijah is com. Seven <Annotation annotationId="080024davybyrnes" visited={visitedNotes.has("080024davybyrnes")} annotationSelect={() => {openNote("080024davybyrnes"); addToVisited("080024davybyrnes")}} activeAnnotationId={currentNoteId}>Davy Byrne's</Annotation>. Is eight about. Say half a
+        gulls. Elijah is com. Seven <Annotation annotationId="080024davybyrnes">Davy Byrne's</Annotation>. Is eight about. Say half a
         crown. My poor little pres: p. o. two and six. Write me a long. Do you
         despise? Jingle, have you the? So excited. Why do you call me naught?
         You naughty too? O, Mairy lost the pin of her. Bye for today. <span data-edition="ed1932" data-page="251"> </span>Yes,
@@ -1903,13 +1903,13 @@ const Sirens = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         they don't see. Woman. Sauce for the gander.
       </p>
       <p>
-        <Annotation annotationId="050013jauntingcar" visited={visitedNotes.has("050013jauntingcar")} annotationSelect={() => {openNote("050013jauntingcar"); addToVisited("050013jauntingcar")}} activeAnnotationId={currentNoteId}>A hackney car, number three hundred and twentyfour</Annotation>, driver Barton James
-        of number one Harmony avenue, <Annotation annotationId="050022donnybrook" visited={visitedNotes.has("050022donnybrook")} annotationSelect={() => {openNote("050022donnybrook"); addToVisited("050022donnybrook")}} activeAnnotationId={currentNoteId}>Donnybrook</Annotation>, on which sat a fare, a young
+        <Annotation annotationId="050013jauntingcar">A hackney car, number three hundred and twentyfour</Annotation>, driver Barton James
+        of number one Harmony avenue, <Annotation annotationId="050022donnybrook">Donnybrook</Annotation>, on which sat a fare, a young
         gentleman, stylishly dressed in an indigoblue serge suit made by George
         Robert Mesias, tailor and cutter, of number five Eden quay, and wearing
-        a straw hat very dressy, bought of <Annotation annotationId="040062bolandsbread" visited={visitedNotes.has("040062bolandsbread")} annotationSelect={() => {openNote("040062bolandsbread"); addToVisited("040062bolandsbread")}} activeAnnotationId={currentNoteId}>John Plasto of number one</Annotation> <span data-edition="ed1986" data-page="229"> </span><Annotation annotationId="040062bolandsbread" visited={visitedNotes.has("040062bolandsbread")} annotationSelect={() => {openNote("040062bolandsbread"); addToVisited("040062bolandsbread")}} activeAnnotationId={currentNoteId}>Great
+        a straw hat very dressy, bought of <Annotation annotationId="040062bolandsbread">John Plasto of number one</Annotation> <span data-edition="ed1986" data-page="229"> </span><Annotation annotationId="040062bolandsbread">Great
         Brunswick street, hatter</Annotation>. Eh? This is the jingle that joggled and
-        jingled. By <Annotation annotationId="040060dlugacz" visited={visitedNotes.has("040060dlugacz")} annotationSelect={() => {openNote("040060dlugacz"); addToVisited("040060dlugacz")}} activeAnnotationId={currentNoteId}>Dlugacz' porkshop</Annotation> bright tubes of <Annotation annotationId="040061agendath" visited={visitedNotes.has("040061agendath")} annotationSelect={() => {openNote("040061agendath"); addToVisited("040061agendath")}} activeAnnotationId={currentNoteId}>Agendath</Annotation> trotted a
+        jingled. By <Annotation annotationId="040060dlugacz">Dlugacz' porkshop</Annotation> bright tubes of <Annotation annotationId="040061agendath">Agendath</Annotation> trotted a
         gallantbuttocked mare.
       </p>
       <p>
@@ -1922,7 +1922,7 @@ const Sirens = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       <p>
         Bloom mur: best references. But Henry wrote: it will excite me. You
         know how. In haste. Henry. Greek ee. Better add postscript. What is he
-        playing now? Improvising. Intermezzo. P. S. The rum tum tum. <Annotation annotationId="040017seemtolikeit" visited={visitedNotes.has("040017seemtolikeit")} annotationSelect={() => {openNote("040017seemtolikeit"); addToVisited("040017seemtolikeit")}} activeAnnotationId={currentNoteId}>How will
+        playing now? Improvising. Intermezzo. P. S. The rum tum tum. <Annotation annotationId="040017seemtolikeit">How will
         you pun? You punish me? Crooked skirt swinging, whack by.</Annotation> Tell me I want
         to. Know. O. Course if I didn't I wouldn't ask. La la la ree. Trails off
         there sad in minor. Why minor sad? Sign H. They like sad tail at end. P.
@@ -1936,7 +1936,7 @@ const Sirens = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       <p style={{textIndent:"0cm", textAlign:"center", marginTop:".5cm", marginBottom:".5cm"}}>
         Miss Martha Clifford<br/>
         c/o P. O. <br/>
-        <Annotation annotationId="040041dolphinsbarn" visited={visitedNotes.has("040041dolphinsbarn")} annotationSelect={() => {openNote("040041dolphinsbarn"); addToVisited("040041dolphinsbarn")}} activeAnnotationId={currentNoteId}>Dolphin's barn lane</Annotation><br/>
+        <Annotation annotationId="040041dolphinsbarn">Dolphin's barn lane</Annotation><br/>
         {" "}{" "}{" "}{" "}{" "}{" "}{" "}{" "}{" "}
         {" "}{" "}{" "}{" "}{" "}{" "}{" "}{" "}Dublin.
       </p>
@@ -1944,7 +1944,7 @@ const Sirens = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       <p>
         Blot over the other so he can't read. Right. Idea prize titbit.
         Something detective read off blottingpad. Payment at the rate of guinea
-        per col. <Annotation annotationId="040065matcham" visited={visitedNotes.has("040065matcham")} annotationSelect={() => {openNote("040065matcham"); addToVisited("040065matcham")}} activeAnnotationId={currentNoteId}>Matcham often thinks the laughing witch.</Annotation> Poor Mrs Purefoy. <Annotation annotationId="080010upup" visited={visitedNotes.has("080010upup")} annotationSelect={() => {openNote("080010upup"); addToVisited("080010upup")}} activeAnnotationId={currentNoteId}>U.
+        per col. <Annotation annotationId="040065matcham">Matcham often thinks the laughing witch.</Annotation> Poor Mrs Purefoy. <Annotation annotationId="080010upup">U.
         P.: up.</Annotation>
       </p>
       <p>
@@ -1991,7 +1991,7 @@ const Sirens = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <span data-edition="ed1986" data-page="230"> </span>
       <p>
-        Under <Annotation annotationId="050037tomkernan" visited={visitedNotes.has("050037tomkernan")} annotationSelect={() => {openNote("050037tomkernan"); addToVisited("050037tomkernan")}} activeAnnotationId={currentNoteId}>Tom Kernan's ginhot words</Annotation> the accompanist wove music slow.
+        Under <Annotation annotationId="050037tomkernan">Tom Kernan's ginhot words</Annotation> the accompanist wove music slow.
         Authentic fact. How Walter Bapty lost his voice. Well, sir, the husband
         took him by the throat. <i>Scoundrel,</i> said he, <i>You'll sing no more
         lovesongs.</i> He did, sir Tom. Bob Cowley wove. Tenors get wom.
@@ -2016,7 +2016,7 @@ const Sirens = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       <span data-edition="ed1922" data-page="269"> </span>
       <p>
         Her ear too is a shell, the peeping lobe there. Been to the seaside.
-        <Annotation annotationId="040069seasidegirls" visited={visitedNotes.has("040069seasidegirls")} annotationSelect={() => {openNote("040069seasidegirls"); addToVisited("040069seasidegirls")}} activeAnnotationId={currentNoteId}>Lovely seaside girls.</Annotation> Skin tanned raw. Should have put on coldcream
+        <Annotation annotationId="040069seasidegirls">Lovely seaside girls.</Annotation> Skin tanned raw. Should have put on coldcream
         first make it brown. Buttered toast. O and that lotion mustn't forget.
         Fever near her mouth. Your head it simply. Hair braided over: shell with
         seaweed. Why do they hide their ears with seaweed hair? And Turks their
@@ -2043,7 +2043,7 @@ const Sirens = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         Tap.
       </p>
       <p>
-        By Larry O'Rourke's, by Larry, <Annotation annotationId="040081boldlarry" visited={visitedNotes.has("040081boldlarry")} annotationSelect={() => {openNote("040081boldlarry"); addToVisited("040081boldlarry")}} activeAnnotationId={currentNoteId}>bold Larry O'</Annotation>, Boylan swayed and Boylan
+        By Larry O'Rourke's, by Larry, <Annotation annotationId="040081boldlarry">bold Larry O'</Annotation>, Boylan swayed and Boylan
         turned.
       </p>
       <p>
@@ -2060,9 +2060,9 @@ const Sirens = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         two, one, three, four.
       </p>
       <p>
-        Sea, wind, leaves, thunder, waters, cows lowing, <Annotation annotationId="040037cattlemarket" visited={visitedNotes.has("040037cattlemarket")} annotationSelect={() => {openNote("040037cattlemarket"); addToVisited("040037cattlemarket")}} activeAnnotationId={currentNoteId}>the cattlemarket</Annotation>,
+        Sea, wind, leaves, thunder, waters, cows lowing, <Annotation annotationId="040037cattlemarket">the cattlemarket</Annotation>,
         cocks, hens don't crow, snakes hissss. There's music everywhere.
-        Ruttledge's door: ee creaking. No, that's noise. <Annotation annotationId="080030cenarteco" visited={visitedNotes.has("080030cenarteco")} annotationSelect={() => {openNote("080030cenarteco"); addToVisited("080030cenarteco")}} activeAnnotationId={currentNoteId}>Minuet of <i>Don
+        Ruttledge's door: ee creaking. No, that's noise. <Annotation annotationId="080030cenarteco">Minuet of <i>Don
         Giovanni</i> he's playing now. Court dresses of all descriptions in castle
         chambers dancing.</Annotation> Misery. Peasants outside. Green starving faces eating
         dockleaves. Nice that is. Look: look, look, look, look, look: you look
@@ -2088,7 +2088,7 @@ const Sirens = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         clocks came light to earth.
       </p>
       <p>
-        O, look we are so! <Annotation annotationId="110003chambermusic" visited={visitedNotes.has("110003chambermusic")} annotationSelect={() => {openNote("110003chambermusic"); addToVisited("110003chambermusic")}} activeAnnotationId={currentNoteId}>Chamber music. Could make a kind of pun on that.
+        O, look we are so! <Annotation annotationId="110003chambermusic">Chamber music. Could make a kind of pun on that.
         It is a kind of music I often thought when she. Acoustics that is.
         Tinkling. Empty vessels make most noise.</Annotation> Because the acoustics, the
         resonance changes according as the weight of the water is equal to
@@ -2098,7 +2098,7 @@ const Sirens = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <span data-edition="ed1932" data-page="254"> </span>
       <p>
-        One rapped on a door, one tapped with a knock, did he knock <Annotation annotationId="040003nicename" visited={visitedNotes.has("040003nicename")} annotationSelect={() => {openNote("040003nicename"); addToVisited("040003nicename")}} activeAnnotationId={currentNoteId}>Paul de Kock</Annotation>
+        One rapped on a door, one tapped with a knock, did he knock <Annotation annotationId="040003nicename">Paul de Kock</Annotation>
         with a loud proud knocker with a cock carracarracarra cock. Cockcock.
       </p>
       <p>
@@ -2108,10 +2108,10 @@ const Sirens = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         —{" "}<i>Qui sdegno,</i> Ben, said Father Cowley.
       </p>
       <p>
-        —{" "}No, Ben, Tom Kernan interfered. <Annotation annotationId="110007croppyboy" visited={visitedNotes.has("110007croppyboy")} annotationSelect={() => {openNote("110007croppyboy"); addToVisited("110007croppyboy")}} activeAnnotationId={currentNoteId}><i>The Croppy Boy.</i></Annotation> Our native Doric.
+        —{" "}No, Ben, Tom Kernan interfered. <Annotation annotationId="110007croppyboy"><i>The Croppy Boy.</i></Annotation> Our native Doric.
       </p>
       <p>
-        —{" "}Ay do, Ben, Mr Dedalus said.  <Annotation annotationId="110007croppyboy" visited={visitedNotes.has("110007croppyboy")} annotationSelect={() => {openNote("110007croppyboy"); addToVisited("110007croppyboy")}} activeAnnotationId={currentNoteId}>Good men and true.</Annotation>
+        —{" "}Ay do, Ben, Mr Dedalus said.  <Annotation annotationId="110007croppyboy">Good men and true.</Annotation>
       </p>
       <span data-edition="ed1961" data-page="282"> </span>
       <p>
@@ -2144,7 +2144,7 @@ const Sirens = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <p>
         The voice of dark age, of unlove, earth's fatigue made grave approach
-        and painful, come from afar, from hoary mountains, called on <Annotation annotationId="110007croppyboy" visited={visitedNotes.has("110007croppyboy")} annotationSelect={() => {openNote("110007croppyboy"); addToVisited("110007croppyboy")}} activeAnnotationId={currentNoteId}>good men
+        and painful, come from afar, from hoary mountains, called on <Annotation annotationId="110007croppyboy">good men
         and true. The priest he sought. With him would he speak a word.</Annotation>
       </p>
       <p>
@@ -2159,7 +2159,7 @@ const Sirens = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <span data-edition="ed1922" data-page="271"> </span><span data-edition="ed1986" data-page="232"> </span>
       <p>
-        <Annotation annotationId="110007croppyboy" visited={visitedNotes.has("110007croppyboy")} annotationSelect={() => {openNote("110007croppyboy"); addToVisited("110007croppyboy")}} activeAnnotationId={currentNoteId}>The priest's at home. A false priest's servant bade him welcome. Step
+        <Annotation annotationId="110007croppyboy">The priest's at home. A false priest's servant bade him welcome. Step
         in. The holy father.</Annotation> Curlycues of chords.
       </p>
       <p>
@@ -2167,13 +2167,13 @@ const Sirens = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         in. Hushaby. Lullaby. Die, dog. Little dog, die.
       </p>
       <p>
-        The voice of warning, solemn warning, told them <Annotation annotationId="110007croppyboy" visited={visitedNotes.has("110007croppyboy")} annotationSelect={() => {openNote("110007croppyboy"); addToVisited("110007croppyboy")}} activeAnnotationId={currentNoteId}>the youth had entered
+        The voice of warning, solemn warning, told them <Annotation annotationId="110007croppyboy">the youth had entered
         a lonely hall, told them how solemn fell his footstep there, told them
         the gloomy chamber, the vested priest sitting to shrive.</Annotation>
       </p>
       <p>
         Decent soul. Bit addled now. Thinks he'll win in <i>Answers</i> poets'
-        <span data-edition="ed1932" data-page="255"> </span>picture puzzle. We hand you crisp <Annotation annotationId="010019money" visited={visitedNotes.has("010019money")} annotationSelect={() => {openNote("010019money"); addToVisited("010019money")}} activeAnnotationId={currentNoteId}>five pound note</Annotation>. Bird sitting hatching
+        <span data-edition="ed1932" data-page="255"> </span>picture puzzle. We hand you crisp <Annotation annotationId="010019money">five pound note</Annotation>. Bird sitting hatching
         in a nest. Lay of the last minstrel he thought it was. See blank tee
         what domestic animal? Tee dash ar most courageous mariner. Good voice he
         has still. No eunuch yet with all his belongings.
@@ -2188,7 +2188,7 @@ const Sirens = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <p>
         The voice of penance and of grief came slow, embellished, tremulous.
-        Ben's contrite beard confessed: <Annotation annotationId="110007croppyboy" visited={visitedNotes.has("110007croppyboy")} annotationSelect={() => {openNote("110007croppyboy"); addToVisited("110007croppyboy")}} activeAnnotationId={currentNoteId}> <i>in nomine Domini,</i> in God's name. He
+        Ben's contrite beard confessed: <Annotation annotationId="110007croppyboy"> <i>in nomine Domini,</i> in God's name. He
         knelt. He beat his hand upon his breast, confessing: <i>mea culpa.</i></Annotation>
       </p>
       <p>
@@ -2204,8 +2204,8 @@ const Sirens = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         expressive, fullbusted satin. Kernan. Si.
       </p>
       <p>
-        The sighing voice of sorrow sang. <Annotation annotationId="110007croppyboy" visited={visitedNotes.has("110007croppyboy")} annotationSelect={() => {openNote("110007croppyboy"); addToVisited("110007croppyboy")}} activeAnnotationId={currentNoteId}>His sins. Since Easter he had cursed
-        three times.</Annotation> You bitch's bast. <Annotation annotationId="110007croppyboy" visited={visitedNotes.has("110007croppyboy")} annotationSelect={() => {openNote("110007croppyboy"); addToVisited("110007croppyboy")}} activeAnnotationId={currentNoteId}>And once at masstime he had gone to play.
+        The sighing voice of sorrow sang. <Annotation annotationId="110007croppyboy">His sins. Since Easter he had cursed
+        three times.</Annotation> You bitch's bast. <Annotation annotationId="110007croppyboy">And once at masstime he had gone to play.
         Once by the churchyard he had passed and for his mother's rest he had
         not prayed.</Annotation> A boy. A croppy boy.
       </p>
@@ -2236,23 +2236,23 @@ const Sirens = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         She looked fine. Her crocus dress she wore lowcut, belongings on show.
         Clove her breath was always in theatre when she bent to ask a question.
         Told her what Spinoza says in that book of poor papa's. Hypnotised,
-        listening. Eyes like that. She bent. <Annotation annotationId="170008precedingseries" visited={visitedNotes.has("170008precedingseries")} annotationSelect={() => {openNote("170008precedingseries"); addToVisited("170008precedingseries")}} activeAnnotationId={currentNoteId}>Chap in dresscircle staring down
+        listening. Eyes like that. She bent. <Annotation annotationId="170008precedingseries">Chap in dresscircle staring down
         into her with his operaglass for all he was worth.</Annotation> Beauty of music <span data-edition="ed1986" data-page="233"> </span>you
         must hear twice. Nature woman half a look. God made the country man the
         tune. Met him pike hoses. Philosophy. O rocks!
       </p>
       <span data-edition="ed1932" data-page="256"> </span><span data-edition="ed1961" data-page="284"> </span>
       <p>
-        <Annotation annotationId="110007croppyboy" visited={visitedNotes.has("110007croppyboy")} annotationSelect={() => {openNote("110007croppyboy"); addToVisited("110007croppyboy")}} activeAnnotationId={currentNoteId}>All gone. All fallen. At the siege of Ross his father, at Gorey all his
-        brothers fell. To Wexford</Annotation>, we are the boys of Wexford, <Annotation annotationId="110007croppyboy" visited={visitedNotes.has("110007croppyboy")} annotationSelect={() => {openNote("110007croppyboy"); addToVisited("110007croppyboy")}} activeAnnotationId={currentNoteId}>he would. Last of
+        <Annotation annotationId="110007croppyboy">All gone. All fallen. At the siege of Ross his father, at Gorey all his
+        brothers fell. To Wexford</Annotation>, we are the boys of Wexford, <Annotation annotationId="110007croppyboy">he would. Last of
         his name and race.</Annotation>
       </p>
       <p>
-        I too. <Annotation annotationId="040054saltcloak" visited={visitedNotes.has("040054saltcloak")} annotationSelect={() => {openNote("040054saltcloak"); addToVisited("040054saltcloak")}} activeAnnotationId={currentNoteId}>Last of my race.</Annotation> Milly young student. Well, my fault perhaps. No
+        I too. <Annotation annotationId="040054saltcloak">Last of my race.</Annotation> Milly young student. Well, my fault perhaps. No
         son. Rudy. Too late now. Or if not? If not? If still?
       </p>
       <p>
-        <Annotation annotationId="110007croppyboy" visited={visitedNotes.has("110007croppyboy")} annotationSelect={() => {openNote("110007croppyboy"); addToVisited("110007croppyboy")}} activeAnnotationId={currentNoteId}>He bore no hate.</Annotation>
+        <Annotation annotationId="110007croppyboy">He bore no hate.</Annotation>
       </p>
       <p>
         Hate. Love. Those are names. Rudy. Soon I am old. 
@@ -2262,11 +2262,11 @@ const Sirens = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         pale, to Bloom soon old. But when was young?
       </p>
       <p>
-        Ireland comes now. <Annotation annotationId="110007croppyboy" visited={visitedNotes.has("110007croppyboy")} annotationSelect={() => {openNote("110007croppyboy"); addToVisited("110007croppyboy")}} activeAnnotationId={currentNoteId}>My country above the king.</Annotation> She listens. <Annotation annotationId="100012evildays" visited={visitedNotes.has("100012evildays")} annotationSelect={() => {openNote("100012evildays"); addToVisited("100012evildays")}} activeAnnotationId={currentNoteId}>Who fears to
+        Ireland comes now. <Annotation annotationId="110007croppyboy">My country above the king.</Annotation> She listens. <Annotation annotationId="100012evildays">Who fears to
         speak of nineteen four?</Annotation> Time to be shoving. Looked enough.
       </p>
       <p>
-        —{" "} <Annotation annotationId="110007croppyboy" visited={visitedNotes.has("110007croppyboy")} annotationSelect={() => {openNote("110007croppyboy"); addToVisited("110007croppyboy")}} activeAnnotationId={currentNoteId}> <i>Bless me, father,</i> Dollard the croppy cried. <i>Bless me and let me
+        —{" "} <Annotation annotationId="110007croppyboy"> <i>Bless me, father,</i> Dollard the croppy cried. <i>Bless me and let me
         go.</i></Annotation>
       </p>
       <p>
@@ -2280,7 +2280,7 @@ const Sirens = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         Laughter in court. Henry. I never signed it. The lovely name you.
       </p>
       <p>
-        Low sank the music, air and words. Then hastened. <Annotation annotationId="110007croppyboy" visited={visitedNotes.has("110007croppyboy")} annotationSelect={() => {openNote("110007croppyboy"); addToVisited("110007croppyboy")}} activeAnnotationId={currentNoteId}>The false priest
+        Low sank the music, air and words. Then hastened. <Annotation annotationId="110007croppyboy">The false priest
         rustling soldier from his cassock. A yeoman captain.</Annotation> They know it all by
         heart. The thrill they itch for. Yeoman cap.
       </p>
@@ -2298,7 +2298,7 @@ const Sirens = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         didn't see. 
         <span data-edition="ed1922" data-page="273"> </span>
         They want it. Not too much polite. That's why he gets them.
-        Gold in your pocket, brass in your face. With look to look. Songs without words. <Annotation annotationId="170008precedingseries" visited={visitedNotes.has("170008precedingseries")} annotationSelect={() => {openNote("170008precedingseries"); addToVisited("170008precedingseries")}} activeAnnotationId={currentNoteId}>Molly, that hurdygurdy boy.</Annotation>
+        Gold in your pocket, brass in your face. With look to look. Songs without words. <Annotation annotationId="170008precedingseries">Molly, that hurdygurdy boy.</Annotation>
         She knew he meant the monkey was sick. Or because so like the Spanish.
         Understand animals too that way. Solomon did. Gift of nature.
       </p>
@@ -2311,8 +2311,8 @@ const Sirens = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       <span data-edition="ed1939" data-page="208"> </span>
       <span data-edition="ed1961" data-page="285"> </span>
       <p>
-        <Annotation annotationId="110007croppyboy" visited={visitedNotes.has("110007croppyboy")} annotationSelect={() => {openNote("110007croppyboy"); addToVisited("110007croppyboy")}} activeAnnotationId={currentNoteId}>With hoarse rude fury the yeoman cursed</Annotation>, swelling in apoplectic bitch's
-        bastard. <Annotation annotationId="110007croppyboy" visited={visitedNotes.has("110007croppyboy")} annotationSelect={() => {openNote("110007croppyboy"); addToVisited("110007croppyboy")}} activeAnnotationId={currentNoteId}>A good thought, boy, to come. One hour's your time to live,
+        <Annotation annotationId="110007croppyboy">With hoarse rude fury the yeoman cursed</Annotation>, swelling in apoplectic bitch's
+        bastard. <Annotation annotationId="110007croppyboy">A good thought, boy, to come. One hour's your time to live,
         your last.</Annotation>
       </p>
       <p>
@@ -2335,7 +2335,7 @@ const Sirens = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         Popped corks, splashes of beerfroth, stacks of empties.
       </p>
       <p>
-        <Annotation annotationId="110008leavetohands" visited={visitedNotes.has("110008leavetohands")} annotationSelect={() => {openNote("110008leavetohands"); addToVisited("110008leavetohands")}} activeAnnotationId={currentNoteId}>On the smooth jutting beerpull laid Lydia hand, lightly, plumply, leave
+        <Annotation annotationId="110008leavetohands">On the smooth jutting beerpull laid Lydia hand, lightly, plumply, leave
         it to my hands. All lost in pity for croppy. Fro, to: to, fro: over
         the polished knob (she knows his eyes, my eyes, her eyes) her thumb and
         finger passed in pity: passed, repassed and, gently touching, then slid
@@ -2349,14 +2349,14 @@ const Sirens = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         Tap. Tap. Tap.
       </p>
       <p>
-        <Annotation annotationId="110007croppyboy" visited={visitedNotes.has("110007croppyboy")} annotationSelect={() => {openNote("110007croppyboy"); addToVisited("110007croppyboy")}} activeAnnotationId={currentNoteId}>I hold this house. Amen. He gnashed in fury. Traitors swing.</Annotation>
+        <Annotation annotationId="110007croppyboy">I hold this house. Amen. He gnashed in fury. Traitors swing.</Annotation>
       </p>
       <p>
         The chords consented. Very sad thing. But had to be. 
       </p>
       <p>
         Get out before the end. Thanks, that was heavenly. Where's my hat. Pass by her. 
-        <Annotation annotationId="050021freeman" visited={visitedNotes.has("050021freeman")} annotationSelect={() => {openNote("050021freeman"); addToVisited("050021freeman")}} activeAnnotationId={currentNoteId}>Can leave that Freeman.</Annotation> Letter I have. Suppose she were the? No. Walk, walk,
+        <Annotation annotationId="050021freeman">Can leave that Freeman.</Annotation> Letter I have. Suppose she were the? No. Walk, walk,
         walk. Like Cashel Boylo Connoro Coylo Tisdall Maurice Tisntdall Farrell.
         Waaaaaaalk.
       </p>
@@ -2371,7 +2371,7 @@ const Sirens = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         By deaf Pat in the doorway straining ear Bloom passed.
       </p>
       <p>
-        <Annotation annotationId="110007croppyboy" visited={visitedNotes.has("110007croppyboy")} annotationSelect={() => {openNote("110007croppyboy"); addToVisited("110007croppyboy")}} activeAnnotationId={currentNoteId}>At Geneva barrack that young man died. At Passage was his body laid.</Annotation>
+        <Annotation annotationId="110007croppyboy">At Geneva barrack that young man died. At Passage was his body laid.</Annotation>
         Dolor! O, he dolores! The voice of the mournful chanter called to
         dolorous prayer.
       </p>
@@ -2386,12 +2386,12 @@ const Sirens = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
         Tap. Tap. Tap.
       </p>
       <p>
-        Pray for him, prayed the bass of Dollard. <Annotation annotationId="110007croppyboy" visited={visitedNotes.has("110007croppyboy")} annotationSelect={() => {openNote("110007croppyboy"); addToVisited("110007croppyboy")}} activeAnnotationId={currentNoteId}>You who hear in peace. Breathe
+        Pray for him, prayed the bass of Dollard. <Annotation annotationId="110007croppyboy">You who hear in peace. Breathe
         a prayer, drop a tear, good men, good people. He was the croppy boy.</Annotation>
       </p>
       <span data-edition="ed1932" data-page="258"> </span>
       <p>
-        Scaring eavesdropping boots croppy bootsboy Bloom in <Annotation annotationId="110010ormondbar" visited={visitedNotes.has("110010ormondbar")} annotationSelect={() => {openNote("110010ormondbar"); addToVisited("110010ormondbar")}} activeAnnotationId={currentNoteId}>the Ormond hallway</Annotation>
+        Scaring eavesdropping boots croppy bootsboy Bloom in <Annotation annotationId="110010ormondbar">the Ormond hallway</Annotation>
         heard growls and roars of bravo, fat backslapping, their boots all
         treading, boots not the boots the boy. General chorus off for a swill to
         wash it down. Glad I avoided.
@@ -2596,7 +2596,7 @@ const Sirens = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       </p>
       <p>
         Instruments. A blade of grass, shell of her hands, then blow. Even
-        comb and tissuepaper you can knock a tune out of. Molly in her shift <Annotation annotationId="040049pleasantoldtimes" visited={visitedNotes.has("040049pleasantoldtimes")} annotationSelect={() => {openNote("040049pleasantoldtimes"); addToVisited("040049pleasantoldtimes")}} activeAnnotationId={currentNoteId}>in
+        comb and tissuepaper you can knock a tune out of. Molly in her shift <Annotation annotationId="040049pleasantoldtimes">in
         Lombard street west</Annotation>, hair down. I suppose each kind of trade made its
         own, don't you see? Hunter with a horn. Haw. Have you the? <i>Cloche.
         Sonnez la.</i> <span data-edition="ed1986" data-page="237"> </span>Shepherd his pipe. Policeman a whistle.

--- a/src/content/chapters/Telemachus.js
+++ b/src/content/chapters/Telemachus.js
@@ -1,79 +1,73 @@
 import Annotation from "../../components/Annotation";
 
-const Telemachus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
+const Telemachus = () => {
   return (
     <div>
     <p></p>
     <center>
-      <Annotation 
-        annotationId="010000telemachus" visited={visitedNotes.has("010000telemachus")}
-        annotationSelect={() => {openNote("010000telemachus"); addToVisited("010000telemachus")}}
-        activeAnnotationId={currentNoteId}
-      >
-        <font size="+2">[1]</font>
-      </Annotation>  
+      <Annotation annotationId="010000telemachus"><font size="+2">[1]</font></Annotation>  
     </center>
     <br/>
-    Stately, plump <Annotation annotationId="010001buckmulligan" visited={visitedNotes.has("010001buckmulligan")} annotationSelect={() => {openNote("010001buckmulligan"); addToVisited("010001buckmulligan")}} activeAnnotationId={currentNoteId}>Buck Mulligan</Annotation> <Annotation annotationId="010002stairhead" visited={visitedNotes.has("010002stairhead")} annotationSelect={() => {openNote("010002stairhead"); addToVisited("010002stairhead")}} activeAnnotationId={currentNoteId}>came from the stairhead</Annotation>, bearing a bowl of
-    lather on which <Annotation annotationId="010003mirrorrazor" visited={visitedNotes.has("010003mirrorrazor")} annotationSelect={() => {openNote("010003mirrorrazor"); addToVisited("010003mirrorrazor")}} activeAnnotationId={currentNoteId}>a mirror and a razor lay crossed</Annotation>. A <Annotation annotationId="010004yellowdressinggown" visited={visitedNotes.has("010004yellowdressinggown")} annotationSelect={() => {openNote("010004yellowdressinggown"); addToVisited("010004yellowdressinggown")}} activeAnnotationId={currentNoteId}>yellow dressinggown</Annotation>,
-    <Annotation annotationId="010005ungirdled" visited={visitedNotes.has("010005ungirdled")} annotationSelect={() => {openNote("010005ungirdled"); addToVisited("010005ungirdled")}} activeAnnotationId={currentNoteId}>ungirdled</Annotation>, was sustained gently behind him by the mild morning air. He
+    Stately, plump <Annotation annotationId="010001buckmulligan">Buck Mulligan</Annotation> <Annotation annotationId="010002stairhead">came from the stairhead</Annotation>, bearing a bowl of
+    lather on which <Annotation annotationId="010003mirrorrazor">a mirror and a razor lay crossed</Annotation>. A <Annotation annotationId="010004yellowdressinggown">yellow dressinggown</Annotation>,
+    <Annotation annotationId="010005ungirdled">ungirdled</Annotation>, was sustained gently behind him by the mild morning air. He
     held the bowl aloft and intoned:
     <p></p>
     <p>
-      —{" "}<Annotation annotationId="010006introibo" visited={visitedNotes.has("010006introibo")} annotationSelect={() => {openNote("010006introibo"); addToVisited("010006introibo")}} activeAnnotationId={currentNoteId}><i>Introibo ad altare Dei</i></Annotation>.
+      —{" "}<Annotation annotationId="010006introibo"><i>Introibo ad altare Dei</i></Annotation>.
     </p>
     <p>
       Halted, he peered down the dark winding stairs and called up coarsely:
     </p>
     <p>
-      —{" "}Come up, <Annotation annotationId="010007kinch" visited={visitedNotes.has("010007kinch")} annotationSelect={() => {openNote("010007kinch"); addToVisited("010007kinch")}} activeAnnotationId={currentNoteId}>Kinch</Annotation>! Come up, you fearful <Annotation annotationId="010008jesuit" visited={visitedNotes.has("010008jesuit")} annotationSelect={() => {openNote("010008jesuit"); addToVisited("010008jesuit")}} activeAnnotationId={currentNoteId}>jesuit</Annotation>.
+      —{" "}Come up, <Annotation annotationId="010007kinch">Kinch</Annotation>! Come up, you fearful <Annotation annotationId="010008jesuit">jesuit</Annotation>.
     </p>
     <p>
-      Solemnly he came forward and <Annotation annotationId="010002stairhead" visited={visitedNotes.has("010002stairhead")} annotationSelect={() => {openNote("010002stairhead"); addToVisited("010002stairhead")}} activeAnnotationId={currentNoteId}>mounted the round gunrest</Annotation>. He faced about
-      and blessed gravely thrice the <Annotation annotationId="010009tower" visited={visitedNotes.has("010009tower")} annotationSelect={() => {openNote("010009tower"); addToVisited("010009tower")}} activeAnnotationId={currentNoteId}>tower</Annotation>, the surrounding country and the <Annotation annotationId="010010mountains" visited={visitedNotes.has("010010mountains")} annotationSelect={() => {openNote("010010mountains"); addToVisited("010010mountains")}} activeAnnotationId={currentNoteId}>awaking mountains</Annotation>. Then, catching sight of <Annotation annotationId="010011stephendedalus" visited={visitedNotes.has("010011stephendedalus")} annotationSelect={() => {openNote("010011stephendedalus"); addToVisited("010011stephendedalus")}} activeAnnotationId={currentNoteId}>Stephen Dedalus</Annotation>, he bent
+      Solemnly he came forward and <Annotation annotationId="010002stairhead">mounted the round gunrest</Annotation>. He faced about
+      and blessed gravely thrice the <Annotation annotationId="010009tower">tower</Annotation>, the surrounding country and the <Annotation annotationId="010010mountains">awaking mountains</Annotation>. Then, catching sight of <Annotation annotationId="010011stephendedalus">Stephen Dedalus</Annotation>, he bent
       towards him and made rapid crosses in the air, gurgling in his throat
       and shaking his head. Stephen Dedalus, displeased and sleepy, leaned
       his arms on the top of the staircase and looked coldly at the shaking
       gurgling face that blessed him, equine in its length, and at the light
-      <Annotation annotationId="010005ungirdled" visited={visitedNotes.has("010005ungirdled")} annotationSelect={() => {openNote("010005ungirdled"); addToVisited("010005ungirdled")}} activeAnnotationId={currentNoteId}>untonsured</Annotation> hair, grained and hued like pale oak.
+      <Annotation annotationId="010005ungirdled">untonsured</Annotation> hair, grained and hued like pale oak.
     </p>
     <p>
       Buck Mulligan peeped an instant under the mirror and then covered the
       bowl smartly.
     </p>
     <p>
-      —{" "}<Annotation annotationId="010013barracks" visited={visitedNotes.has("010013barracks")} annotationSelect={() => {openNote("010013barracks"); addToVisited("010013barracks")}} activeAnnotationId={currentNoteId}>Back to barracks</Annotation>! he said sternly.
+      —{" "}<Annotation annotationId="010013barracks">Back to barracks</Annotation>! he said sternly.
     </p>
     <p>
       He added in a preacher's tone:
     </p>
     <p>
-      —{" "}<Annotation annotationId="010014genuinechristine" visited={visitedNotes.has("010014genuinechristine")} annotationSelect={() => {openNote("010014genuinechristine"); addToVisited("010014genuinechristine")}} activeAnnotationId={currentNoteId}>For this, O dearly beloved, is the genuine Christine: body and soul
+      —{" "}<Annotation annotationId="010014genuinechristine">For this, O dearly beloved, is the genuine Christine: body and soul
       and blood and ouns.</Annotation> Slow music, please. Shut your eyes, gents. One
-      moment. <Annotation annotationId="010015whitecorpuscles" visited={visitedNotes.has("010015whitecorpuscles")} annotationSelect={() => {openNote("010015whitecorpuscles"); addToVisited("010015whitecorpuscles")}} activeAnnotationId={currentNoteId}>A little trouble about those white corpuscles</Annotation>. Silence, all.
+      moment. <Annotation annotationId="010015whitecorpuscles">A little trouble about those white corpuscles</Annotation>. Silence, all.
     </p>
     <p>
       He peered sideways up and gave a long low whistle of call, then paused
       awhile in rapt attention, his even white teeth glistening here and there
-      with gold points. <Annotation annotationId="010017chrysostomos" visited={visitedNotes.has("010017chrysostomos")} annotationSelect={() => {openNote("010017chrysostomos"); addToVisited("010017chrysostomos")}} activeAnnotationId={currentNoteId}>Chrysostomos</Annotation>. <Annotation annotationId="010016shrillwhistles" visited={visitedNotes.has("010016shrillwhistles")} annotationSelect={() => {openNote("010016shrillwhistles"); addToVisited("010016shrillwhistles")}} activeAnnotationId={currentNoteId}>Two strong shrill whistles answered</Annotation>
+      with gold points. <Annotation annotationId="010017chrysostomos">Chrysostomos</Annotation>. <Annotation annotationId="010016shrillwhistles">Two strong shrill whistles answered</Annotation>
       through the calm.
     </p>
     <p>
-      —{" "}Thanks, old chap, he cried briskly. That will do nicely. <Annotation annotationId="010015whitecorpuscles" visited={visitedNotes.has("010015whitecorpuscles")} annotationSelect={() => {openNote("010015whitecorpuscles"); addToVisited("010015whitecorpuscles")}} activeAnnotationId={currentNoteId}>Switch off the current</Annotation>, will you?
+      —{" "}Thanks, old chap, he cried briskly. That will do nicely. <Annotation annotationId="010015whitecorpuscles">Switch off the current</Annotation>, will you?
     </p>
     <span data-edition="ed1922" data-page="3"></span>
     <p>
       He skipped off the gunrest and looked gravely at his watcher, gathering
-      about his legs the loose folds of his gown. <Annotation annotationId="010153plumpface" visited={visitedNotes.has("010153plumpface")} annotationSelect={() => {openNote("010153plumpface"); addToVisited("010153plumpface")}} activeAnnotationId={currentNoteId}>The plump</Annotation><span data-edition="ed1932" data-page="3"> </span><Annotation annotationId="010153plumpface" visited={visitedNotes.has("010153plumpface")} annotationSelect={() => {openNote("010153plumpface"); addToVisited("010153plumpface")}} activeAnnotationId={currentNoteId}>shadowed face and
+      about his legs the loose folds of his gown. <Annotation annotationId="010153plumpface">The plump</Annotation><span data-edition="ed1932" data-page="3"> </span><Annotation annotationId="010153plumpface">shadowed face and
       sullen oval jowl recalled a prelate, patron of arts in the middle ages.</Annotation>
       A pleasant smile broke quietly over his lips. 
     </p>
     <p>
-      —{" "}<Annotation annotationId="010154mockery" visited={visitedNotes.has("010154mockery")} annotationSelect={() => {openNote("010154mockery"); addToVisited("010154mockery")}} activeAnnotationId={currentNoteId}>The mockery of it!</Annotation> he said gaily. <Annotation annotationId="010020ancientgreek" visited={visitedNotes.has("010020ancientgreek")} annotationSelect={() => {openNote("010020ancientgreek"); addToVisited("010020ancientgreek")}} activeAnnotationId={currentNoteId}>Your absurd name, an ancient Greek!</Annotation>
+      —{" "}<Annotation annotationId="010154mockery">The mockery of it!</Annotation> he said gaily. <Annotation annotationId="010020ancientgreek">Your absurd name, an ancient Greek!</Annotation>
     </p>
     <span data-edition="ed1986" data-page="3"> </span>
     <p>
-      He pointed his finger in friendly jest and went over to the <Annotation annotationId="010002stairhead" visited={visitedNotes.has("010002stairhead")} annotationSelect={() => {openNote("010002stairhead"); addToVisited("010002stairhead")}} activeAnnotationId={currentNoteId}>parapet</Annotation>,
+      He pointed his finger in friendly jest and went over to the <Annotation annotationId="010002stairhead">parapet</Annotation>,
       laughing to himself. Stephen Dedalus stepped up, followed him wearily
       halfway and sat down on the edge of the gunrest, watching him still as he propped his mirror on the <span data-edition="ed1961" data-page="3"> </span>parapet, dipped the brush in the bowl and
       lathered cheeks and neck. 
@@ -83,10 +77,10 @@ const Telemachus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
     </p>
     <span data-edition="ed1939" data-page="5"> </span>
     <p>
-      —{" "}My name is absurd too: <Annotation annotationId="010021malachi" visited={visitedNotes.has("010021malachi")} annotationSelect={() => {openNote("010021malachi"); addToVisited("010021malachi")}} activeAnnotationId={currentNoteId}>Malachi Mulligan, two dactyls</Annotation>. But it has a
-      <Annotation annotationId="010022hellenise" visited={visitedNotes.has("010022hellenise")} annotationSelect={() => {openNote("010022hellenise"); addToVisited("010022hellenise")}} activeAnnotationId={currentNoteId}>Hellenic</Annotation> ring, hasn't it? Tripping and sunny like the buck himself.
+      —{" "}My name is absurd too: <Annotation annotationId="010021malachi">Malachi Mulligan, two dactyls</Annotation>. But it has a
+      <Annotation annotationId="010022hellenise">Hellenic</Annotation> ring, hasn't it? Tripping and sunny like the buck himself.
       We must go to Athens. Will you come if I can get the aunt to fork out
-      twenty <Annotation annotationId="010019money" visited={visitedNotes.has("010019money")} annotationSelect={() => {openNote("010019money"); addToVisited("010019money")}} activeAnnotationId={currentNoteId}>quid</Annotation>?
+      twenty <Annotation annotationId="010019money">quid</Annotation>?
     </p>
     <p>
       He laid the brush aside and, laughing with delight, cried:
@@ -104,33 +98,33 @@ const Telemachus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       —{" "}Yes, my love?
     </p>
     <p>
-      —{" "}How long is <Annotation annotationId="010023haines" visited={visitedNotes.has("010023haines")} annotationSelect={() => {openNote("010023haines"); addToVisited("010023haines")}} activeAnnotationId={currentNoteId}>Haines</Annotation> going to stay in this tower?
+      —{" "}How long is <Annotation annotationId="010023haines">Haines</Annotation> going to stay in this tower?
     </p>
     <p>
       Buck Mulligan showed a shaven cheek over his right shoulder.
     </p>
     <p>
-      —{" "}God, isn't he dreadful? he said frankly. A ponderous <Annotation annotationId="010024stranger" visited={visitedNotes.has("010024stranger")} annotationSelect={() => {openNote("010024stranger"); addToVisited("010024stranger")}} activeAnnotationId={currentNoteId}>Saxon</Annotation>. He thinks
+      —{" "}God, isn't he dreadful? he said frankly. A ponderous <Annotation annotationId="010024stranger">Saxon</Annotation>. He thinks
       you're not a gentleman. God, these bloody English! Bursting with money
       and indigestion.  Because he comes from Oxford. You know, Dedalus, you
       have the real Oxford manner. He can't make you out. O, my name for you
-      is the best: <Annotation annotationId="010007kinch" visited={visitedNotes.has("010007kinch")} annotationSelect={() => {openNote("010007kinch"); addToVisited("010007kinch")}} activeAnnotationId={currentNoteId}>Kinch, the knife-blade.</Annotation>
+      is the best: <Annotation annotationId="010007kinch">Kinch, the knife-blade.</Annotation>
     </p>
     <p>
       He shaved warily over his chin.
     </p>
     <p>
-      —{" "}<Annotation annotationId="010025blackpanther" visited={visitedNotes.has("010025blackpanther")} annotationSelect={() => {openNote("010025blackpanther"); addToVisited("010025blackpanther")}} activeAnnotationId={currentNoteId}>He was raving all night about a black panther, Stephen said. Where is
+      —{" "}<Annotation annotationId="010025blackpanther">He was raving all night about a black panther, Stephen said. Where is
       his guncase?</Annotation>
     </p>
     <p>
-      —{" "}A woful <Annotation annotationId="010051paresis" visited={visitedNotes.has("010051paresis")} annotationSelect={() => {openNote("010051paresis"); addToVisited("010051paresis")}} activeAnnotationId={currentNoteId}>lunatic</Annotation>! Mulligan said. Were you in a funk?
+      —{" "}A woful <Annotation annotationId="010051paresis">lunatic</Annotation>! Mulligan said. Were you in a funk?
     </p>
     <p>
       —{" "}I was, Stephen said with energy and growing fear. Out here in the dark
       with a man I don't know raving and moaning to himself about shooting a
-      black panther. You <Annotation annotationId="010026lifeguard" visited={visitedNotes.has("010026lifeguard")} annotationSelect={() => {openNote("010026lifeguard"); addToVisited("010026lifeguard")}} activeAnnotationId={currentNoteId}>saved men from drowning.</Annotation> I'm not <Annotation annotationId="010027hero" visited={visitedNotes.has("010027hero")} annotationSelect={() => {openNote("010027hero"); addToVisited("010027hero")}} activeAnnotationId={currentNoteId}>a hero,</Annotation> however. If
-      he stays on here <Annotation annotationId="010028iamoff" visited={visitedNotes.has("010028iamoff")} annotationSelect={() => {openNote("010028iamoff"); addToVisited("010028iamoff")}} activeAnnotationId={currentNoteId}>I am off.</Annotation>
+      black panther. You <Annotation annotationId="010026lifeguard">saved men from drowning.</Annotation> I'm not <Annotation annotationId="010027hero">a hero,</Annotation> however. If
+      he stays on here <Annotation annotationId="010028iamoff">I am off.</Annotation>
     </p>
     <p>
       Buck Mulligan frowned at the lather on his razorblade. He hopped down
@@ -138,14 +132,14 @@ const Telemachus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
     </p>
     <span data-edition="ed1922" data-page="4"> </span>
     <p>
-      —{" "}<Annotation annotationId="010128bowsy" visited={visitedNotes.has("010128bowsy")} annotationSelect={() => {openNote("010128bowsy"); addToVisited("010128bowsy")}} activeAnnotationId={currentNoteId}>Scutter</Annotation>! he cried thickly.
+      —{" "}<Annotation annotationId="010128bowsy">Scutter</Annotation>! he cried thickly.
     </p>
     <p>
       He came over to the gunrest and, thrusting a hand into Stephen's upper
       pocket, said:
     </p>
     <p>
-      —{" "}Lend us a loan of your <Annotation annotationId="010030noserag" visited={visitedNotes.has("010030noserag")} annotationSelect={() => {openNote("010030noserag"); addToVisited("010030noserag")}} activeAnnotationId={currentNoteId}>noserag</Annotation> to wipe my razor.
+      —{" "}Lend us a loan of your <Annotation annotationId="010030noserag">noserag</Annotation> to wipe my razor.
     </p>
     <span data-edition="ed1932" data-page="4"> </span>
     <p>
@@ -155,45 +149,45 @@ const Telemachus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
     </p>
     <span data-edition="ed1961" data-page="4"> </span>
     <p>
-      —{" "}The bard's noserag! A new art colour for <Annotation annotationId="010031snotgreen" visited={visitedNotes.has("010031snotgreen")} annotationSelect={() => {openNote("010031snotgreen"); addToVisited("010031snotgreen")}} activeAnnotationId={currentNoteId}>our Irish poets</Annotation>: snotgreen.
+      —{" "}The bard's noserag! A new art colour for <Annotation annotationId="010031snotgreen">our Irish poets</Annotation>: snotgreen.
       You can almost taste it, can't you?
     </p>
     <p>
-      He mounted to the parapet again and gazed out over <Annotation annotationId="010123dublinbay" visited={visitedNotes.has("010123dublinbay")} annotationSelect={() => {openNote("010123dublinbay"); addToVisited("010123dublinbay")}} activeAnnotationId={currentNoteId}>Dublin bay</Annotation>, his fair
+      He mounted to the parapet again and gazed out over <Annotation annotationId="010123dublinbay">Dublin bay</Annotation>, his fair
       oakpale hair stirring slightly.
     </p>
     <p>
-      —{" "}God! he said quietly. Isn't the sea <Annotation annotationId="010032sweetmother" visited={visitedNotes.has("010032sweetmother")} annotationSelect={() => {openNote("010032sweetmother"); addToVisited("010032sweetmother")}} activeAnnotationId={currentNoteId}>what Algy calls it: a great
-      sweet mother</Annotation>? The snotgreen sea. The scrotumtightening sea. <Annotation annotationId="010033epioinopaponton" visited={visitedNotes.has("010033epioinopaponton")} annotationSelect={() => {openNote("010033epioinopaponton"); addToVisited("010033epioinopaponton")}} activeAnnotationId={currentNoteId}><i>Epi oinopa
-      ponton</i>.</Annotation> Ah, Dedalus, the Greeks! I must teach you. You must <Annotation annotationId="010034theoriginal" visited={visitedNotes.has("010034theoriginal")} annotationSelect={() => {openNote("010034theoriginal"); addToVisited("010034theoriginal")}} activeAnnotationId={currentNoteId}>read them
-      in the</Annotation><span data-edition="ed1986" data-page="4"> </span> <Annotation annotationId="010034theoriginal" visited={visitedNotes.has("010034theoriginal")} annotationSelect={() => {openNote("010034theoriginal"); addToVisited("010034theoriginal")}} activeAnnotationId={currentNoteId}>original.</Annotation> <Annotation annotationId="010035thalatta" visited={visitedNotes.has("010035thalatta")} annotationSelect={() => {openNote("010035thalatta"); addToVisited("010035thalatta")}} activeAnnotationId={currentNoteId}><i>Thalatta! Thalatta</i>!</Annotation> She is our great sweet mother.
+      —{" "}God! he said quietly. Isn't the sea <Annotation annotationId="010032sweetmother">what Algy calls it: a great
+      sweet mother</Annotation>? The snotgreen sea. The scrotumtightening sea. <Annotation annotationId="010033epioinopaponton"><i>Epi oinopa
+      ponton</i>.</Annotation> Ah, Dedalus, the Greeks! I must teach you. You must <Annotation annotationId="010034theoriginal">read them
+      in the</Annotation><span data-edition="ed1986" data-page="4"> </span> <Annotation annotationId="010034theoriginal">original.</Annotation> <Annotation annotationId="010035thalatta"><i>Thalatta! Thalatta</i>!</Annotation> She is our great sweet mother.
       Come and look.
     </p>
     <p>
       Stephen stood up and went over to the parapet. Leaning on it he looked
-      down on the water and on the <Annotation annotationId="010036mailboat" visited={visitedNotes.has("010036mailboat")} annotationSelect={() => {openNote("010036mailboat"); addToVisited("010036mailboat")}} activeAnnotationId={currentNoteId}>mailboat</Annotation> clearing the <Annotation annotationId="010037harbourmouth" visited={visitedNotes.has("010037harbourmouth")} annotationSelect={() => {openNote("010037harbourmouth"); addToVisited("010037harbourmouth")}} activeAnnotationId={currentNoteId}>harbourmouth of
+      down on the water and on the <Annotation annotationId="010036mailboat">mailboat</Annotation> clearing the <Annotation annotationId="010037harbourmouth">harbourmouth of
       Kingstown</Annotation>.
     </p>
     <p>
-      —{" "}<Annotation annotationId="010039mightymother" visited={visitedNotes.has("010039mightymother")} annotationSelect={() => {openNote("010039mightymother"); addToVisited("010039mightymother")}} activeAnnotationId={currentNoteId}>Our mighty mother</Annotation>! Buck Mulligan said.
+      —{" "}<Annotation annotationId="010039mightymother">Our mighty mother</Annotation>! Buck Mulligan said.
     </p>
     <p>
-      He turned abruptly <Annotation annotationId="010038greateyes" visited={visitedNotes.has("010038greateyes")} annotationSelect={() => {openNote("010038greateyes"); addToVisited("010038greateyes")}} activeAnnotationId={currentNoteId}>his great searching eyes</Annotation> from the sea to Stephen's
+      He turned abruptly <Annotation annotationId="010038greateyes">his great searching eyes</Annotation> from the sea to Stephen's
       face.
     </p>
     <p>
-      —{" "}The aunt thinks <Annotation annotationId="010042prayforme" visited={visitedNotes.has("010042prayforme")} annotationSelect={() => {openNote("010042prayforme"); addToVisited("010042prayforme")}} activeAnnotationId={currentNoteId}>you killed your mother</Annotation>, he said. That's why she won't
+      —{" "}The aunt thinks <Annotation annotationId="010042prayforme">you killed your mother</Annotation>, he said. That's why she won't
       let me have anything to do with you.
     </p>
     <p>
-      —{" "}<Annotation annotationId="010041killergod" visited={visitedNotes.has("010041killergod")} annotationSelect={() => {openNote("010041killergod"); addToVisited("010041killergod")}} activeAnnotationId={currentNoteId}>Someone killed her</Annotation>, Stephen said gloomily.
+      —{" "}<Annotation annotationId="010041killergod">Someone killed her</Annotation>, Stephen said gloomily.
     </p>
     <p>
       —{" "}You could have knelt down, damn it, Kinch, when your dying mother
-      asked you, Buck Mulligan said. I'm <Annotation annotationId="010040hyperborean" visited={visitedNotes.has("010040hyperborean")} annotationSelect={() => {openNote("010040hyperborean"); addToVisited("010040hyperborean")}} activeAnnotationId={currentNoteId}>hyperborean</Annotation> as much as you. But to
+      asked you, Buck Mulligan said. I'm <Annotation annotationId="010040hyperborean">hyperborean</Annotation> as much as you. But to
       think of your 
       <span data-edition="ed1939" data-page="6"> </span>
-      mother <Annotation annotationId="010042prayforme" visited={visitedNotes.has("010042prayforme")} annotationSelect={() => {openNote("010042prayforme"); addToVisited("010042prayforme")}} activeAnnotationId={currentNoteId}>begging you with her last breath to kneel down and
+      mother <Annotation annotationId="010042prayforme">begging you with her last breath to kneel down and
       pray for her. And you refused.</Annotation> There is something sinister in you...
     </p>
     <p>
@@ -201,7 +195,7 @@ const Telemachus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       smile curled his lips.
     </p>
     <p>
-      —{" "}But a lovely <Annotation annotationId="010043mummer" visited={visitedNotes.has("010043mummer")} annotationSelect={() => {openNote("010043mummer"); addToVisited("010043mummer")}} activeAnnotationId={currentNoteId}>mummer</Annotation>! he murmured to himself. Kinch, the loveliest
+      —{" "}But a lovely <Annotation annotationId="010043mummer">mummer</Annotation>! he murmured to himself. Kinch, the loveliest
       mummer of them all!
     </p>
     <p>
@@ -210,14 +204,14 @@ const Telemachus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
     <p>
       Stephen, an elbow rested on the jagged granite, leaned his palm against
       his brow and gazed at the fraying edge of his shiny black coat-sleeve.
-      Pain, that was not yet the <Annotation annotationId="010044painfretted" visited={visitedNotes.has("010044painfretted")} annotationSelect={() => {openNote("010044painfretted"); addToVisited("010044painfretted")}} activeAnnotationId={currentNoteId}>pain of love</Annotation>, fretted his heart. <Annotation annotationId="010045waxandrosewood" visited={visitedNotes.has("010045waxandrosewood")} annotationSelect={() => {openNote("010045waxandrosewood"); addToVisited("010045waxandrosewood")}} activeAnnotationId={currentNoteId}>Silently, in
+      Pain, that was not yet the <Annotation annotationId="010044painfretted">pain of love</Annotation>, fretted his heart. <Annotation annotationId="010045waxandrosewood">Silently, in
       a dream she had come to him after her death</Annotation>, her wasted body within its
       loose brown graveclothes giving off an odour of wax and rosewood, her
       breath, that had bent upon him, mute, reproachful, a faint odour of
       wetted ashes. Across the 
       <span data-edition="ed1922" data-page="5"> </span>
       threadbare cuffedge he saw the sea hailed as a
-      great sweet mother by the wellfed voice beside him. The <Annotation annotationId="010123dublinbay" visited={visitedNotes.has("010123dublinbay")} annotationSelect={() => {openNote("010123dublinbay"); addToVisited("010123dublinbay")}} activeAnnotationId={currentNoteId}>ring of bay
+      great sweet mother by the wellfed voice beside him. The <Annotation annotationId="010123dublinbay">ring of bay
       and skyline</Annotation> held a dull green mass of liquid. A bowl of white<span data-edition="ed1932" data-page="5"> </span> china had
       stood beside her deathbed holding the green sluggish bile which she had
       torn up from her rotting liver by fits of loud groaning vomiting.
@@ -227,8 +221,8 @@ const Telemachus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       Buck Mulligan wiped again his razorblade.
     </p>
     <p>
-      —{" "}Ah, poor <Annotation annotationId="010047dogsbody" visited={visitedNotes.has("010047dogsbody")} annotationSelect={() => {openNote("010047dogsbody"); addToVisited("010047dogsbody")}} activeAnnotationId={currentNoteId}>dogsbody</Annotation>! he said in a kind voice. I must give you a shirt
-      and a few noserags. How are the secondhand <Annotation annotationId="010128bowsy" visited={visitedNotes.has("010128bowsy")} annotationSelect={() => {openNote("010128bowsy"); addToVisited("010128bowsy")}} activeAnnotationId={currentNoteId}>breeks</Annotation>?
+      —{" "}Ah, poor <Annotation annotationId="010047dogsbody">dogsbody</Annotation>! he said in a kind voice. I must give you a shirt
+      and a few noserags. How are the secondhand <Annotation annotationId="010128bowsy">breeks</Annotation>?
     </p>
     <p>
       —{" "}They fit well enough, Stephen answered.
@@ -238,12 +232,12 @@ const Telemachus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
     </p>
     <p>
       —{" "}The mockery of it, he said contentedly. Secondleg they should be. God
-      knows what poxy <Annotation annotationId="010128bowsy" visited={visitedNotes.has("010128bowsy")} annotationSelect={() => {openNote("010128bowsy"); addToVisited("010128bowsy")}} activeAnnotationId={currentNoteId}>bowsy</Annotation> left them off. I have a lovely pair with a hair
+      knows what poxy <Annotation annotationId="010128bowsy">bowsy</Annotation> left them off. I have a lovely pair with a hair
       stripe, grey. You'll look spiffing in them. I'm not joking, Kinch. You
       look damn well when you're dressed.
     </p>
     <p>
-      —{" "}Thanks, Stephen said. <Annotation annotationId="010048greypants" visited={visitedNotes.has("010048greypants")} annotationSelect={() => {openNote("010048greypants"); addToVisited("010048greypants")}} activeAnnotationId={currentNoteId}>I can't wear them if they are grey.</Annotation>
+      —{" "}Thanks, Stephen said. <Annotation annotationId="010048greypants">I can't wear them if they are grey.</Annotation>
     </p>
     <p>
       —{" "}He can't wear them, Buck Mulligan told his face in the mirror.
@@ -260,12 +254,12 @@ const Telemachus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       smokeblue mobile eyes.
     </p>
     <p>
-      —{" "}That fellow I was with in <Annotation annotationId="010049shiptavern" visited={visitedNotes.has("010049shiptavern")} annotationSelect={() => {openNote("010049shiptavern"); addToVisited("010049shiptavern")}} activeAnnotationId={currentNoteId}>the Ship</Annotation> last night, said Buck Mulligan,
-      says you have g.p.i. He's <Annotation annotationId="010050dottyville" visited={visitedNotes.has("010050dottyville")} annotationSelect={() => {openNote("010050dottyville"); addToVisited("010050dottyville")}} activeAnnotationId={currentNoteId}>up in Dottyville with Conolly Norman</Annotation>. <Annotation annotationId="010051paresis" visited={visitedNotes.has("010051paresis")} annotationSelect={() => {openNote("010051paresis"); addToVisited("010051paresis")}} activeAnnotationId={currentNoteId}>General
+      —{" "}That fellow I was with in <Annotation annotationId="010049shiptavern">the Ship</Annotation> last night, said Buck Mulligan,
+      says you have g.p.i. He's <Annotation annotationId="010050dottyville">up in Dottyville with Conolly Norman</Annotation>. <Annotation annotationId="010051paresis">General
       paralysis of the insane!</Annotation>
     </p>
     <p>
-      He swept the mirror a half circle in the air <Annotation annotationId="010021malachi" visited={visitedNotes.has("010021malachi")} annotationSelect={() => {openNote("010021malachi"); addToVisited("010021malachi")}} activeAnnotationId={currentNoteId}>to flash the tidings abroad</Annotation>
+      He swept the mirror a half circle in the air <Annotation annotationId="010021malachi">to flash the tidings abroad</Annotation>
       in sunlight now radiant on the sea. His curling shaven lips laughed and
       the edges of his white glittering teeth. Laughter seized all his strong
       wellknit trunk.
@@ -275,19 +269,19 @@ const Telemachus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
     </p>
     <p>
       Stephen bent forward and peered at the mirror held out to him, cleft by
-      a crooked crack, hair on end. <Annotation annotationId="010052otherssee" visited={visitedNotes.has("010052otherssee")} annotationSelect={() => {openNote("010052otherssee"); addToVisited("010052otherssee")}} activeAnnotationId={currentNoteId}>As he and others see me.</Annotation> Who chose this
+      a crooked crack, hair on end. <Annotation annotationId="010052otherssee">As he and others see me.</Annotation> Who chose this
       face for me? This dogsbody to rid of vermin. It asks me too.
     </p>
     <p>
       —{" "}I pinched it out of the skivvy's room, Buck Mulligan said. It does her
-      all right. The aunt always keeps plainlooking servants for Malachi. <Annotation annotationId="040077ourfather" visited={visitedNotes.has("040077ourfather")} annotationSelect={() => {openNote("040077ourfather"); addToVisited("040077ourfather")}} activeAnnotationId={currentNoteId}>Lead
-      him not into temptation.</Annotation> And her name is <Annotation annotationId="010054ursula" visited={visitedNotes.has("010054ursula")} annotationSelect={() => {openNote("010054ursula"); addToVisited("010054ursula")}} activeAnnotationId={currentNoteId}>Ursula.</Annotation>
+      all right. The aunt always keeps plainlooking servants for Malachi. <Annotation annotationId="040077ourfather">Lead
+      him not into temptation.</Annotation> And her name is <Annotation annotationId="010054ursula">Ursula.</Annotation>
     </p>
     <p>
       Laughing again, he brought the mirror away from Stephen's peering eyes.
     </p>
     <p>
-      —{" "}<Annotation annotationId="010055calibanmirror" visited={visitedNotes.has("010055calibanmirror")} annotationSelect={() => {openNote("010055calibanmirror"); addToVisited("010055calibanmirror")}} activeAnnotationId={currentNoteId}>The rage of Caliban at not seeing his face in a mirror</Annotation>, he said. If
+      —{" "}<Annotation annotationId="010055calibanmirror">The rage of Caliban at not seeing his face in a mirror</Annotation>, he said. If
       Wilde were only alive to see you!
     </p>
     <span data-edition="ed1922" data-page="6"> </span>
@@ -296,12 +290,12 @@ const Telemachus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
     </p>
     <span data-edition="ed1939" data-page="7"> </span>
     <p>
-      —{" "}It is <Annotation annotationId="010056crackedlookingglass" visited={visitedNotes.has("010056crackedlookingglass")} annotationSelect={() => {openNote("010056crackedlookingglass"); addToVisited("010056crackedlookingglass")}} activeAnnotationId={currentNoteId}>a symbol of Irish art. The cracked lookingglass of a servant.</Annotation>
+      —{" "}It is <Annotation annotationId="010056crackedlookingglass">a symbol of Irish art. The cracked lookingglass of a servant.</Annotation>
     </p>
     <span data-edition="ed1961" data-page="6"> </span>
     <span data-edition="ed1932" data-page="6"> </span>
     <p>
-      Buck Mulligan suddenly <Annotation annotationId="010152linkedarm" visited={visitedNotes.has("010152linkedarm")} annotationSelect={() => {openNote("010152linkedarm"); addToVisited("010152linkedarm")}} activeAnnotationId={currentNoteId}>linked his arm</Annotation> in Stephen's and walked with him
+      Buck Mulligan suddenly <Annotation annotationId="010152linkedarm">linked his arm</Annotation> in Stephen's and walked with him
       round the tower, his razor and mirror clacking in the pocket where he
       had thrust them.
     </p>
@@ -310,42 +304,42 @@ const Telemachus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       God knows you have more spirit than any of them.
     </p>
     <p>
-      Parried again. <Annotation annotationId="010003mirrorrazor" visited={visitedNotes.has("010003mirrorrazor")} annotationSelect={() => {openNote("010003mirrorrazor"); addToVisited("010003mirrorrazor")}} activeAnnotationId={currentNoteId}>He fears the lancet of my art as I fear that of his.</Annotation> The
+      Parried again. <Annotation annotationId="010003mirrorrazor">He fears the lancet of my art as I fear that of his.</Annotation> The
       cold steelpen.
     </p>
     <p>
-      —{" "}Cracked lookingglass of a servant! Tell that to the <Annotation annotationId="010023haines" visited={visitedNotes.has("010023haines")} annotationSelect={() => {openNote("010023haines"); addToVisited("010023haines")}} activeAnnotationId={currentNoteId}>oxy chap</Annotation>
-      downstairs and touch him for a <Annotation annotationId="010019money" visited={visitedNotes.has("010019money")} annotationSelect={() => {openNote("010019money"); addToVisited("010019money")}} activeAnnotationId={currentNoteId}>guinea</Annotation>. He's stinking with money and
-      thinks you're not a gentleman. His old fellow made his tin by <Annotation annotationId="010058bloodyswindle" visited={visitedNotes.has("010058bloodyswindle")} annotationSelect={() => {openNote("010058bloodyswindle"); addToVisited("010058bloodyswindle")}} activeAnnotationId={currentNoteId}>selling
+      —{" "}Cracked lookingglass of a servant! Tell that to the <Annotation annotationId="010023haines">oxy chap</Annotation>
+      downstairs and touch him for a <Annotation annotationId="010019money">guinea</Annotation>. He's stinking with money and
+      thinks you're not a gentleman. His old fellow made his tin by <Annotation annotationId="010058bloodyswindle">selling
       jalap to Zulus or some bloody swindle</Annotation> or other. God, Kinch, if you and I
-      could only work together we might do something for the island. <Annotation annotationId="010022hellenise" visited={visitedNotes.has("010022hellenise")} annotationSelect={() => {openNote("010022hellenise"); addToVisited("010022hellenise")}} activeAnnotationId={currentNoteId}>Hellenise it.</Annotation>
+      could only work together we might do something for the island. <Annotation annotationId="010022hellenise">Hellenise it.</Annotation>
     </p>
     <p>
-      <Annotation annotationId="010060cranlysarm" visited={visitedNotes.has("010060cranlysarm")} annotationSelect={() => {openNote("010060cranlysarm"); addToVisited("010060cranlysarm")}} activeAnnotationId={currentNoteId}>Cranly's arm.</Annotation> His arm.
+      <Annotation annotationId="010060cranlysarm">Cranly's arm.</Annotation> His arm.
     </p>
     <p>
       —{" "}And to think of your having to beg from these swine. I'm the only one
       that knows what you are. Why don't you trust me more? What have you
       up your nose against me? Is it Haines? If he makes any noise here I'll
-      bring down Seymour and we'll give him <Annotation annotationId="010063ragging" visited={visitedNotes.has("010063ragging")} annotationSelect={() => {openNote("010063ragging"); addToVisited("010063ragging")}} activeAnnotationId={currentNoteId}>a ragging worse than they gave
+      bring down Seymour and we'll give him <Annotation annotationId="010063ragging">a ragging worse than they gave
       Clive Kempthorpe.</Annotation>
     </p>
     <p>
-      Young shouts of moneyed voices in Clive Kempthorpe's rooms. <Annotation annotationId="010024stranger" visited={visitedNotes.has("010024stranger")} annotationSelect={() => {openNote("010024stranger"); addToVisited("010024stranger")}} activeAnnotationId={currentNoteId}>Palefaces</Annotation>:
+      Young shouts of moneyed voices in Clive Kempthorpe's rooms. <Annotation annotationId="010024stranger">Palefaces</Annotation>:
       they hold their ribs with laughter, one clasping another. O, I shall
-      expire! <Annotation annotationId="010061breaknews" visited={visitedNotes.has("010061breaknews")} annotationSelect={() => {openNote("010061breaknews"); addToVisited("010061breaknews")}} activeAnnotationId={currentNoteId}>Break the news to her gently</Annotation>, Aubrey! I shall die! With slit
+      expire! <Annotation annotationId="010061breaknews">Break the news to her gently</Annotation>, Aubrey! I shall die! With slit
       ribbons of his shirt whipping the air he hops and hobbles round the
-      table, with trousers down at heels, chased by Ades of <Annotation annotationId="010063ragging" visited={visitedNotes.has("010063ragging")} annotationSelect={() => {openNote("010063ragging"); addToVisited("010063ragging")}} activeAnnotationId={currentNoteId}>Magdalen</Annotation> with the
-      tailor's<span data-edition="ed1986" data-page="6"> </span> shears. <Annotation annotationId="010063ragging" visited={visitedNotes.has("010063ragging")} annotationSelect={() => {openNote("010063ragging"); addToVisited("010063ragging")}} activeAnnotationId={currentNoteId}>A scared calf's face gilded with marmalade. I don't
+      table, with trousers down at heels, chased by Ades of <Annotation annotationId="010063ragging">Magdalen</Annotation> with the
+      tailor's<span data-edition="ed1986" data-page="6"> </span> shears. <Annotation annotationId="010063ragging">A scared calf's face gilded with marmalade. I don't
       want to be debagged!</Annotation> Don't you play the giddy ox with me!
     </p>
     <p>
       Shouts from the open window startling evening in the quadrangle. A deaf
-      gardener, aproned, masked with <Annotation annotationId="010022hellenise" visited={visitedNotes.has("010022hellenise")} annotationSelect={() => {openNote("010022hellenise"); addToVisited("010022hellenise")}} activeAnnotationId={currentNoteId}>Matthew Arnold</Annotation>'s face, pushes his mower
+      gardener, aproned, masked with <Annotation annotationId="010022hellenise">Matthew Arnold</Annotation>'s face, pushes his mower
       on the sombre lawn watching narrowly the dancing motes of grasshalms.
     </p>
     <p>
-      <Annotation annotationId="010065omphalos" visited={visitedNotes.has("010065omphalos")} annotationSelect={() => {openNote("010065omphalos"); addToVisited("010065omphalos")}} activeAnnotationId={currentNoteId}>To ourselves... new paganism... omphalos.</Annotation>
+      <Annotation annotationId="010065omphalos">To ourselves... new paganism... omphalos.</Annotation>
     </p>
     <p>
       —{" "}Let him stay, Stephen said. There's nothing wrong with him except at
@@ -356,8 +350,8 @@ const Telemachus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       quite frank with you. What have you against me now?
     </p>
     <p>
-      They halted, looking towards the blunt cape of <Annotation annotationId="010066brayhead" visited={visitedNotes.has("010066brayhead")} annotationSelect={() => {openNote("010066brayhead"); addToVisited("010066brayhead")}} activeAnnotationId={currentNoteId}>Bray Head</Annotation> that lay on the
-      water like the snout of a sleeping whale. Stephen <Annotation annotationId="010152linkedarm" visited={visitedNotes.has("010152linkedarm")} annotationSelect={() => {openNote("010152linkedarm"); addToVisited("010152linkedarm")}} activeAnnotationId={currentNoteId}>freed his arm</Annotation> quietly.
+      They halted, looking towards the blunt cape of <Annotation annotationId="010066brayhead">Bray Head</Annotation> that lay on the
+      water like the snout of a sleeping whale. Stephen <Annotation annotationId="010152linkedarm">freed his arm</Annotation> quietly.
     </p>
     <span data-edition="ed1961" data-page="7"> </span>
     <span data-edition="ed1922" data-page="7"> </span>
@@ -383,7 +377,7 @@ const Telemachus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       Buck Mulligan frowned quickly and said:
     </p>
     <p>
-      —{" "}What? Where? I can't remember anything. <Annotation annotationId="010067hartley" visited={visitedNotes.has("010067hartley")} annotationSelect={() => {openNote("010067hartley"); addToVisited("010067hartley")}} activeAnnotationId={currentNoteId}>I remember only ideas and
+      —{" "}What? Where? I can't remember anything. <Annotation annotationId="010067hartley">I remember only ideas and
       sensations.</Annotation> Why? What happened in the name of God?
     </p>
     <p>
@@ -395,11 +389,11 @@ const Telemachus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       —{" "}Yes? Buck Mulligan said. What did I say? I forget.
     </p>
     <p>
-      —{" "}You said, Stephen answered, <Annotation annotationId="010059pulsesbeating" visited={visitedNotes.has("010059pulsesbeating")} annotationSelect={() => {openNote("010059pulsesbeating"); addToVisited("010059pulsesbeating")}} activeAnnotationId={currentNoteId}><i>O, it's only Dedalus whose mother is
+      —{" "}You said, Stephen answered, <Annotation annotationId="010059pulsesbeating"><i>O, it's only Dedalus whose mother is
       beastly dead.</i></Annotation>
     </p>
     <p>
-      A <Annotation annotationId="010059pulsesbeating" visited={visitedNotes.has("010059pulsesbeating")} annotationSelect={() => {openNote("010059pulsesbeating"); addToVisited("010059pulsesbeating")}} activeAnnotationId={currentNoteId}>flush</Annotation> which made him seem younger and more engaging rose to Buck
+      A <Annotation annotationId="010059pulsesbeating">flush</Annotation> which made him seem younger and more engaging rose to Buck
       Mulligan's cheek.
     </p>
     <span data-edition="ed1939" data-page="8"> </span>
@@ -411,20 +405,20 @@ const Telemachus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
     </p>
     <p>
       —{" "}And what is death, he asked, your mother's or yours or my own? You
-      saw only your mother die. I see them pop off every day in <Annotation annotationId="010068themater" visited={visitedNotes.has("010068themater")} annotationSelect={() => {openNote("010068themater"); addToVisited("010068themater")}} activeAnnotationId={currentNoteId}>the Mater and
+      saw only your mother die. I see them pop off every day in <Annotation annotationId="010068themater">the Mater and
       Richmond</Annotation> and cut up into tripes in the dissectingroom. It's a beastly
       thing and nothing else. It simply doesn't matter. You wouldn't kneel
       down to pray for your mother on her deathbed when she asked you. Why?
-      Because you have the cursed <Annotation annotationId="010008jesuit" visited={visitedNotes.has("010008jesuit")} annotationSelect={() => {openNote("010008jesuit"); addToVisited("010008jesuit")}} activeAnnotationId={currentNoteId}>jesuit</Annotation> strain in you, only it's injected the
+      Because you have the cursed <Annotation annotationId="010008jesuit">jesuit</Annotation> strain in you, only it's injected the
       wrong way. To me it's all a mockery and beastly. Her cerebral lobes
-      are not functioning. She calls the doctor <Annotation annotationId="010069teazle" visited={visitedNotes.has("010069teazle")} annotationSelect={() => {openNote("010069teazle"); addToVisited("010069teazle")}} activeAnnotationId={currentNoteId}>sir Peter Teazle</Annotation> and picks
+      are not functioning. She calls the doctor <Annotation annotationId="010069teazle">sir Peter Teazle</Annotation> and picks
       buttercups off the quilt. Humour her till it's over. You crossed her
       last wish in death and yet you sulk with me because I don't whinge like
-      some <Annotation annotationId="010070mutes" visited={visitedNotes.has("010070mutes")} annotationSelect={() => {openNote("010070mutes"); addToVisited("010070mutes")}} activeAnnotationId={currentNoteId}>hired mute</Annotation><span data-edition="ed1986" data-page="7"> </span><Annotation annotationId="010070mutes" visited={visitedNotes.has("010070mutes")} annotationSelect={() => {openNote("010070mutes"); addToVisited("010070mutes")}} activeAnnotationId={currentNoteId}>from Lalouette's</Annotation>. Absurd! I suppose I did say it. I
+      some <Annotation annotationId="010070mutes">hired mute</Annotation><span data-edition="ed1986" data-page="7"> </span><Annotation annotationId="010070mutes">from Lalouette's</Annotation>. Absurd! I suppose I did say it. I
       didn't mean to offend the memory of your mother.
     </p>
     <p>
-      He had spoken himself into boldness. Stephen, shielding the <Annotation annotationId="010059pulsesbeating" visited={visitedNotes.has("010059pulsesbeating")} annotationSelect={() => {openNote("010059pulsesbeating"); addToVisited("010059pulsesbeating")}} activeAnnotationId={currentNoteId}>gaping
+      He had spoken himself into boldness. Stephen, shielding the <Annotation annotationId="010059pulsesbeating">gaping
       wounds</Annotation> which the words had left in his heart, said very coldly:
     </p>
     <p>
@@ -445,9 +439,9 @@ const Telemachus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       —{" "}O, an impossible person! he exclaimed.
     </p>
     <p>
-      He walked off quickly round the parapet. Stephen stood at <Annotation annotationId="010009tower" visited={visitedNotes.has("010009tower")} annotationSelect={() => {openNote("010009tower"); addToVisited("010009tower")}} activeAnnotationId={currentNoteId}>his post</Annotation>,
+      He walked off quickly round the parapet. Stephen stood at <Annotation annotationId="010009tower">his post</Annotation>,
       gazing over the calm sea towards the headland. Sea and headland now grew
-      dim. <span data-edition="ed1932" data-page="8"> </span><Annotation annotationId="010059pulsesbeating" visited={visitedNotes.has("010059pulsesbeating")} annotationSelect={() => {openNote("010059pulsesbeating"); addToVisited("010059pulsesbeating")}} activeAnnotationId={currentNoteId}>Pulses were beating in his eyes, veiling their sight, and he felt
+      dim. <span data-edition="ed1932" data-page="8"> </span><Annotation annotationId="010059pulsesbeating">Pulses were beating in his eyes, veiling their sight, and he felt
       the fever of his cheeks.</Annotation>
     </p>
     <p>
@@ -463,8 +457,8 @@ const Telemachus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       He turned towards Stephen and said:
     </p>
     <p>
-      —{" "}Look at the sea. What does it care about offences? Chuck <Annotation annotationId="010008jesuit" visited={visitedNotes.has("010008jesuit")} annotationSelect={() => {openNote("010008jesuit"); addToVisited("010008jesuit")}} activeAnnotationId={currentNoteId}>Loyola</Annotation>,
-      Kinch, and come on down. The <Annotation annotationId="010024stranger" visited={visitedNotes.has("010024stranger")} annotationSelect={() => {openNote("010024stranger"); addToVisited("010024stranger")}} activeAnnotationId={currentNoteId}>Sassenach</Annotation> wants his morning rashers.
+      —{" "}Look at the sea. What does it care about offences? Chuck <Annotation annotationId="010008jesuit">Loyola</Annotation>,
+      Kinch, and come on down. The <Annotation annotationId="010024stranger">Sassenach</Annotation> wants his morning rashers.
     </p>
     <p>
       His head halted again for a moment at the top of the staircase, level
@@ -472,30 +466,30 @@ const Telemachus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
     </p>
     <p>
       —{" "}Don't mope over it all day, he said. I'm inconsequent. Give up the
-      <Annotation annotationId="010071moodybrooding" visited={visitedNotes.has("010071moodybrooding")} annotationSelect={() => {openNote("010071moodybrooding"); addToVisited("010071moodybrooding")}} activeAnnotationId={currentNoteId}>moody brooding</Annotation>.
+      <Annotation annotationId="010071moodybrooding">moody brooding</Annotation>.
     </p>
     <p>
       His head vanished but the drone of his descending voice boomed out of
-      the <Annotation annotationId="010002stairhead" visited={visitedNotes.has("010002stairhead")} annotationSelect={() => {openNote("010002stairhead"); addToVisited("010002stairhead")}} activeAnnotationId={currentNoteId}>stairhead</Annotation>:
+      the <Annotation annotationId="010002stairhead">stairhead</Annotation>:
     </p>
     <i></i>
-    <p><i><Annotation annotationId="010072bittermystery" visited={visitedNotes.has("010072bittermystery")} annotationSelect={() => {openNote("010072bittermystery"); addToVisited("010072bittermystery")}} activeAnnotationId={currentNoteId}>And no more turn aside and brood <br/>
+    <p><i><Annotation annotationId="010072bittermystery">And no more turn aside and brood <br/>
       Upon love's bitter mystery<br/>
       For Fergus rules the brazen cars.</Annotation></i>
     </p>
     <p>
-      <Annotation annotationId="010072bittermystery" visited={visitedNotes.has("010072bittermystery")} annotationSelect={() => {openNote("010072bittermystery"); addToVisited("010072bittermystery")}} activeAnnotationId={currentNoteId}>Woodshadows</Annotation> floated silently by through the morning peace from the
+      <Annotation annotationId="010072bittermystery">Woodshadows</Annotation> floated silently by through the morning peace from the
       stairhead seaward where he gazed. Inshore and farther out the mirror of
-      water whitened, spurned by lightshod hurrying feet. <Annotation annotationId="010072bittermystery" visited={visitedNotes.has("010072bittermystery")} annotationSelect={() => {openNote("010072bittermystery"); addToVisited("010072bittermystery")}} activeAnnotationId={currentNoteId}>White breast of
-      the dim sea.</Annotation> The <Annotation annotationId="010073twiningstresses" visited={visitedNotes.has("010073twiningstresses")} annotationSelect={() => {openNote("010073twiningstresses"); addToVisited("010073twiningstresses")}} activeAnnotationId={currentNoteId}>twining stresses,</Annotation> two by two. A hand plucking the
+      water whitened, spurned by lightshod hurrying feet. <Annotation annotationId="010072bittermystery">White breast of
+      the dim sea.</Annotation> The <Annotation annotationId="010073twiningstresses">twining stresses,</Annotation> two by two. A hand plucking the
       harpstrings merging their twining chords. Wavewhite wedded words
       shimmering on the dim tide.
     </p>
     <p>
-      <Annotation annotationId="010074cloudcover" visited={visitedNotes.has("010074cloudcover")} annotationSelect={() => {openNote("010074cloudcover"); addToVisited("010074cloudcover")}} activeAnnotationId={currentNoteId}>A cloud began to cover the sun slowly,</Annotation> shadowing the bay in
-      deeper green. It lay behind him, <Annotation annotationId="010159bitterwaters" visited={visitedNotes.has("010159bitterwaters")} annotationSelect={() => {openNote("010159bitterwaters"); addToVisited("010159bitterwaters")}} activeAnnotationId={currentNoteId}>a bowl of bitter waters. </Annotation><Annotation annotationId="010072bittermystery" visited={visitedNotes.has("010072bittermystery")} annotationSelect={() => {openNote("010072bittermystery"); addToVisited("010072bittermystery")}} activeAnnotationId={currentNoteId}>Fergus' song</Annotation>:
+      <Annotation annotationId="010074cloudcover">A cloud began to cover the sun slowly,</Annotation> shadowing the bay in
+      deeper green. It lay behind him, <Annotation annotationId="010159bitterwaters">a bowl of bitter waters. </Annotation><Annotation annotationId="010072bittermystery">Fergus' song</Annotation>:
       I sang it alone in the house, holding down the long dark chords. Her
-      door was open: she wanted to hear my music. <Annotation annotationId="010042prayforme" visited={visitedNotes.has("010042prayforme")} annotationSelect={() => {openNote("010042prayforme"); addToVisited("010042prayforme")}} activeAnnotationId={currentNoteId}>Silent with awe and pity
+      door was open: she wanted to hear my music. <Annotation annotationId="010042prayforme">Silent with awe and pity
       I went to her bedside.</Annotation> She was crying in her wretched bed. For those
       words, Stephen: love's bitter mystery.
     </p>
@@ -505,12 +499,12 @@ const Telemachus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
     </p>
     <span data-edition="ed1922" data-page="9"> </span>
     <p> 
-      Her secrets: old <Annotation annotationId="010075featherfans" visited={visitedNotes.has("010075featherfans")} annotationSelect={() => {openNote("010075featherfans"); addToVisited("010075featherfans")}} activeAnnotationId={currentNoteId}>feather fans</Annotation>, tasselled <Annotation annotationId="010076dancecards" visited={visitedNotes.has("010076dancecards")} annotationSelect={() => {openNote("010076dancecards"); addToVisited("010076dancecards")}} activeAnnotationId={currentNoteId}>dancecards</Annotation>, powdered with musk,
+      Her secrets: old <Annotation annotationId="010075featherfans">feather fans</Annotation>, tasselled <Annotation annotationId="010076dancecards">dancecards</Annotation>, powdered with musk,
       a gaud of amber beads in her locked drawer. A <span data-edition="ed1961" data-page="9"> </span>birdcage hung in the sunny
-      window of her house when she was a girl. She heard <Annotation annotationId="010077pantomime" visited={visitedNotes.has("010077pantomime")} annotationSelect={() => {openNote("010077pantomime"); addToVisited("010077pantomime")}} activeAnnotationId={currentNoteId}>old Royce sing</Annotation><span data-edition="ed1986" data-page="8"> </span><Annotation annotationId="010077pantomime" visited={visitedNotes.has("010077pantomime")} annotationSelect={() => {openNote("010077pantomime"); addToVisited("010077pantomime")}} activeAnnotationId={currentNoteId}>{" "}in the
+      window of her house when she was a girl. She heard <Annotation annotationId="010077pantomime">old Royce sing</Annotation><span data-edition="ed1986" data-page="8"> </span><Annotation annotationId="010077pantomime">{" "}in the
       pantomime of Turko the terrible</Annotation> and laughed with others when he sang:
     </p>
-    <p><i><Annotation annotationId="010078invisibility" visited={visitedNotes.has("010078invisibility")} annotationSelect={() => {openNote("010078invisibility"); addToVisited("010078invisibility")}} activeAnnotationId={currentNoteId}>I am the boy <br/>
+    <p><i><Annotation annotationId="010078invisibility">I am the boy <br/>
       That can enjoy <br/>
       Invisibility.</Annotation></i>
     </p>
@@ -522,30 +516,30 @@ const Telemachus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       <i>And no more turn aside and brood.</i>
     </p>
     <p>
-      Folded away in the <Annotation annotationId="010079akasicrecords" visited={visitedNotes.has("010079akasicrecords")} annotationSelect={() => {openNote("010079akasicrecords"); addToVisited("010079akasicrecords")}} activeAnnotationId={currentNoteId}>memory of nature</Annotation> with her toys. Memories beset his
+      Folded away in the <Annotation annotationId="010079akasicrecords">memory of nature</Annotation> with her toys. Memories beset his
       brooding brain. Her glass of water from the kitchen tap when she had
       approached the sacrament. A cored apple, filled with brown sugar,
       roasting for her at the hob on a dark autumn evening. Her shapely
-      fingernails reddened by the <Annotation annotationId="010080squashedlice" visited={visitedNotes.has("010080squashedlice")} annotationSelect={() => {openNote("010080squashedlice"); addToVisited("010080squashedlice")}} activeAnnotationId={currentNoteId}>blood of squashed lice</Annotation> from the children's
+      fingernails reddened by the <Annotation annotationId="010080squashedlice">blood of squashed lice</Annotation> from the children's
       shirts.
     </p>
     <p>
-      <Annotation annotationId="010045waxandrosewood" visited={visitedNotes.has("010045waxandrosewood")} annotationSelect={() => {openNote("010045waxandrosewood"); addToVisited("010045waxandrosewood")}} activeAnnotationId={currentNoteId}>In a dream, silently, she had come to him</Annotation>, her wasted body within its
+      <Annotation annotationId="010045waxandrosewood">In a dream, silently, she had come to him</Annotation>, her wasted body within its
       loose graveclothes giving off an odour of wax and rosewood, her breath,
       bent over him with mute secret words, a faint odour of wetted ashes.
     </p>
     <p>
-      Her glazing eyes, staring out of death, to shake and bend my soul. <Annotation annotationId="010081staringoutofdeath" visited={visitedNotes.has("010081staringoutofdeath")} annotationSelect={() => {openNote("010081staringoutofdeath"); addToVisited("010081staringoutofdeath")}} activeAnnotationId={currentNoteId}>On me
+      Her glazing eyes, staring out of death, to shake and bend my soul. <Annotation annotationId="010081staringoutofdeath">On me
       alone.</Annotation> The ghostcandle to light her agony. Ghostly light on the tortured
       face. Her hoarse loud breath rattling in horror, while all prayed on
-      their knees. Her eyes on me to strike me down. <Annotation annotationId="010082liliatarutilantium" visited={visitedNotes.has("010082liliatarutilantium")} annotationSelect={() => {openNote("010082liliatarutilantium"); addToVisited("010082liliatarutilantium")}} activeAnnotationId={currentNoteId}><i>Liliata rutilantium te
+      their knees. Her eyes on me to strike me down. <Annotation annotationId="010082liliatarutilantium"><i>Liliata rutilantium te
       confessorum turma circumdet: iubilantium te virginum chorus excipiat.</i></Annotation>
     </p>
     <p>
-      <Annotation annotationId="010062ghoul" visited={visitedNotes.has("010062ghoul")} annotationSelect={() => {openNote("010062ghoul"); addToVisited("010062ghoul")}} activeAnnotationId={currentNoteId}>Ghoul! Chewer of corpses!</Annotation>
+      <Annotation annotationId="010062ghoul">Ghoul! Chewer of corpses!</Annotation>
     </p>
     <p>
-      <Annotation annotationId="010083nomother" visited={visitedNotes.has("010083nomother")} annotationSelect={() => {openNote("010083nomother"); addToVisited("010083nomother")}} activeAnnotationId={currentNoteId}>No, mother.</Annotation> Let me be and let me live.
+      <Annotation annotationId="010083nomother">No, mother.</Annotation> Let me be and let me live.
     </p>
     <p>
       —{" "}Kinch ahoy!
@@ -553,10 +547,10 @@ const Telemachus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
     <p>
       Buck Mulligan's voice sang from within the tower. It came nearer up the
       staircase, calling again. Stephen, still trembling at his soul's cry,
-      heard <Annotation annotationId="010074cloudcover" visited={visitedNotes.has("010074cloudcover")} annotationSelect={() => {openNote("010074cloudcover"); addToVisited("010074cloudcover")}} activeAnnotationId={currentNoteId}>warm running sunlight</Annotation> and in the air behind him friendly words.
+      heard <Annotation annotationId="010074cloudcover">warm running sunlight</Annotation> and in the air behind him friendly words.
     </p>
     <p>
-      —{" "}Dedalus, come down, like a good <Annotation annotationId="010128bowsy" visited={visitedNotes.has("010128bowsy")} annotationSelect={() => {openNote("010128bowsy"); addToVisited("010128bowsy")}} activeAnnotationId={currentNoteId}>mosey</Annotation>. Breakfast is ready. Haines is
+      —{" "}Dedalus, come down, like a good <Annotation annotationId="010128bowsy">mosey</Annotation>. Breakfast is ready. Haines is
       apologising for waking us last night. It's all right.
     </p>
     <p>
@@ -572,7 +566,7 @@ const Telemachus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
     </p>
     <p>
       —{" "}I told him your symbol of Irish art. He says it's very clever. Touch
-      him for a quid, will you? A <Annotation annotationId="010019money" visited={visitedNotes.has("010019money")} annotationSelect={() => {openNote("010019money"); addToVisited("010019money")}} activeAnnotationId={currentNoteId}>guinea</Annotation>, I mean.
+      him for a quid, will you? A <Annotation annotationId="010019money">guinea</Annotation>, I mean.
     </p>
     <span data-edition="ed1961" data-page="10"> </span>
     <p>
@@ -585,8 +579,8 @@ const Telemachus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       —{" "}If you want it, Stephen said.
     </p>
     <p>
-      —{" "}Four shining <Annotation annotationId="010019money" visited={visitedNotes.has("010019money")} annotationSelect={() => {openNote("010019money"); addToVisited("010019money")}} activeAnnotationId={currentNoteId}>sovereigns</Annotation>, Buck Mulligan cried with delight. We'll
-      have a glorious drunk to astonish the druidy <Annotation annotationId="010018druids" visited={visitedNotes.has("010018druids")} annotationSelect={() => {openNote("010018druids"); addToVisited("010018druids")}} activeAnnotationId={currentNoteId}>druids</Annotation>. Four omnipotent
+      —{" "}Four shining <Annotation annotationId="010019money">sovereigns</Annotation>, Buck Mulligan cried with delight. We'll
+      have a glorious drunk to astonish the druidy <Annotation annotationId="010018druids">druids</Annotation>. Four omnipotent
       sovereigns.
     </p>
     <p>
@@ -596,7 +590,7 @@ const Telemachus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
     <span data-edition="ed1939" data-page="10"> </span>
     <span data-edition="ed1932" data-page="10"> </span>
     <span data-edition="ed1986" data-page="9"> </span>
-    <p><Annotation annotationId="010029coronation" visited={visitedNotes.has("010029coronation")} annotationSelect={() => {openNote("010029coronation"); addToVisited("010029coronation")}} activeAnnotationId={currentNoteId}><i>O, won't we have a merry time, <br/>
+    <p><Annotation annotationId="010029coronation"><i>O, won't we have a merry time, <br/>
       Drinking whisky, beer and wine! <br/>
       On coronation, <br/>
       Coronation day! <br/>
@@ -604,17 +598,17 @@ const Telemachus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       On coronation day! <br/></i></Annotation>
     </p>
     <p>
-      <Annotation annotationId="010074cloudcover" visited={visitedNotes.has("010074cloudcover")} annotationSelect={() => {openNote("010074cloudcover"); addToVisited("010074cloudcover")}} activeAnnotationId={currentNoteId}>Warm sunshine merrying over the sea</Annotation>. The nickel shavingbowl shone,
+      <Annotation annotationId="010074cloudcover">Warm sunshine merrying over the sea</Annotation>. The nickel shavingbowl shone,
       forgotten, on the parapet. Why should I bring it down? Or leave it there
       all day, forgotten friendship?
     </p>
     <p>
       He went over to it, held it in his hands awhile, feeling its coolness,
-      smelling the clammy slaver of the lather in which the brush was stuck. So I carried the boat of incense then at <Annotation annotationId="010157clongowes" visited={visitedNotes.has("010157clongowes")} annotationSelect={() => {openNote("010157clongowes"); addToVisited("010157clongowes")}} activeAnnotationId={currentNoteId}>Clongowes</Annotation>. I am another now and
-      yet the same. A servant too. <Annotation annotationId="010084server" visited={visitedNotes.has("010084server")} annotationSelect={() => {openNote("010084server"); addToVisited("010084server")}} activeAnnotationId={currentNoteId}>A server of a servant.</Annotation>
+      smelling the clammy slaver of the lather in which the brush was stuck. So I carried the boat of incense then at <Annotation annotationId="010157clongowes">Clongowes</Annotation>. I am another now and
+      yet the same. A servant too. <Annotation annotationId="010084server">A server of a servant.</Annotation>
     </p>
     <p>
-      <Annotation annotationId="010085towerlivingroom" visited={visitedNotes.has("010085towerlivingroom")} annotationSelect={() => {openNote("010085towerlivingroom"); addToVisited("010085towerlivingroom")}} activeAnnotationId={currentNoteId}>In the gloomy domed livingroom of the tower Buck Mulligan's gowned form
+      <Annotation annotationId="010085towerlivingroom">In the gloomy domed livingroom of the tower Buck Mulligan's gowned form
       moved briskly about the hearth to and fro, hiding and revealing its
       yellow glow. Two shafts of soft daylight fell across the flagged floor
       from the high barbacans</Annotation>: and at the meeting of their rays a cloud of
@@ -624,15 +618,15 @@ const Telemachus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       —{" "}We'll be choked, Buck Mulligan said. Haines, open that door, will you?
     </p>
     <p>
-      Stephen laid the shavingbowl on the locker. A tall figure <Annotation annotationId="010085towerlivingroom" visited={visitedNotes.has("010085towerlivingroom")} annotationSelect={() => {openNote("010085towerlivingroom"); addToVisited("010085towerlivingroom")}} activeAnnotationId={currentNoteId}>rose from the
+      Stephen laid the shavingbowl on the locker. A tall figure <Annotation annotationId="010085towerlivingroom">rose from the
       hammock where it had been sitting, went to the doorway and pulled open
       the inner doors.</Annotation>
     </p>
     <p>
-      —{" "}Have you <Annotation annotationId="010146hugekey" visited={visitedNotes.has("010146hugekey")} annotationSelect={() => {openNote("010146hugekey"); addToVisited("010146hugekey")}} activeAnnotationId={currentNoteId}>the key</Annotation>? a voice asked.
+      —{" "}Have you <Annotation annotationId="010146hugekey">the key</Annotation>? a voice asked.
     </p>
     <p>
-      —{" "}Dedalus has it, Buck Mulligan said. <Annotation annotationId="010128bowsy" visited={visitedNotes.has("010128bowsy")} annotationSelect={() => {openNote("010128bowsy"); addToVisited("010128bowsy")}} activeAnnotationId={currentNoteId}>Janey Mack</Annotation>, I'm choked!
+      —{" "}Dedalus has it, Buck Mulligan said. <Annotation annotationId="010128bowsy">Janey Mack</Annotation>, I'm choked!
     </p>
     <span data-edition="ed1922" data-page="11"> </span>
     <p>
@@ -653,10 +647,10 @@ const Telemachus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       them down heavily and sighed with relief.
     </p>
     <p>
-      —{" "}I'm melting, he said, <Annotation annotationId="010053candledildo" visited={visitedNotes.has("010053candledildo")} annotationSelect={() => {openNote("010053candledildo"); addToVisited("010053candledildo")}} activeAnnotationId={currentNoteId}>as the candle remarked when... </Annotation>But, hush! Not a
+      —{" "}I'm melting, he said, <Annotation annotationId="010053candledildo">as the candle remarked when... </Annotation>But, hush! Not a
       word more on that subject! Kinch, wake up! Bread, butter, honey. Haines,
       come in. The grub is ready. Bless us, O Lord, and these thy gifts.
-      Where's the sugar? O, <Annotation annotationId="010128bowsy" visited={visitedNotes.has("010128bowsy")} annotationSelect={() => {openNote("010128bowsy"); addToVisited("010128bowsy")}} activeAnnotationId={currentNoteId}>jay</Annotation>, there's no milk.
+      Where's the sugar? O, <Annotation annotationId="010128bowsy">jay</Annotation>, there's no milk.
     </p>
     <p>
       Stephen fetched the loaf and the pot of honey and the buttercooler <span data-edition="ed1932" data-page="11">{" "}</span>from
@@ -687,7 +681,7 @@ const Telemachus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       and slapped it out on three plates, saying:
     </p>
     <p>
-      —{" "}<Annotation annotationId="010057crossed" visited={visitedNotes.has("010057crossed")} annotationSelect={() => {openNote("010057crossed"); addToVisited("010057crossed")}} activeAnnotationId={currentNoteId}><i>In nomine Patris et Filii et Spiritus Sancti.</i></Annotation>
+      —{" "}<Annotation annotationId="010057crossed"><i>In nomine Patris et Filii et Spiritus Sancti.</i></Annotation>
     </p>
     <span data-edition="ed1939" data-page="11"> </span>
     <p>
@@ -702,7 +696,7 @@ const Telemachus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       wheedling voice:
     </p>
     <p>
-      —{" "}When I makes tea I makes tea, as <Annotation annotationId="010134mothergrogan" visited={visitedNotes.has("010134mothergrogan")} annotationSelect={() => {openNote("010134mothergrogan"); addToVisited("010134mothergrogan")}} activeAnnotationId={currentNoteId}>old mother Grogan</Annotation> said. And when I
+      —{" "}When I makes tea I makes tea, as <Annotation annotationId="010134mothergrogan">old mother Grogan</Annotation> said. And when I
       makes water I makes water.
     </p>
     <p>
@@ -717,12 +711,12 @@ const Telemachus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
     </p>
     <span data-edition="ed1922" data-page="12"> </span>
     <p>
-      He lunged towards his messmates in turn a thick slice of bread, <Annotation annotationId="010009tower" visited={visitedNotes.has("010009tower")} annotationSelect={() => {openNote("010009tower"); addToVisited("010009tower")}} activeAnnotationId={currentNoteId}>impaled
+      He lunged towards his messmates in turn a thick slice of bread, <Annotation annotationId="010009tower">impaled
       on his knife.</Annotation>
     </p>
     <p>
-      —{" "}<Annotation annotationId="010064dundrum" visited={visitedNotes.has("010064dundrum")} annotationSelect={() => {openNote("010064dundrum"); addToVisited("010064dundrum")}} activeAnnotationId={currentNoteId}>That's folk, he said very earnestly, for your book, Haines. Five
-      lines of text and ten pages of notes about the folk and</Annotation><span data-edition="ed1961" data-page="12"> </span><Annotation annotationId="010064dundrum" visited={visitedNotes.has("010064dundrum")} annotationSelect={() => {openNote("010064dundrum"); addToVisited("010064dundrum")}} activeAnnotationId={currentNoteId}> the fishgods of
+      —{" "}<Annotation annotationId="010064dundrum">That's folk, he said very earnestly, for your book, Haines. Five
+      lines of text and ten pages of notes about the folk and</Annotation><span data-edition="ed1961" data-page="12"> </span><Annotation annotationId="010064dundrum"> the fishgods of
       Dundrum. Printed by the weird sisters in the year of the big wind.</Annotation>
     </p>
     <p>
@@ -731,7 +725,7 @@ const Telemachus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
     </p>
     <p>
       —{" "}Can you recall, brother, is mother Grogan's tea and water pot spoken
-      of <Annotation annotationId="010064dundrum" visited={visitedNotes.has("010064dundrum")} annotationSelect={() => {openNote("010064dundrum"); addToVisited("010064dundrum")}} activeAnnotationId={currentNoteId}>in the Mabinogion or is it in the Upanishads?</Annotation> 
+      of <Annotation annotationId="010064dundrum">in the Mabinogion or is it in the Upanishads?</Annotation> 
     </p>
     <p>
       —{" "}I doubt it, said Stephen gravely.
@@ -741,7 +735,7 @@ const Telemachus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
     </p>
     <p>
       —{" "}I fancy, Stephen said as he ate, it did not exist in or out of the
-      Mabinogion. Mother Grogan was, one imagines, a kinswoman of <Annotation annotationId="010086maryann" visited={visitedNotes.has("010086maryann")} annotationSelect={() => {openNote("010086maryann"); addToVisited("010086maryann")}} activeAnnotationId={currentNoteId}>Mary Ann.</Annotation>
+      Mabinogion. Mother Grogan was, one imagines, a kinswoman of <Annotation annotationId="010086maryann">Mary Ann.</Annotation>
     </p>
     <p>
       Buck Mulligan's face smiled with delight.
@@ -754,7 +748,7 @@ const Telemachus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       Then, suddenly overclouding all his features, he growled in a hoarsened
       rasping voice as he hewed again vigorously at the loaf:
     </p>
-    <p><i>—{" "}{" "}<Annotation annotationId="010086maryann" visited={visitedNotes.has("010086maryann")} annotationSelect={() => {openNote("010086maryann"); addToVisited("010086maryann")}} activeAnnotationId={currentNoteId}>For old Mary Ann <br/>
+    <p><i>—{" "}{" "}<Annotation annotationId="010086maryann">For old Mary Ann <br/>
       She doesn't care a damn. <br/>
       But, hising up her petticoats... <br/></Annotation></i>
     </p>
@@ -785,7 +779,7 @@ const Telemachus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
     </p>
     <p>
       —{" "}The islanders, Mulligan said to Haines casually, speak frequently of
-      the <Annotation annotationId="010087prepuces" visited={visitedNotes.has("010087prepuces")} annotationSelect={() => {openNote("010087prepuces"); addToVisited("010087prepuces")}} activeAnnotationId={currentNoteId}>collector of prepuces.</Annotation>
+      the <Annotation annotationId="010087prepuces">collector of prepuces.</Annotation>
     </p>
     <p>
       —{" "}How much, sir? asked the old woman.
@@ -796,15 +790,15 @@ const Telemachus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
     <p>
       He watched her pour into the measure and thence into the jug rich white
       <span data-edition="ed1922" data-page="13"> </span>
-      milk, <Annotation annotationId="040058shegoatsudder" visited={visitedNotes.has("040058shegoatsudder")} annotationSelect={() => {openNote("040058shegoatsudder"); addToVisited("040058shegoatsudder")}} activeAnnotationId={currentNoteId}>not hers. Old shrunken paps.</Annotation> She poured again a measureful and
-      a <Annotation annotationId="010108tilly" visited={visitedNotes.has("010108tilly")} annotationSelect={() => {openNote("010108tilly"); addToVisited("010108tilly")}} activeAnnotationId={currentNoteId}>tilly</Annotation>. Old and 
+      milk, <Annotation annotationId="040058shegoatsudder">not hers. Old shrunken paps.</Annotation> She poured again a measureful and
+      a <Annotation annotationId="010108tilly">tilly</Annotation>. Old and 
       <span data-edition="ed1939" data-page="12"> </span>
-      secret she had entered from a morning world, <Annotation annotationId="010089maybemessenger" visited={visitedNotes.has("010089maybemessenger")} annotationSelect={() => {openNote("010089maybemessenger"); addToVisited("010089maybemessenger")}} activeAnnotationId={currentNoteId}>maybe
+      secret she had entered from a morning world, <Annotation annotationId="010089maybemessenger">maybe
       a messenger.</Annotation> She praised the goodness of the milk, pouring it out.
       Crouching by a patient cow at daybreak in the lush field, a witch on her
       toadstool, her <span data-edition="ed1961" data-page="13"> </span>wrinkled fingers quick at the squirting dugs. They lowed
-      about her whom they knew, dewsilky cattle. <Annotation annotationId="010090shanvanvocht" visited={visitedNotes.has("010090shanvanvocht")} annotationSelect={() => {openNote("010090shanvanvocht"); addToVisited("010090shanvanvocht")}} activeAnnotationId={currentNoteId}>Silk of the kine and poor old
-      woman</Annotation>, names given her in old times. A wandering crone, <Annotation annotationId="010089maybemessenger" visited={visitedNotes.has("010089maybemessenger")} annotationSelect={() => {openNote("010089maybemessenger"); addToVisited("010089maybemessenger")}} activeAnnotationId={currentNoteId}>lowly form of
+      about her whom they knew, dewsilky cattle. <Annotation annotationId="010090shanvanvocht">Silk of the kine and poor old
+      woman</Annotation>, names given her in old times. A wandering crone, <Annotation annotationId="010089maybemessenger">lowly form of
       an immortal</Annotation> serving her conqueror and her gay betrayer, their common
       cuckquean, a messenger from the secret morning. To serve or to upbraid,
       whether he could not tell: but scorned to beg her favour.
@@ -821,7 +815,7 @@ const Telemachus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
     <p>
       —{" "}If we could only live on good food like that, he said to her somewhat
       loudly, we wouldn't have the country full of rotten teeth and rotten
-      guts. <Annotation annotationId="060036bogs" visited={visitedNotes.has("060036bogs")} annotationSelect={() => {openNote("060036bogs"); addToVisited("060036bogs")}} activeAnnotationId={currentNoteId}>Living in a bogswamp</Annotation>, eating cheap food and the streets paved with
+      guts. <Annotation annotationId="060036bogs">Living in a bogswamp</Annotation>, eating cheap food and the streets paved with
       dust, horsedung and consumptives' spits.
     </p>
     <p>
@@ -834,8 +828,8 @@ const Telemachus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
     <p>
       Stephen listened in scornful silence. She bows her old head to a voice
       that speaks to her loudly, her bonesetter, her medicineman: me she
-      slights. To the voice that will <Annotation annotationId="010155shriveandoil" visited={visitedNotes.has("010155shriveandoil")} annotationSelect={() => {openNote("010155shriveandoil"); addToVisited("010155shriveandoil")}} activeAnnotationId={currentNoteId}>shrive and oil for the grave</Annotation> all there
-      is of her but her <Annotation annotationId="010148uncleanloins" visited={visitedNotes.has("010148uncleanloins")} annotationSelect={() => {openNote("010148uncleanloins"); addToVisited("010148uncleanloins")}} activeAnnotationId={currentNoteId}>woman's unclean loins</Annotation>, of man's flesh made not in
+      slights. To the voice that will <Annotation annotationId="010155shriveandoil">shrive and oil for the grave</Annotation> all there
+      is of her but her <Annotation annotationId="010148uncleanloins">woman's unclean loins</Annotation>, of man's flesh made not in
       God's likeness, the serpent's prey. And to the loud voice that now bids
       her be silent with wondering unsteady eyes.
     </p>
@@ -849,10 +843,10 @@ const Telemachus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       Haines spoke to her again a longer speech, confidently.
     </p>
     <p>
-      <Annotation annotationId="010091speakirish" visited={visitedNotes.has("010091speakirish")} annotationSelect={() => {openNote("010091speakirish"); addToVisited("010091speakirish")}} activeAnnotationId={currentNoteId}>—{" "}Irish, Buck Mulligan said. Is there Gaelic on you?</Annotation>
+      <Annotation annotationId="010091speakirish">—{" "}Irish, Buck Mulligan said. Is there Gaelic on you?</Annotation>
     </p>
     <p>
-      <Annotation annotationId="010091speakirish" visited={visitedNotes.has("010091speakirish")} annotationSelect={() => {openNote("010091speakirish"); addToVisited("010091speakirish")}} activeAnnotationId={currentNoteId}>—{" "}I thought it was Irish, she said, by the sound of it. Are you from the
+      <Annotation annotationId="010091speakirish">—{" "}I thought it was Irish, she said, by the sound of it. Are you from the
       west, sir?</Annotation>
     </p>
     <p>
@@ -887,7 +881,7 @@ const Telemachus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       Stephen filled again the three cups.
     </p>
     <p>
-      —{" "}Bill, sir? she said, halting. Well, <Annotation annotationId="010019money" visited={visitedNotes.has("010019money")} annotationSelect={() => {openNote("010019money"); addToVisited("010019money")}} activeAnnotationId={currentNoteId}>it's seven mornings a pint at
+      —{" "}Bill, sir? she said, halting. Well, <Annotation annotationId="010019money">it's seven mornings a pint at
       twopence is seven twos is a shilling and twopence over and these three
       mornings a quart at fourpence is three quarts is a shilling and one and two is two and two</Annotation>, sir.
     </p>
@@ -901,7 +895,7 @@ const Telemachus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
     </p>
     <p>
       Stephen filled a third cup, a spoonful of tea colouring faintly the
-      thick rich milk. Buck Mulligan brought up a <Annotation annotationId="010019money" visited={visitedNotes.has("010019money")} annotationSelect={() => {openNote("010019money"); addToVisited("010019money")}} activeAnnotationId={currentNoteId}>florin</Annotation>, twisted it round in
+      thick rich milk. Buck Mulligan brought up a <Annotation annotationId="010019money">florin</Annotation>, twisted it round in
       his fingers and cried:
     </p>
     <p>
@@ -912,7 +906,7 @@ const Telemachus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       He passed it along the table towards the old woman, saying:
     </p>
     <p>
-      —{" "}<Annotation annotationId="010092oblation" visited={visitedNotes.has("010092oblation")} annotationSelect={() => {openNote("010092oblation"); addToVisited("010092oblation")}} activeAnnotationId={currentNoteId}>Ask nothing more of me, sweet. All I can give you I give.</Annotation>
+      —{" "}<Annotation annotationId="010092oblation">Ask nothing more of me, sweet. All I can give you I give.</Annotation>
     </p>
     <p>
       Stephen laid the coin in her uneager hand.
@@ -922,13 +916,13 @@ const Telemachus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       —{" "}We'll owe twopence, he said.
     </p>
     <p>
-      —{" "}<Annotation annotationId="010143timeenough" visited={visitedNotes.has("010143timeenough")} annotationSelect={() => {openNote("010143timeenough"); addToVisited("010143timeenough")}} activeAnnotationId={currentNoteId}>Time enough</Annotation>, sir, she said, taking the coin. Time enough. Good
+      —{" "}<Annotation annotationId="010143timeenough">Time enough</Annotation>, sir, she said, taking the coin. Time enough. Good
       morning, sir.
     </p>
     <p>
       She curtseyed and went out, followed by Buck Mulligan's tender chant:
     </p>
-    <p><i>—{" "}{" "}<Annotation annotationId="010092oblation" visited={visitedNotes.has("010092oblation")} annotationSelect={() => {openNote("010092oblation"); addToVisited("010092oblation")}} activeAnnotationId={currentNoteId}>Heart of my heart, were it more, <br/>
+    <p><i>—{" "}{" "}<Annotation annotationId="010092oblation">Heart of my heart, were it more, <br/>
       More would be laid at your feet.</Annotation></i>
     </p>
     <p>
@@ -936,11 +930,11 @@ const Telemachus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
     </p>
     <p>
       —{" "}Seriously, Dedalus. I'm stony. Hurry out to your school kip and bring
-      us back some money. Today the bards must drink and junket. <Annotation annotationId="010093doduty" visited={visitedNotes.has("010093doduty")} annotationSelect={() => {openNote("010093doduty"); addToVisited("010093doduty")}} activeAnnotationId={currentNoteId}>Ireland
+      us back some money. Today the bards must drink and junket. <Annotation annotationId="010093doduty">Ireland
       expects that every man this day will do his duty.</Annotation>
     </p>
     <p>
-      —{" "}That reminds me, Haines said, rising, that I have to visit your <Annotation annotationId="010144nationallibrary" visited={visitedNotes.has("010144nationallibrary")} annotationSelect={() => {openNote("010144nationallibrary"); addToVisited("010144nationallibrary")}} activeAnnotationId={currentNoteId}>national library</Annotation> today.
+      —{" "}That reminds me, Haines said, rising, that I have to visit your <Annotation annotationId="010144nationallibrary">national library</Annotation> today.
     </p>
     <p>
       —{" "}Our swim first, Buck Mulligan said.
@@ -955,12 +949,12 @@ const Telemachus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       Then he said to Haines:
     </p>
     <p>—{" "}The unclean bard makes a point of 
-      <Annotation annotationId="010133monthlywash" visited={visitedNotes.has("010133monthlywash")} annotationSelect={() => {openNote("010133monthlywash"); addToVisited("010133monthlywash")}} activeAnnotationId={currentNoteId}>washing once a month</Annotation>.
+      <Annotation annotationId="010133monthlywash">washing once a month</Annotation>.
     </p>
     <span data-edition="ed1922" data-page="15"> </span>
     <span data-edition="ed1961" data-page="15"> </span>
     <p>
-      —{" "}<Annotation annotationId="010116gulfstream" visited={visitedNotes.has("010116gulfstream")} annotationSelect={() => {openNote("010116gulfstream"); addToVisited("010116gulfstream")}} activeAnnotationId={currentNoteId}>All Ireland is washed by the gulfstream</Annotation>, Stephen said as he let honey
+      —{" "}<Annotation annotationId="010116gulfstream">All Ireland is washed by the gulfstream</Annotation>, Stephen said as he let honey
       trickle over a slice of the loaf.
     </p>
     <span data-edition="ed1986" data-page="13"> </span>
@@ -969,10 +963,10 @@ const Telemachus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       loose collar of his tennis shirt spoke:
     </p>
     <p>
-      —{" "}<Annotation annotationId="020006chapbook" visited={visitedNotes.has("020006chapbook")} annotationSelect={() => {openNote("020006chapbook"); addToVisited("020006chapbook")}} activeAnnotationId={currentNoteId}>I intend to make a collection of your sayings</Annotation> if you will let me.
+      —{" "}<Annotation annotationId="020006chapbook">I intend to make a collection of your sayings</Annotation> if you will let me.
     </p>
     <p>
-      Speaking to me. <Annotation annotationId="010094agenbite" visited={visitedNotes.has("010094agenbite")} annotationSelect={() => {openNote("010094agenbite"); addToVisited("010094agenbite")}} activeAnnotationId={currentNoteId}>They wash and tub and scrub. Agenbite of inwit.
+      Speaking to me. <Annotation annotationId="010094agenbite">They wash and tub and scrub. Agenbite of inwit.
       Conscience. Yet here's a spot.</Annotation>
     </p>
     <p>
@@ -984,7 +978,7 @@ const Telemachus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       of tone:
     </p>
     <p>
-      —{" "}Wait till you <Annotation annotationId="010139hearhim" visited={visitedNotes.has("010139hearhim")} annotationSelect={() => {openNote("010139hearhim"); addToVisited("010139hearhim")}} activeAnnotationId={currentNoteId}>hear him on Hamlet</Annotation>, Haines.
+      —{" "}Wait till you <Annotation annotationId="010139hearhim">hear him on Hamlet</Annotation>, Haines.
     </p>
     <p>
       —{" "}Well, I mean it, Haines said, still speaking to Stephen. I was just
@@ -994,7 +988,7 @@ const Telemachus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       —{" "}Would I make money by it? Stephen asked.
     </p>
     <p>
-      Haines laughed and, as he took his soft grey hat from the <Annotation annotationId="010085towerlivingroom" visited={visitedNotes.has("010085towerlivingroom")} annotationSelect={() => {openNote("010085towerlivingroom"); addToVisited("010085towerlivingroom")}} activeAnnotationId={currentNoteId}>holdfast of
+      Haines laughed and, as he took his soft grey hat from the <Annotation annotationId="010085towerlivingroom">holdfast of
       the hammock</Annotation>, said:
     </p>
     <p>
@@ -1005,7 +999,7 @@ const Telemachus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       said with coarse vigour:
     </p>
     <p>
-      —{" "}You put <Annotation annotationId="010020ancientgreek" visited={visitedNotes.has("010020ancientgreek")} annotationSelect={() => {openNote("010020ancientgreek"); addToVisited("010020ancientgreek")}} activeAnnotationId={currentNoteId}>your hoof</Annotation> in it now. What did you say that for?
+      —{" "}You put <Annotation annotationId="010020ancientgreek">your hoof</Annotation> in it now. What did you say that for?
     </p>
     <span data-edition="ed1932" data-page="15"> </span>
     <p>
@@ -1031,7 +1025,7 @@ const Telemachus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
     </p>
     <p>
       —{" "}To tell you the God's truth I think you're right. Damn all else they
-      are good for. <Annotation annotationId="010137usurper" visited={visitedNotes.has("010137usurper")} annotationSelect={() => {openNote("010137usurper"); addToVisited("010137usurper")}} activeAnnotationId={currentNoteId}>Why don't you play them as I do?</Annotation> To hell with them all.
+      are good for. <Annotation annotationId="010137usurper">Why don't you play them as I do?</Annotation> To hell with them all.
       Let us get out of the kip.
     </p>
     <p>
@@ -1039,7 +1033,7 @@ const Telemachus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       resignedly:
     </p>
     <p>
-      —{" "}Mulligan is <Annotation annotationId="010095stripped" visited={visitedNotes.has("010095stripped")} annotationSelect={() => {openNote("010095stripped"); addToVisited("010095stripped")}} activeAnnotationId={currentNoteId}>stripped of his garments.</Annotation>
+      —{" "}Mulligan is <Annotation annotationId="010095stripped">stripped of his garments.</Annotation>
     </p>
     <p>
       He emptied his pockets on to the table.
@@ -1053,15 +1047,15 @@ const Telemachus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       chiding them, and to his dangling watchchain. His hands plunged and
       rummaged in his trunk while he called for a clean handkerchief. God,
       we'll simply have to dress the character. I want puce gloves and
-      green boots. <Annotation annotationId="010096contradictmyself" visited={visitedNotes.has("010096contradictmyself")} annotationSelect={() => {openNote("010096contradictmyself"); addToVisited("010096contradictmyself")}} activeAnnotationId={currentNoteId}>Contradiction. Do I contradict myself? Very well then</Annotation>, I
-      contradict myself. <Annotation annotationId="010021malachi" visited={visitedNotes.has("010021malachi")} annotationSelect={() => {openNote("010021malachi"); addToVisited("010021malachi")}} activeAnnotationId={currentNoteId}>Mercurial Malachi</Annotation>. A limp black missile flew out of
+      green boots. <Annotation annotationId="010096contradictmyself">Contradiction. Do I contradict myself? Very well then</Annotation>, I
+      contradict myself. <Annotation annotationId="010021malachi">Mercurial Malachi</Annotation>. A limp black missile flew out of
       his talking hands.
     </p>
     <p>
-      —{" "}And there's your <Annotation annotationId="010097latinquarterhat" visited={visitedNotes.has("010097latinquarterhat")} annotationSelect={() => {openNote("010097latinquarterhat"); addToVisited("010097latinquarterhat")}} activeAnnotationId={currentNoteId}>Latin quarter hat</Annotation>, he said.
+      —{" "}And there's your <Annotation annotationId="010097latinquarterhat">Latin quarter hat</Annotation>, he said.
     </p>
     <p>
-      <Annotation annotationId="030147takeitup" visited={visitedNotes.has("030147takeitup")} annotationSelect={() => {openNote("030147takeitup"); addToVisited("030147takeitup")}} activeAnnotationId={currentNoteId}>Stephen picked it up and put it on.</Annotation> Haines called to them from the
+      <Annotation annotationId="030147takeitup">Stephen picked it up and put it on.</Annotation> Haines called to them from the
       doorway:
     </p>
     <p>
@@ -1070,16 +1064,16 @@ const Telemachus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
     <span data-edition="ed1986" data-page="14"> </span>
     <p>
       —{" "}I'm ready, Buck Mulligan answered, going towards the door. Come out,
-      Kinch. <Annotation annotationId="010138eatenall" visited={visitedNotes.has("010138eatenall")} annotationSelect={() => {openNote("010138eatenall"); addToVisited("010138eatenall")}} activeAnnotationId={currentNoteId}>You have eaten all we left, I suppose.</Annotation> Resigned he passed out
+      Kinch. <Annotation annotationId="010138eatenall">You have eaten all we left, I suppose.</Annotation> Resigned he passed out
       with grave words and gait, saying, wellnigh with sorrow:
     </p>
     <p>
-      —{" "}<Annotation annotationId="010098metbutterly" visited={visitedNotes.has("010098metbutterly")} annotationSelect={() => {openNote("010098metbutterly"); addToVisited("010098metbutterly")}} activeAnnotationId={currentNoteId}>And going forth he met Butterly.</Annotation>
+      —{" "}<Annotation annotationId="010098metbutterly">And going forth he met Butterly.</Annotation>
     </p>
     <p>
-      Stephen, taking his <Annotation annotationId="010099ashplant" visited={visitedNotes.has("010099ashplant")} annotationSelect={() => {openNote("010099ashplant"); addToVisited("010099ashplant")}} activeAnnotationId={currentNoteId}>ashplant</Annotation> from its leaningplace, followed them out
-      and, as they went <Annotation annotationId="010085towerlivingroom" visited={visitedNotes.has("010085towerlivingroom")} annotationSelect={() => {openNote("010085towerlivingroom"); addToVisited("010085towerlivingroom")}} activeAnnotationId={currentNoteId}>down the ladder</Annotation>, pulled to the slow iron door and
-      locked it. He put <Annotation annotationId="010146hugekey" visited={visitedNotes.has("010146hugekey")} annotationSelect={() => {openNote("010146hugekey"); addToVisited("010146hugekey")}} activeAnnotationId={currentNoteId}>the huge key</Annotation> in his inner pocket.
+      Stephen, taking his <Annotation annotationId="010099ashplant">ashplant</Annotation> from its leaningplace, followed them out
+      and, as they went <Annotation annotationId="010085towerlivingroom">down the ladder</Annotation>, pulled to the slow iron door and
+      locked it. He put <Annotation annotationId="010146hugekey">the huge key</Annotation> in his inner pocket.
     </p>
     <p>
       At the foot of the ladder Buck Mulligan asked:
@@ -1114,24 +1108,24 @@ const Telemachus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       They halted while Haines surveyed the tower and said at last:
     </p>
     <p>
-      —{" "}Rather bleak in wintertime, I should say. <Annotation annotationId="010100martellos" visited={visitedNotes.has("010100martellos")} annotationSelect={() => {openNote("010100martellos"); addToVisited("010100martellos")}} activeAnnotationId={currentNoteId}>Martello you call it?</Annotation>
+      —{" "}Rather bleak in wintertime, I should say. <Annotation annotationId="010100martellos">Martello you call it?</Annotation>
     </p>
     <p>
-      —{" "}<Annotation annotationId="010100martellos" visited={visitedNotes.has("010100martellos")} annotationSelect={() => {openNote("010100martellos"); addToVisited("010100martellos")}} activeAnnotationId={currentNoteId}>Billy Pitt had them built</Annotation>, Buck Mulligan said, when the <Annotation annotationId="010101frenchonsea" visited={visitedNotes.has("010101frenchonsea")} annotationSelect={() => {openNote("010101frenchonsea"); addToVisited("010101frenchonsea")}} activeAnnotationId={currentNoteId}>French were on
-      the sea</Annotation>. But ours is the <Annotation annotationId="010100martellos" visited={visitedNotes.has("010100martellos")} annotationSelect={() => {openNote("010100martellos"); addToVisited("010100martellos")}} activeAnnotationId={currentNoteId}><i>omphalos</i>.</Annotation>
+      —{" "}<Annotation annotationId="010100martellos">Billy Pitt had them built</Annotation>, Buck Mulligan said, when the <Annotation annotationId="010101frenchonsea">French were on
+      the sea</Annotation>. But ours is the <Annotation annotationId="010100martellos"><i>omphalos</i>.</Annotation>
     </p>
     <p>
-      —{" "}What is <Annotation annotationId="010139hearhim" visited={visitedNotes.has("010139hearhim")} annotationSelect={() => {openNote("010139hearhim"); addToVisited("010139hearhim")}} activeAnnotationId={currentNoteId}>your idea of Hamlet</Annotation>? Haines asked Stephen.
+      —{" "}What is <Annotation annotationId="010139hearhim">your idea of Hamlet</Annotation>? Haines asked Stephen.
     </p>
     <p>
-      —{" "}No, no, Buck Mulligan shouted in pain. I'm not equal to <Annotation annotationId="010102aquinas" visited={visitedNotes.has("010102aquinas")} annotationSelect={() => {openNote("010102aquinas"); addToVisited("010102aquinas")}} activeAnnotationId={currentNoteId}>Thomas Aquinas
+      —{" "}No, no, Buck Mulligan shouted in pain. I'm not equal to <Annotation annotationId="010102aquinas">Thomas Aquinas
       and the fiftyfive reasons</Annotation> he has made to prop it up. Wait till I
       have a few pints in me first.
     </p>
     <span data-edition="ed1961" data-page="17"> </span>
     <p>
       He turned to Stephen, saying, as he pulled down neatly the peaks of his
-      <Annotation annotationId="010103waistcoat" visited={visitedNotes.has("010103waistcoat")} annotationSelect={() => {openNote("010103waistcoat"); addToVisited("010103waistcoat")}} activeAnnotationId={currentNoteId}>primrose waistcoat</Annotation>:
+      <Annotation annotationId="010103waistcoat">primrose waistcoat</Annotation>:
     </p>
     <span data-edition="ed1922" data-page="17"> </span>
     <p>
@@ -1145,7 +1139,7 @@ const Telemachus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       —{" "}You pique my curiosity, Haines said amiably. Is it some paradox?
     </p>
     <p>
-      —{" "}Pooh! Buck Mulligan said. We have grown out of <Annotation annotationId="010145wildeparadoxes" visited={visitedNotes.has("010145wildeparadoxes")} annotationSelect={() => {openNote("010145wildeparadoxes"); addToVisited("010145wildeparadoxes")}} activeAnnotationId={currentNoteId}>Wilde and paradoxes</Annotation>.
+      —{" "}Pooh! Buck Mulligan said. We have grown out of <Annotation annotationId="010145wildeparadoxes">Wilde and paradoxes</Annotation>.
       It's quite simple. He proves by algebra that Hamlet's grandson is
       Shakespeare's grandfather and that he himself is the ghost of his own
       father.
@@ -1154,11 +1148,11 @@ const Telemachus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       —{" "}What? Haines said, beginning to point at Stephen. He himself?
     </p>
     <p>
-      Buck Mulligan slung his towel <Annotation annotationId="010104stole" visited={visitedNotes.has("010104stole")} annotationSelect={() => {openNote("010104stole"); addToVisited("010104stole")}} activeAnnotationId={currentNoteId}>stolewise</Annotation> round his neck and, bending in
+      Buck Mulligan slung his towel <Annotation annotationId="010104stole">stolewise</Annotation> round his neck and, bending in
       loose laughter, said to Stephen's ear:
     </p>
     <p>
-      —{" "}O, shade of Kinch the elder! <Annotation annotationId="010105japhet" visited={visitedNotes.has("010105japhet")} annotationSelect={() => {openNote("010105japhet"); addToVisited("010105japhet")}} activeAnnotationId={currentNoteId}>Japhet in search of a father!</Annotation>
+      —{" "}O, shade of Kinch the elder! <Annotation annotationId="010105japhet">Japhet in search of a father!</Annotation>
     </p>
     <p>
       —{" "}We're always tired in the morning, Stephen said to Haines. And it is
@@ -1168,43 +1162,43 @@ const Telemachus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       Buck Mulligan, walking forward again, raised his hands.
     </p>
     <p>
-      —{" "}<Annotation annotationId="010106sacredpint" visited={visitedNotes.has("010106sacredpint")} annotationSelect={() => {openNote("010106sacredpint"); addToVisited("010106sacredpint")}} activeAnnotationId={currentNoteId}>The sacred pint alone can unbind the tongue of Dedalus</Annotation>, he said.
+      —{" "}<Annotation annotationId="010106sacredpint">The sacred pint alone can unbind the tongue of Dedalus</Annotation>, he said.
     </p>
     <p>
       —{" "}I mean to say, Haines explained to Stephen as they followed, this
-      tower and these cliffs here remind me somehow of <Annotation annotationId="010009tower" visited={visitedNotes.has("010009tower")} annotationSelect={() => {openNote("010009tower"); addToVisited("010009tower")}} activeAnnotationId={currentNoteId}>Elsinore. <i>That beetles
+      tower and these cliffs here remind me somehow of <Annotation annotationId="010009tower">Elsinore. <i>That beetles
       o'er his base into the sea</i></Annotation>, isn't it?
     </p>
     <span data-edition="ed1986" data-page="15"> </span>
     <p>
       Buck Mulligan turned suddenly for an instant towards Stephen but did
       not speak. In the bright silent instant Stephen saw his own image in
-      <Annotation annotationId="010048greypants" visited={visitedNotes.has("010048greypants")} annotationSelect={() => {openNote("010048greypants"); addToVisited("010048greypants")}} activeAnnotationId={currentNoteId}>cheap dusty mourning between their gay attires</Annotation>.
+      <Annotation annotationId="010048greypants">cheap dusty mourning between their gay attires</Annotation>.
     </p>
     <p>
       —{" "}It's a wonderful tale, Haines said, bringing them to halt again.
     </p>
     <p>
       Eyes, pale as the sea the wind had freshened, paler, firm and prudent.
-      The <Annotation annotationId="010107seasruler" visited={visitedNotes.has("010107seasruler")} annotationSelect={() => {openNote("010107seasruler"); addToVisited("010107seasruler")}} activeAnnotationId={currentNoteId}>seas' ruler</Annotation>, he gazed southward over the bay, empty save for the
-      smokeplume of the <Annotation annotationId="010036mailboat" visited={visitedNotes.has("010036mailboat")} annotationSelect={() => {openNote("010036mailboat"); addToVisited("010036mailboat")}} activeAnnotationId={currentNoteId}>mailboat</Annotation> vague on the bright skyline and a sail
-      tacking by <Annotation annotationId="010135bullockharbour" visited={visitedNotes.has("010135bullockharbour")} annotationSelect={() => {openNote("010135bullockharbour"); addToVisited("010135bullockharbour")}} activeAnnotationId={currentNoteId}>the Muglins</Annotation>.
+      The <Annotation annotationId="010107seasruler">seas' ruler</Annotation>, he gazed southward over the bay, empty save for the
+      smokeplume of the <Annotation annotationId="010036mailboat">mailboat</Annotation> vague on the bright skyline and a sail
+      tacking by <Annotation annotationId="010135bullockharbour">the Muglins</Annotation>.
     </p>
     <span data-edition="ed1932" data-page="17"> </span>
     <p>
       —{" "}I read a theological interpretation of it somewhere, he said bemused.
-      <Annotation annotationId="010119trinity" visited={visitedNotes.has("010119trinity")} annotationSelect={() => {openNote("010119trinity"); addToVisited("010119trinity")}} activeAnnotationId={currentNoteId}>The Father and the Son idea.</Annotation> The Son striving to be atoned with the
+      <Annotation annotationId="010119trinity">The Father and the Son idea.</Annotation> The Son striving to be atoned with the
       Father.
     </p>
     <p>
       Buck Mulligan at once put on a blithe broadly smiling face. He looked
       at them, his wellshaped mouth open happily, his eyes, from which he had
       suddenly withdrawn all shrewd sense, blinking with mad gaiety. He moved
-      a doll's head to and fro, <span data-edition="ed1961" data-page="18"> </span>the brims of his <Annotation annotationId="010109panamahat" visited={visitedNotes.has("010109panamahat")} annotationSelect={() => {openNote("010109panamahat"); addToVisited("010109panamahat")}} activeAnnotationId={currentNoteId}>Panama hat</Annotation> quivering, and
+      a doll's head to and fro, <span data-edition="ed1961" data-page="18"> </span>the brims of his <Annotation annotationId="010109panamahat">Panama hat</Annotation> quivering, and
       began to chant in a quiet happy foolish voice:
     </p>
     <p><i>—{" "}{" "}I'm the queerest young fellow that ever you heard. <br/>
-      <Annotation annotationId="010150fatherbird" visited={visitedNotes.has("010150fatherbird")} annotationSelect={() => {openNote("010150fatherbird"); addToVisited("010150fatherbird")}} activeAnnotationId={currentNoteId}>My mother's a jew, my father's a bird</Annotation>. <br/>
+      <Annotation annotationId="010150fatherbird">My mother's a jew, my father's a bird</Annotation>. <br/>
       With Joseph the joiner I cannot agree. <br/>
       So here's to disciples and Calvary.</i>
     </p>
@@ -1213,7 +1207,7 @@ const Telemachus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       He held up a forefinger of warning.
     </p>
     <p><i>—{" "}{" "}
-      <Annotation annotationId="010151drinkwater" visited={visitedNotes.has("010151drinkwater")} annotationSelect={() => {openNote("010151drinkwater"); addToVisited("010151drinkwater")}} activeAnnotationId={currentNoteId}>If anyone thinks that I amn't divine<br/>He'll get no free drinks when I'm making the wine <br/>
+      <Annotation annotationId="010151drinkwater">If anyone thinks that I amn't divine<br/>He'll get no free drinks when I'm making the wine <br/>
       But have to drink water and wish it were plain <br/>
       That I make when the wine becomes water again.</Annotation></i>
     </p>
@@ -1226,11 +1220,11 @@ const Telemachus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
     <p><i>—{" "}{" "}Goodbye, now, goodbye! Write down all I said <br/>
       And tell Tom, Dick and Harry I rose from the dead. <br/>
       What's bred in the bone cannot fail me to fly <br/>
-      And <Annotation annotationId="010149olivet" visited={visitedNotes.has("010149olivet")} annotationSelect={() => {openNote("010149olivet"); addToVisited("010149olivet")}} activeAnnotationId={currentNoteId}>Olivet's breezy</Annotation>... Goodbye, now, goodbye!</i>
+      And <Annotation annotationId="010149olivet">Olivet's breezy</Annotation>... Goodbye, now, goodbye!</i>
     </p>
     <p>
-      He capered before them <Annotation annotationId="010111fortyfoot" visited={visitedNotes.has("010111fortyfoot")} annotationSelect={() => {openNote("010111fortyfoot"); addToVisited("010111fortyfoot")}} activeAnnotationId={currentNoteId}>down towards the fortyfoot hole</Annotation>, fluttering his
-      winglike hands, leaping nimbly, <Annotation annotationId="010021malachi" visited={visitedNotes.has("010021malachi")} annotationSelect={() => {openNote("010021malachi"); addToVisited("010021malachi")}} activeAnnotationId={currentNoteId}>Mercury's hat</Annotation> quivering in the fresh
+      He capered before them <Annotation annotationId="010111fortyfoot">down towards the fortyfoot hole</Annotation>, fluttering his
+      winglike hands, leaping nimbly, <Annotation annotationId="010021malachi">Mercury's hat</Annotation> quivering in the fresh
       wind that bore back to them his brief birdlike cries.
     </p>
     <p>
@@ -1243,7 +1237,7 @@ const Telemachus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       it somehow, doesn't it? What did he call it? Joseph the Joiner?
     </p>
     <p>
-      —{" "}<Annotation annotationId="010110jokingjesus" visited={visitedNotes.has("010110jokingjesus")} annotationSelect={() => {openNote("010110jokingjesus"); addToVisited("010110jokingjesus")}} activeAnnotationId={currentNoteId}>The ballad of joking Jesus</Annotation>, Stephen answered.
+      —{" "}<Annotation annotationId="010110jokingjesus">The ballad of joking Jesus</Annotation>, Stephen answered.
     </p>
     <p>
       —{" "}O, Haines said, you have heard it before?
@@ -1261,7 +1255,7 @@ const Telemachus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
     </p>
     <span data-edition="ed1986" data-page="16"> </span>
     <p>
-      Haines stopped to take out <Annotation annotationId="010142greenstone" visited={visitedNotes.has("010142greenstone")} annotationSelect={() => {openNote("010142greenstone"); addToVisited("010142greenstone")}} activeAnnotationId={currentNoteId}>a smooth silver case in which</Annotation><span data-edition="ed1961" data-page="19"> </span><Annotation annotationId="010142greenstone" visited={visitedNotes.has("010142greenstone")} annotationSelect={() => {openNote("010142greenstone"); addToVisited("010142greenstone")}} activeAnnotationId={currentNoteId}> twinkled a
+      Haines stopped to take out <Annotation annotationId="010142greenstone">a smooth silver case in which</Annotation><span data-edition="ed1961" data-page="19"> </span><Annotation annotationId="010142greenstone"> twinkled a
       green stone</Annotation>. He sprang it open with his thumb and offered it.
     </p>
     <p>
@@ -1285,10 +1279,10 @@ const Telemachus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
     </p>
     <p>
       He walked on, waiting to be spoken to, trailing his ashplant by his
-      side. <Annotation annotationId="010099ashplant" visited={visitedNotes.has("010099ashplant")} annotationSelect={() => {openNote("010099ashplant"); addToVisited("010099ashplant")}} activeAnnotationId={currentNoteId}>Its ferrule followed lightly on the path, squealing at his heels.
+      side. <Annotation annotationId="010099ashplant">Its ferrule followed lightly on the path, squealing at his heels.
       My familiar,</Annotation> after me, calling, Steeeeeeeeeeeephen! A wavering line
       along the path. They will walk on it tonight, coming here in the dark.
-      He wants that key. It is mine. <Annotation annotationId="010001buckmulligan" visited={visitedNotes.has("010001buckmulligan")} annotationSelect={() => {openNote("010001buckmulligan"); addToVisited("010001buckmulligan")}} activeAnnotationId={currentNoteId}>I paid the rent.</Annotation> <Annotation annotationId="010112saltbread" visited={visitedNotes.has("010112saltbread")} annotationSelect={() => {openNote("010112saltbread"); addToVisited("010112saltbread")}} activeAnnotationId={currentNoteId}>Now I eat his salt
+      He wants that key. It is mine. <Annotation annotationId="010001buckmulligan">I paid the rent.</Annotation> <Annotation annotationId="010112saltbread">Now I eat his salt
       bread.</Annotation> Give him the key too. All. He will ask for it. That was in his
       eyes.
     </p>
@@ -1300,18 +1294,18 @@ const Telemachus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       all unkind.
     </p>
     <p>
-      —{" "}After all, I should think you are able to free yourself. <Annotation annotationId="010113ownmaster" visited={visitedNotes.has("010113ownmaster")} annotationSelect={() => {openNote("010113ownmaster"); addToVisited("010113ownmaster")}} activeAnnotationId={currentNoteId}>You are your
+      —{" "}After all, I should think you are able to free yourself. <Annotation annotationId="010113ownmaster">You are your
       own master</Annotation>, it seems to me.
     </p>
     <p>
-      —{" "}<Annotation annotationId="010114stateandchurch" visited={visitedNotes.has("010114stateandchurch")} annotationSelect={() => {openNote("010114stateandchurch"); addToVisited("010114stateandchurch")}} activeAnnotationId={currentNoteId}>I am the servant of two masters, Stephen said, an English and an
+      —{" "}<Annotation annotationId="010114stateandchurch">I am the servant of two masters, Stephen said, an English and an
       Italian.</Annotation>
     </p>
     <p>
       —{" "}Italian? Haines said.
     </p>
     <p>
-      <Annotation annotationId="010156crazyqueen" visited={visitedNotes.has("010156crazyqueen")} annotationSelect={() => {openNote("010156crazyqueen"); addToVisited("010156crazyqueen")}} activeAnnotationId={currentNoteId}>A crazy queen, old and jealous. Kneel down before me.</Annotation>
+      <Annotation annotationId="010156crazyqueen">A crazy queen, old and jealous. Kneel down before me.</Annotation>
     </p>
     <p>
       —{" "}And a third, Stephen said, there is who wants me for odd jobs.
@@ -1331,48 +1325,48 @@ const Telemachus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
     <p>
       —{" "}I can quite understand that, he said calmly. An Irishman must think
       like that, I daresay. We feel in England that we have treated you rather
-      unfairly. <Annotation annotationId="010141blamehistory" visited={visitedNotes.has("010141blamehistory")} annotationSelect={() => {openNote("010141blamehistory"); addToVisited("010141blamehistory")}} activeAnnotationId={currentNoteId}>It seems history is to blame.</Annotation>
+      unfairly. <Annotation annotationId="010141blamehistory">It seems history is to blame.</Annotation>
     </p>
     <p>
       The proud potent titles clanged over Stephen's memory the triumph<span data-edition="ed1932" data-page="19"> </span>
-      of their brazen bells: <Annotation annotationId="010115creed" visited={visitedNotes.has("010115creed")} annotationSelect={() => {openNote("010115creed"); addToVisited("010115creed")}} activeAnnotationId={currentNoteId}><i>et unam sanctam catholicam</i></Annotation><span data-edition="ed1961" data-page="20"> </span><Annotation annotationId="010115creed" visited={visitedNotes.has("010115creed")} annotationSelect={() => {openNote("010115creed"); addToVisited("010115creed")}} activeAnnotationId={currentNoteId}><i> et apostolicam
+      of their brazen bells: <Annotation annotationId="010115creed"><i>et unam sanctam catholicam</i></Annotation><span data-edition="ed1961" data-page="20"> </span><Annotation annotationId="010115creed"><i> et apostolicam
       ecclesiam</i></Annotation>: the slow growth and change of rite and dogma like his own
-      rare thoughts, a chemistry of stars. <Annotation annotationId="010117symbolapostles" visited={visitedNotes.has("010117symbolapostles")} annotationSelect={() => {openNote("010117symbolapostles"); addToVisited("010117symbolapostles")}} activeAnnotationId={currentNoteId}>Symbol of the apostles</Annotation> in the<Annotation annotationId="010118masspopemarcellus" visited={visitedNotes.has("010118masspopemarcellus")} annotationSelect={() => {openNote("010118masspopemarcellus"); addToVisited("010118masspopemarcellus")}} activeAnnotationId={currentNoteId}>
+      rare thoughts, a chemistry of stars. <Annotation annotationId="010117symbolapostles">Symbol of the apostles</Annotation> in the<Annotation annotationId="010118masspopemarcellus">
       mass for pope Marcellus</Annotation>, the voices blended, singing alone loud in
-      affirmation: and behind their chant <Annotation annotationId="010088archangelmichael" visited={visitedNotes.has("010088archangelmichael")} annotationSelect={() => {openNote("010088archangelmichael"); addToVisited("010088archangelmichael")}} activeAnnotationId={currentNoteId}>the vigilant angel of the church
+      affirmation: and behind their chant <Annotation annotationId="010088archangelmichael">the vigilant angel of the church
       militant</Annotation>disarmed and menaced her heresiarchs. A horde of heresies
       fleeing with mitres awry: Photius and the brood of mockers
       <span data-edition="ed1922" data-page="20"> </span>
-      of whom Mulligan was one, and Arius, warring his life long upon<Annotation annotationId="010119trinity" visited={visitedNotes.has("010119trinity")} annotationSelect={() => {openNote("010119trinity"); addToVisited("010119trinity")}} activeAnnotationId={currentNoteId}>the
+      of whom Mulligan was one, and Arius, warring his life long upon<Annotation annotationId="010119trinity">the
       consubstantiality of the Son with the Father</Annotation>, and Valentine, spurning
       Christ's terrene body, and the subtle African heresiarch Sabellius<span data-edition="ed1986" data-page="17"> </span> who
       held that the Father was Himself His own Son. Words Mulligan had spoken
-      a moment since in mockery to the <Annotation annotationId="010024stranger" visited={visitedNotes.has("010024stranger")} annotationSelect={() => {openNote("010024stranger"); addToVisited("010024stranger")}} activeAnnotationId={currentNoteId}>stranger</Annotation>. Idle mockery. The void
-      awaits surely all them that <Annotation annotationId="010120weavewind" visited={visitedNotes.has("010120weavewind")} annotationSelect={() => {openNote("010120weavewind"); addToVisited("010120weavewind")}} activeAnnotationId={currentNoteId}>weave the wind</Annotation>: a menace, a disarming and a
-      worsting from those embattled angels of the church, <Annotation annotationId="010088archangelmichael" visited={visitedNotes.has("010088archangelmichael")} annotationSelect={() => {openNote("010088archangelmichael"); addToVisited("010088archangelmichael")}} activeAnnotationId={currentNoteId}>Michael's host,</Annotation>
+      a moment since in mockery to the <Annotation annotationId="010024stranger">stranger</Annotation>. Idle mockery. The void
+      awaits surely all them that <Annotation annotationId="010120weavewind">weave the wind</Annotation>: a menace, a disarming and a
+      worsting from those embattled angels of the church, <Annotation annotationId="010088archangelmichael">Michael's host,</Annotation>
       who defend her ever in the hour of conflict with their lances and their
       shields.
     </p>
     <p>
-      <Annotation annotationId="010121applause" visited={visitedNotes.has("010121applause")} annotationSelect={() => {openNote("010121applause"); addToVisited("010121applause")}} activeAnnotationId={currentNoteId}>Hear, hear! Prolonged applause. <i>Zut! Nom de Dieu!</i></Annotation>
+      <Annotation annotationId="010121applause">Hear, hear! Prolonged applause. <i>Zut! Nom de Dieu!</i></Annotation>
     </p>
     <p>
       —{" "}Of course I'm a Britisher, Haines' voice said, and I feel as one. I
-      don't want to see my country fall into the hands of <Annotation annotationId="010122germanjews" visited={visitedNotes.has("010122germanjews")} annotationSelect={() => {openNote("010122germanjews"); addToVisited("010122germanjews")}} activeAnnotationId={currentNoteId}>German jews</Annotation> either.
+      don't want to see my country fall into the hands of <Annotation annotationId="010122germanjews">German jews</Annotation> either.
       That's our national problem, I'm afraid, just now.
     </p>
     <p>
       Two men stood at the verge of the cliff, watching: businessman, boatman.
     </p>
     <p>
-      —{" "}She's making for <Annotation annotationId="010135bullockharbour" visited={visitedNotes.has("010135bullockharbour")} annotationSelect={() => {openNote("010135bullockharbour"); addToVisited("010135bullockharbour")}} activeAnnotationId={currentNoteId}>Bullock harbour</Annotation>.
+      —{" "}She's making for <Annotation annotationId="010135bullockharbour">Bullock harbour</Annotation>.
     </p>
     <p>
       The boatman nodded towards the north of the bay with some disdain.
     </p>
     <p>
-      —{" "}There's <Annotation annotationId="010124fivefathoms" visited={visitedNotes.has("010124fivefathoms")} annotationSelect={() => {openNote("010124fivefathoms"); addToVisited("010124fivefathoms")}} activeAnnotationId={currentNoteId}>five fathoms</Annotation> out there, he said. It'll be swept up that way
-      when <Annotation annotationId="010125hightide" visited={visitedNotes.has("010125hightide")} annotationSelect={() => {openNote("010125hightide"); addToVisited("010125hightide")}} activeAnnotationId={currentNoteId}>the tide comes in about one</Annotation>. It's nine days today.
+      —{" "}There's <Annotation annotationId="010124fivefathoms">five fathoms</Annotation> out there, he said. It'll be swept up that way
+      when <Annotation annotationId="010125hightide">the tide comes in about one</Annotation>. It's nine days today.
     </p>
     <p>
       The man that was drowned. A sail veering about the blank bay waiting
@@ -1380,20 +1374,20 @@ const Telemachus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       saltwhite. Here I am.
     </p>
     <p>
-      They followed the winding path down to the <Annotation annotationId="010111fortyfoot" visited={visitedNotes.has("010111fortyfoot")} annotationSelect={() => {openNote("010111fortyfoot"); addToVisited("010111fortyfoot")}} activeAnnotationId={currentNoteId}>creek</Annotation>. Buck Mulligan stood on
+      They followed the winding path down to the <Annotation annotationId="010111fortyfoot">creek</Annotation>. Buck Mulligan stood on
       a stone, in shirtsleeves, his unclipped tie rippling over his shoulder.
-      A young man clinging to a spur of rock near him, <Annotation annotationId="010147sealshead" visited={visitedNotes.has("010147sealshead")} annotationSelect={() => {openNote("010147sealshead"); addToVisited("010147sealshead")}} activeAnnotationId={currentNoteId}>moved slowly frogwise
+      A young man clinging to a spur of rock near him, <Annotation annotationId="010147sealshead">moved slowly frogwise
       his green legs in the deep jelly of the water</Annotation>.
     </p>
     <p>
       —{" "}Is the brother with you, Malachi?
     </p>
     <p>
-      —{" "}Down in <Annotation annotationId="010126mullingar" visited={visitedNotes.has("010126mullingar")} annotationSelect={() => {openNote("010126mullingar"); addToVisited("010126mullingar")}} activeAnnotationId={currentNoteId}>Westmeath.</Annotation> With the Bannons.
+      —{" "}Down in <Annotation annotationId="010126mullingar">Westmeath.</Annotation> With the Bannons.
     </p>
     <p>
       —{" "}Still there? I got a card from Bannon. Says he found a sweet young
-      thing down there. <Annotation annotationId="010127photogirl" visited={visitedNotes.has("010127photogirl")} annotationSelect={() => {openNote("010127photogirl"); addToVisited("010127photogirl")}} activeAnnotationId={currentNoteId}>Photo girl</Annotation> he calls her.
+      thing down there. <Annotation annotationId="010127photogirl">Photo girl</Annotation> he calls her.
     </p>
     <span data-edition="ed1961" data-page="21"> </span>
     <p>
@@ -1402,19 +1396,19 @@ const Telemachus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
     <p>
       Buck Mulligan sat down to unlace his boots. An elderly man shot up near
       the spur of rock a blowing red face. He scrambled up by the stones,
-      water glistening on his pate and on its <Annotation annotationId="010136nimbus" visited={visitedNotes.has("010136nimbus")} annotationSelect={() => {openNote("010136nimbus"); addToVisited("010136nimbus")}} activeAnnotationId={currentNoteId}>garland of grey hair</Annotation>,<span data-edition="ed1932" data-page="20"> </span>water
+      water glistening on his pate and on its <Annotation annotationId="010136nimbus">garland of grey hair</Annotation>,<span data-edition="ed1932" data-page="20"> </span>water
       rilling over his chest and paunch and spilling jets out of his black
       sagging loincloth.
     </p>
     <p>
       Buck Mulligan made way for him to scramble past and, glancing at Haines
-      and Stephen, <Annotation annotationId="010057crossed" visited={visitedNotes.has("010057crossed")} annotationSelect={() => {openNote("010057crossed"); addToVisited("010057crossed")}} activeAnnotationId={currentNoteId}>crossed himself piously</Annotation> with his thumbnail at brow and lips
+      and Stephen, <Annotation annotationId="010057crossed">crossed himself piously</Annotation> with his thumbnail at brow and lips
       and breastbone.
     </p>
     <span data-edition="ed1922" data-page="21"> </span>
     <p>
       —{" "}Seymour's back in town, the young man said, grasping again his spur of
-      rock. Chucked medicine and <Annotation annotationId="010058bloodyswindle" visited={visitedNotes.has("010058bloodyswindle")} annotationSelect={() => {openNote("010058bloodyswindle"); addToVisited("010058bloodyswindle")}} activeAnnotationId={currentNoteId}>going in for the army.</Annotation> 
+      rock. Chucked medicine and <Annotation annotationId="010058bloodyswindle">going in for the army.</Annotation> 
     </p>
     <span data-edition="ed1939" data-page="18"> </span>
     <p>
@@ -1427,11 +1421,11 @@ const Telemachus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       —{" "}Yes.
     </p>
     <p>
-      —{" "}Spooning with him last night <Annotation annotationId="010037harbourmouth" visited={visitedNotes.has("010037harbourmouth")} annotationSelect={() => {openNote("010037harbourmouth"); addToVisited("010037harbourmouth")}} activeAnnotationId={currentNoteId}>on the pier</Annotation>. The father is rotto with
+      —{" "}Spooning with him last night <Annotation annotationId="010037harbourmouth">on the pier</Annotation>. The father is rotto with
       money.
     </p>
     <p>
-      —{" "}Is she <Annotation annotationId="010058bloodyswindle" visited={visitedNotes.has("010058bloodyswindle")} annotationSelect={() => {openNote("010058bloodyswindle"); addToVisited("010058bloodyswindle")}} activeAnnotationId={currentNoteId}>up the pole?</Annotation>
+      —{" "}Is she <Annotation annotationId="010058bloodyswindle">up the pole?</Annotation>
     </p>
     <p>
       —{" "}Better ask Seymour that.
@@ -1451,7 +1445,7 @@ const Telemachus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       He broke off in alarm, feeling his side under his flapping shirt.
     </p>
     <p>
-      —{" "}<Annotation annotationId="010129ubermensch" visited={visitedNotes.has("010129ubermensch")} annotationSelect={() => {openNote("010129ubermensch"); addToVisited("010129ubermensch")}} activeAnnotationId={currentNoteId}>My twelfth rib is gone, he cried. I'm the <i>Uebermensch.</i></Annotation> <Annotation annotationId="010130toothless" visited={visitedNotes.has("010130toothless")} annotationSelect={() => {openNote("010130toothless"); addToVisited("010130toothless")}} activeAnnotationId={currentNoteId}>Toothless
+      —{" "}<Annotation annotationId="010129ubermensch">My twelfth rib is gone, he cried. I'm the <i>Uebermensch.</i></Annotation> <Annotation annotationId="010130toothless">Toothless
       Kinch</Annotation> and I, the supermen.
     </p>
     <p>
@@ -1466,7 +1460,7 @@ const Telemachus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
     </p>
     <p>
       The young man shoved himself backward through the water and reached
-      <Annotation annotationId="010111fortyfoot" visited={visitedNotes.has("010111fortyfoot")} annotationSelect={() => {openNote("010111fortyfoot"); addToVisited("010111fortyfoot")}} activeAnnotationId={currentNoteId}>the middle of the creek</Annotation> in two long clean strokes. Haines sat down on a
+      <Annotation annotationId="010111fortyfoot">the middle of the creek</Annotation> in two long clean strokes. Haines sat down on a
       stone, smoking.
     </p>
     <p>
@@ -1490,7 +1484,7 @@ const Telemachus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
       clothes.
     </p>
     <p>
-      —{" "}And <Annotation annotationId="010019money" visited={visitedNotes.has("010019money")} annotationSelect={() => {openNote("010019money"); addToVisited("010019money")}} activeAnnotationId={currentNoteId}>twopence</Annotation>, he said, for a pint. Throw it there.
+      —{" "}And <Annotation annotationId="010019money">twopence</Annotation>, he said, for a pint. Throw it there.
     </p>
     <p>
       Stephen threw two pennies on the soft heap. Dressing, undressing. Buck
@@ -1498,7 +1492,7 @@ const Telemachus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
     </p>
     <span data-edition="ed1932" data-page="21"> </span>
     <p>
-      —{" "}<Annotation annotationId="010129ubermensch" visited={visitedNotes.has("010129ubermensch")} annotationSelect={() => {openNote("010129ubermensch"); addToVisited("010129ubermensch")}} activeAnnotationId={currentNoteId}>He who stealeth from the poor lendeth to the Lord. Thus spake
+      —{" "}<Annotation annotationId="010129ubermensch">He who stealeth from the poor lendeth to the Lord. Thus spake
       Zarathustra.</Annotation>
     </p>
     <span data-edition="ed1922" data-page="22"> </span>
@@ -1507,13 +1501,13 @@ const Telemachus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
     </p>
     <p>
       —{" "}We'll see you again, Haines said, turning as Stephen walked up the
-      path and smiling at <Annotation annotationId="010132wildirish" visited={visitedNotes.has("010132wildirish")} annotationSelect={() => {openNote("010132wildirish"); addToVisited("010132wildirish")}} activeAnnotationId={currentNoteId}>wild Irish</Annotation>.
+      path and smiling at <Annotation annotationId="010132wildirish">wild Irish</Annotation>.
     </p>
     <p>
-      Horn of a bull, hoof of a horse, <Annotation annotationId="010024stranger" visited={visitedNotes.has("010024stranger")} annotationSelect={() => {openNote("010024stranger"); addToVisited("010024stranger")}} activeAnnotationId={currentNoteId}>smile of a Saxon.</Annotation>
+      Horn of a bull, hoof of a horse, <Annotation annotationId="010024stranger">smile of a Saxon.</Annotation>
     </p>
     <p>
-      —{" "}<Annotation annotationId="010049shiptavern" visited={visitedNotes.has("010049shiptavern")} annotationSelect={() => {openNote("010049shiptavern"); addToVisited("010049shiptavern")}} activeAnnotationId={currentNoteId}>The Ship, Buck Mulligan cried. Half twelve.</Annotation>
+      —{" "}<Annotation annotationId="010049shiptavern">The Ship, Buck Mulligan cried. Half twelve.</Annotation>
     </p>
     <p>
       —{" "}Good, Stephen said.
@@ -1521,21 +1515,21 @@ const Telemachus = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
     <p>
       He walked along the upwardcurving path.
     </p>
-    <p><Annotation annotationId="010012quarterto" visited={visitedNotes.has("010012quarterto")} annotationSelect={() => {openNote("010012quarterto"); addToVisited("010012quarterto")}} activeAnnotationId={currentNoteId}><i>Liliata rutilantium. <br/>
+    <p><Annotation annotationId="010012quarterto"><i>Liliata rutilantium. <br/>
       Turma circumdet. <br/>
       Iubilantium te virginum.</i></Annotation>
     </p>
     <p>
-      The priest's grey <Annotation annotationId="010136nimbus" visited={visitedNotes.has("010136nimbus")} annotationSelect={() => {openNote("010136nimbus"); addToVisited("010136nimbus")}} activeAnnotationId={currentNoteId}>nimbus in a niche</Annotation> where he dressed discreetly. I will
+      The priest's grey <Annotation annotationId="010136nimbus">nimbus in a niche</Annotation> where he dressed discreetly. I will
       not sleep here tonight. Home also I cannot go.
     </p>
     <p>
       A voice, sweettoned and sustained, called to him from the sea. Turning
-      the curve he waved his hand. It called again. <Annotation annotationId="010147sealshead" visited={visitedNotes.has("010147sealshead")} annotationSelect={() => {openNote("010147sealshead"); addToVisited("010147sealshead")}} activeAnnotationId={currentNoteId}>A sleek brown head, a
+      the curve he waved his hand. It called again. <Annotation annotationId="010147sealshead">A sleek brown head, a
       seal's</Annotation>, far out on the water, round.
     </p>
     <p>
-      <Annotation annotationId="010137usurper" visited={visitedNotes.has("010137usurper")} annotationSelect={() => {openNote("010137usurper"); addToVisited("010137usurper")}} activeAnnotationId={currentNoteId}>Usurper.</Annotation>
+      <Annotation annotationId="010137usurper">Usurper.</Annotation>
     </p>
     <br/><br/><br/>
     <span data-edition="ed1961" data-page="23"> </span>

--- a/src/content/chapters/WanderingRocks.js
+++ b/src/content/chapters/WanderingRocks.js
@@ -1,32 +1,32 @@
 import Annotation from "../../components/Annotation";
 
 
-const WanderingRocks = ({openNote, currentNoteId, visitedNotes, addToVisited}) => {
+const WanderingRocks = () => {
   return (
     <div>
       <p></p>
       <center><font size="+2">[10]</font></center>
       <br/>
-      The superior, the very reverend  <Annotation annotationId="050052conmee" visited={visitedNotes.has("050052conmee")} annotationSelect={() => {openNote("050052conmee"); addToVisited("050052conmee")}} activeAnnotationId={currentNoteId}>John Conmee S.J.</Annotation> reset his smooth watch
-      in his interior pocket as he came <Annotation annotationId="100010xavier" visited={visitedNotes.has("100010xavier")} annotationSelect={() => {openNote("100010xavier"); addToVisited("100010xavier")}} activeAnnotationId={currentNoteId}>down the presbytery steps</Annotation>. Five to
-      three. Just nice time to <Annotation annotationId="100011toartane" visited={visitedNotes.has("100011toartane")} annotationSelect={() => {openNote("100011toartane"); addToVisited("100011toartane")}} activeAnnotationId={currentNoteId}>walk to Artane</Annotation>. What was that boy's name again?
-      Dignam. Yes. <i>Vere dignum et iustum est.</i>  <Annotation annotationId="100011toartane" visited={visitedNotes.has("100011toartane")} annotationSelect={() => {openNote("100011toartane"); addToVisited("100011toartane")}} activeAnnotationId={currentNoteId}>Brother Swan</Annotation> was the person
+      The superior, the very reverend  <Annotation annotationId="050052conmee">John Conmee S.J.</Annotation> reset his smooth watch
+      in his interior pocket as he came <Annotation annotationId="100010xavier">down the presbytery steps</Annotation>. Five to
+      three. Just nice time to <Annotation annotationId="100011toartane">walk to Artane</Annotation>. What was that boy's name again?
+      Dignam. Yes. <i>Vere dignum et iustum est.</i>  <Annotation annotationId="100011toartane">Brother Swan</Annotation> was the person
       to see. Mr Cunningham's letter. Yes. Oblige him, if possible. Good
       practical catholic: useful at mission time.
       <p></p>
       <p>
         A onelegged sailor, swinging himself onward by lazy jerks of his
-        crutches, growled some notes. He jerked short before <Annotation annotationId="100010xavier" visited={visitedNotes.has("100010xavier")} annotationSelect={() => {openNote("100010xavier"); addToVisited("100010xavier")}} activeAnnotationId={currentNoteId}>the convent of the
+        crutches, growled some notes. He jerked short before <Annotation annotationId="100010xavier">the convent of the
         sisters of charity</Annotation> and held out a peaked cap for alms towards the very
         reverend John Conmee S. J. Father Conmee blessed him in the sun for his
         purse held, he knew, one silver crown.
       </p>
       <p>
-        Father Conmee crossed to <Annotation annotationId="100010xavier" visited={visitedNotes.has("100010xavier")} annotationSelect={() => {openNote("100010xavier"); addToVisited("100010xavier")}} activeAnnotationId={currentNoteId}>Mountjoy square</Annotation>. He thought, but not for long,
+        Father Conmee crossed to <Annotation annotationId="100010xavier">Mountjoy square</Annotation>. He thought, but not for long,
         of soldiers and sailors, whose legs had been shot off by cannonballs,
         ending their days in some pauper ward, and of cardinal <span data-edition="ed1932" data-page="196"></span>Wolsey's words:
         <i>If I had served my God as I have served my king He would not have
-        abandoned me in my old days.</i> He  <Annotation annotationId="100011toartane" visited={visitedNotes.has("100011toartane")} annotationSelect={() => {openNote("100011toartane"); addToVisited("100011toartane")}} activeAnnotationId={currentNoteId}>walked by the treeshade of sunnywinking
+        abandoned me in my old days.</i> He  <Annotation annotationId="100011toartane">walked by the treeshade of sunnywinking
         leaves</Annotation>: and towards him came the wife of Mr David Sheehy M.P.
       </p>
       <p>
@@ -73,7 +73,7 @@ const WanderingRocks = ({openNote, currentNoteId, visitedNotes, addToVisited}) =
       </p>
       <span data-edition="ed1939" data-page="161"> </span>
       <p>
-        Father Conmee stopped three little schoolboys at <Annotation annotationId="100011toartane" visited={visitedNotes.has("100011toartane")} annotationSelect={() => {openNote("100011toartane"); addToVisited("100011toartane")}} activeAnnotationId={currentNoteId}>the corner of Mountjoy
+        Father Conmee stopped three little schoolboys at <Annotation annotationId="100011toartane">the corner of Mountjoy
         square</Annotation>. Yes: they were from Belvedere. The little house. Aha. And were
         they good boys at school? O. That was very good now. And what was his
         name? Jack Sohan. And his name? Ger. Gallaher. And the other little man?
@@ -81,7 +81,7 @@ const WanderingRocks = ({openNote, currentNoteId, visitedNotes, addToVisited}) =
       </p>
       <p>
         Father Conmee gave a letter from his breast to Master Brunny Lynam and
-        pointed to <Annotation annotationId="100011toartane" visited={visitedNotes.has("100011toartane")} annotationSelect={() => {openNote("100011toartane"); addToVisited("100011toartane")}} activeAnnotationId={currentNoteId}>the red pillarbox at the corner of Fitzgibbon street</Annotation>.
+        pointed to <Annotation annotationId="100011toartane">the red pillarbox at the corner of Fitzgibbon street</Annotation>.
       </p>
       <p>
         —{" "}But mind you don't post yourself into the box, little man, he said.
@@ -98,7 +98,7 @@ const WanderingRocks = ({openNote, currentNoteId, visitedNotes, addToVisited}) =
       <p>
         Master Brunny Lynam ran across the road and put Father Conmee's <span data-edition="ed1932" data-page="197"></span>letter
         to father provincial into the mouth of the bright red letterbox. Father
-        Conmee smiled and nodded and smiled and walked along <Annotation annotationId="100011toartane" visited={visitedNotes.has("100011toartane")} annotationSelect={() => {openNote("100011toartane"); addToVisited("100011toartane")}} activeAnnotationId={currentNoteId}>Mountjoy square
+        Conmee smiled and nodded and smiled and walked along <Annotation annotationId="100011toartane">Mountjoy square
         east</Annotation>.
       </p>
       <p>
@@ -123,7 +123,7 @@ const WanderingRocks = ({openNote, currentNoteId, visitedNotes, addToVisited}) =
         say?... such a queenly mien.
       </p>
       <p>
-        Father Conmee <Annotation annotationId="100011toartane" visited={visitedNotes.has("100011toartane")} annotationSelect={() => {openNote("100011toartane"); addToVisited("100011toartane")}} activeAnnotationId={currentNoteId}>walked down Great Charles street and glanced at the shutup
+        Father Conmee <Annotation annotationId="100011toartane">walked down Great Charles street and glanced at the shutup
         free church</Annotation> on his left. The reverend T. R. Greene B.A. will (D.V.)
         speak. The incumbent they called him. He felt it incumbent on him to say
         a few words. But one should be charitable. Invincible ignorance. They
@@ -131,31 +131,31 @@ const WanderingRocks = ({openNote, currentNoteId, visitedNotes, addToVisited}) =
       </p>
       <span data-edition="ed1961" data-page="220"></span>
       <p>
-        Father Conmee <Annotation annotationId="100011toartane" visited={visitedNotes.has("100011toartane")} annotationSelect={() => {openNote("100011toartane"); addToVisited("100011toartane")}} activeAnnotationId={currentNoteId}>turned the corner and walked along the North Circular
+        Father Conmee <Annotation annotationId="100011toartane">turned the corner and walked along the North Circular
         road</Annotation>. It was a wonder that there was not a tramline in such an important
         thoroughfare. Surely, there ought to be.
       </p>
       <p>
-        A band of satchelled schoolboys crossed from <Annotation annotationId="100011toartane" visited={visitedNotes.has("100011toartane")} annotationSelect={() => {openNote("100011toartane"); addToVisited("100011toartane")}} activeAnnotationId={currentNoteId}>Richmond street</Annotation>. All
+        A band of satchelled schoolboys crossed from <Annotation annotationId="100011toartane">Richmond street</Annotation>. All
         raised untidy caps. Father Conmee greeted them more than once benignly.
-        <Annotation annotationId="100013christianbrother" visited={visitedNotes.has("100013christianbrother")} annotationSelect={() => {openNote("100013christianbrother"); addToVisited("100013christianbrother")}} activeAnnotationId={currentNoteId}>Christian brother boys.</Annotation>
+        <Annotation annotationId="100013christianbrother">Christian brother boys.</Annotation>
       </p>
       <p>
-        Father Conmee smelt incense on his right hand as he walked. <Annotation annotationId="100011toartane" visited={visitedNotes.has("100011toartane")} annotationSelect={() => {openNote("100011toartane"); addToVisited("100011toartane")}} activeAnnotationId={currentNoteId}>Saint
+        Father Conmee smelt incense on his right hand as he walked. <Annotation annotationId="100011toartane">Saint
         Joseph's church, Portland row. For aged and virtuous females.</Annotation>
         Father <span data-edition="ed1986" data-page="181"></span>Conmee raised his hat to the Blessed Sacrament. Virtuous: but
         occasionally they were also badtempered.
       </p>
       <p>
-        <Annotation annotationId="100011toartane" visited={visitedNotes.has("100011toartane")} annotationSelect={() => {openNote("100011toartane"); addToVisited("100011toartane")}} activeAnnotationId={currentNoteId}>Near Aldborough house Father Conmee thought of that spendthrift
+        <Annotation annotationId="100011toartane">Near Aldborough house Father Conmee thought of that spendthrift
         nobleman. And now it was an office or something.</Annotation>
       </p>
       <p>
-        Father Conmee began to walk along <Annotation annotationId="100011toartane" visited={visitedNotes.has("100011toartane")} annotationSelect={() => {openNote("100011toartane"); addToVisited("100011toartane")}} activeAnnotationId={currentNoteId}>the North Strand road</Annotation> and was saluted
+        Father Conmee began to walk along <Annotation annotationId="100011toartane">the North Strand road</Annotation> and was saluted
         by Mr William Gallagher who stood in the doorway of his shop. Father
         Conmee saluted Mr William Gallagher and perceived the odours that came
-        from baconflitches and ample cools of butter. He passed <Annotation annotationId="100002tobacco" visited={visitedNotes.has("100002tobacco")} annotationSelect={() => {openNote("100002tobacco"); addToVisited("100002tobacco")}} activeAnnotationId={currentNoteId}>Grogan's the
-        Tobacconist</Annotation> against which newsboards leaned and told of <Annotation annotationId="100008generalslocum" visited={visitedNotes.has("100008generalslocum")} annotationSelect={() => {openNote("100008generalslocum"); addToVisited("100008generalslocum")}} activeAnnotationId={currentNoteId}>a dreadful
+        from baconflitches and ample cools of butter. He passed <Annotation annotationId="100002tobacco">Grogan's the
+        Tobacconist</Annotation> against which newsboards leaned and told of <Annotation annotationId="100008generalslocum">a dreadful
         catastrophe in New York. In America those things were continually
         happening. Unfortunate people to die like that, unprepared. Still, an
         act of perfect contrition.</Annotation>
@@ -175,7 +175,7 @@ const WanderingRocks = ({openNote, currentNoteId, visitedNotes, addToVisited}) =
         tubes.
       </p>
       <p>
-        Moored under the trees of <Annotation annotationId="100011toartane" visited={visitedNotes.has("100011toartane")} annotationSelect={() => {openNote("100011toartane"); addToVisited("100011toartane")}} activeAnnotationId={currentNoteId}>Charleville Mall</Annotation> Father Conmee saw <Annotation annotationId="060036bogs" visited={visitedNotes.has("060036bogs")} annotationSelect={() => {openNote("060036bogs"); addToVisited("060036bogs")}} activeAnnotationId={currentNoteId}>a
+        Moored under the trees of <Annotation annotationId="100011toartane">Charleville Mall</Annotation> Father Conmee saw <Annotation annotationId="060036bogs">a
         turfbarge, a towhorse with pendent head, a bargeman with a hat of dirty
         straw seated amidships</Annotation>, smoking and staring at a branch of poplar above
         him. It was idyllic: and Father Conmee reflected on the providence of
@@ -186,7 +186,7 @@ const WanderingRocks = ({openNote, currentNoteId, visitedNotes, addToVisited}) =
         people.
       </p>
       <p>
-        On <Annotation annotationId="100011toartane" visited={visitedNotes.has("100011toartane")} annotationSelect={() => {openNote("100011toartane"); addToVisited("100011toartane")}} activeAnnotationId={currentNoteId}>Newcomen bridge</Annotation> the very reverend John Conmee S.J. <span data-edition="ed1961" data-page="221"></span>of <Annotation annotationId="100010xavier" visited={visitedNotes.has("100010xavier")} annotationSelect={() => {openNote("100010xavier"); addToVisited("100010xavier")}} activeAnnotationId={currentNoteId}>saint Francis
+        On <Annotation annotationId="100011toartane">Newcomen bridge</Annotation> the very reverend John Conmee S.J. <span data-edition="ed1961" data-page="221"></span>of <Annotation annotationId="100010xavier">saint Francis
         Xavier's church, upper Gardiner street</Annotation>, stepped on to an outward bound
         tram.
       </p>
@@ -196,7 +196,7 @@ const WanderingRocks = ({openNote, currentNoteId, visitedNotes, addToVisited}) =
       </p>
       <p>
         At Newcomen bridge Father Conmee stepped into an outward bound tram for
-        he disliked to traverse on foot the dingy way past <Annotation annotationId="100011toartane" visited={visitedNotes.has("100011toartane")} annotationSelect={() => {openNote("100011toartane"); addToVisited("100011toartane")}} activeAnnotationId={currentNoteId}>Mud Island</Annotation>.
+        he disliked to traverse on foot the dingy way past <Annotation annotationId="100011toartane">Mud Island</Annotation>.
       </p>
       <p>
         Father Conmee sat in a corner of the tramcar, a blue ticket tucked with
@@ -226,7 +226,7 @@ const WanderingRocks = ({openNote, currentNoteId, visitedNotes, addToVisited}) =
         mouth of the awkward old man who had the shaky head.
       </p>
       <p>
-        At <Annotation annotationId="100011toartane" visited={visitedNotes.has("100011toartane")} annotationSelect={() => {openNote("100011toartane"); addToVisited("100011toartane")}} activeAnnotationId={currentNoteId}>Annesley bridge</Annotation> the tram halted and, when it was about to go, an old
+        At <Annotation annotationId="100011toartane">Annesley bridge</Annotation> the tram halted and, when it was about to go, an old
         woman rose suddenly from her place to alight. The conductor pulled the
         bellstrap to stay the car for her. She passed out with her basket and
         a marketnet: and Father Conmee saw the conductor help her and net and
@@ -237,7 +237,7 @@ const WanderingRocks = ({openNote, currentNoteId, visitedNotes, addToVisited}) =
         cares, poor creatures.
       </p>
       <p>
-        From the hoardings <Annotation annotationId="060003eugenestratton" visited={visitedNotes.has("060003eugenestratton")} annotationSelect={() => {openNote("060003eugenestratton"); addToVisited("060003eugenestratton")}} activeAnnotationId={currentNoteId}>Mr Eugene Stratton</Annotation> grimaced with thick niggerlips at
+        From the hoardings <Annotation annotationId="060003eugenestratton">Mr Eugene Stratton</Annotation> grimaced with thick niggerlips at
         Father Conmee.
       </p>
       <span data-edition="ed1961" data-page="222"></span>
@@ -249,7 +249,7 @@ const WanderingRocks = ({openNote, currentNoteId, visitedNotes, addToVisited}) =
         <span data-edition="ed1939" data-page="163"> </span>
         of the faith and of the millions of black and brown and
         yellow souls that had not received the baptism of water when their last
-        hour came like a thief in the night. <Annotation annotationId="010008jesuit" visited={visitedNotes.has("010008jesuit")} annotationSelect={() => {openNote("010008jesuit"); addToVisited("010008jesuit")}} activeAnnotationId={currentNoteId}>That book by the Belgian jesuit,
+        hour came like a thief in the night. <Annotation annotationId="010008jesuit">That book by the Belgian jesuit,
         <i>Le Nombre des Élus,</i></Annotation> seemed to Father Conmee a reasonable plea. Those
         were millions of human souls created by God in His Own likeness to
         whom the faith had not (D.V.) been brought. But they were God's souls,
@@ -257,12 +257,12 @@ const WanderingRocks = ({openNote, currentNoteId, visitedNotes, addToVisited}) =
         be lost, a waste, if one might say.
       </p>
       <p>
-        At <Annotation annotationId="100011toartane" visited={visitedNotes.has("100011toartane")} annotationSelect={() => {openNote("100011toartane"); addToVisited("100011toartane")}} activeAnnotationId={currentNoteId}>the Howth road stop</Annotation> Father Conmee alighted, was saluted by the
+        At <Annotation annotationId="100011toartane">the Howth road stop</Annotation> Father Conmee alighted, was saluted by the
         conductor and saluted in his turn.
       </p>
       <p>
-        <Annotation annotationId="100011toartane" visited={visitedNotes.has("100011toartane")} annotationSelect={() => {openNote("100011toartane"); addToVisited("100011toartane")}} activeAnnotationId={currentNoteId}>The Malahide road</Annotation> was quiet. It pleased Father Conmee, road and name.
-        The joybells were ringing in gay Malahide. <Annotation annotationId="030150malahide" visited={visitedNotes.has("030150malahide")} annotationSelect={() => {openNote("030150malahide"); addToVisited("030150malahide")}} activeAnnotationId={currentNoteId}>Lord Talbot de Malahide,
+        <Annotation annotationId="100011toartane">The Malahide road</Annotation> was quiet. It pleased Father Conmee, road and name.
+        The joybells were ringing in gay Malahide. <Annotation annotationId="030150malahide">Lord Talbot de Malahide,
         immediate hereditary lord admiral of Malahide and the seas adjoining.
         Then came the call to arms and she was maid, wife and widow in one day.</Annotation>
         Those were old worldish days, loyal times in joyous townlands, old times
@@ -306,7 +306,7 @@ const WanderingRocks = ({openNote, currentNoteId, visitedNotes, addToVisited}) =
       <p>
         Father Conmee, reading his office, watched a flock of muttoning clouds
         over Rathcoffey. His thinsocked ankles were tickled by the stubble of
-        <Annotation annotationId="010157clongowes" visited={visitedNotes.has("010157clongowes")} annotationSelect={() => {openNote("010157clongowes"); addToVisited("010157clongowes")}} activeAnnotationId={currentNoteId}>Clongowes field</Annotation>. He walked there, reading in the evening, and heard
+        <Annotation annotationId="010157clongowes">Clongowes field</Annotation>. He walked there, reading in the evening, and heard
         the cries of the boys' lines at their play, young cries in the quiet
         evening. He was their rector: his reign was mild.
       </p>
@@ -318,7 +318,7 @@ const WanderingRocks = ({openNote, currentNoteId, visitedNotes, addToVisited}) =
         Nones. He should have read that before lunch. But lady Maxwell had come.
       </p>
       <p>
-        Father Conmee read in secret <i>Pater</i> and <i>Ave</i> and <Annotation annotationId="010057crossed" visited={visitedNotes.has("010057crossed")} annotationSelect={() => {openNote("010057crossed"); addToVisited("010057crossed")}} activeAnnotationId={currentNoteId}>crossed his breast</Annotation>.
+        Father Conmee read in secret <i>Pater</i> and <i>Ave</i> and <Annotation annotationId="010057crossed">crossed his breast</Annotation>.
         <i>Deus in adiutorium.</i>
       </p>
       <p>
@@ -374,7 +374,7 @@ const WanderingRocks = ({openNote, currentNoteId, visitedNotes, addToVisited}) =
       <span data-edition="ed1922" data-page="215"> </span>
       <p>
         Corny Kelleher sped a silent jet of hayjuice arching from his mouth
-        while a generous white arm from <Annotation annotationId="040005seveneccles" visited={visitedNotes.has("040005seveneccles")} annotationSelect={() => {openNote("040005seveneccles"); addToVisited("040005seveneccles")}} activeAnnotationId={currentNoteId}>a window in Eccles street</Annotation> flung forth a
+        while a generous white arm from <Annotation annotationId="040005seveneccles">a window in Eccles street</Annotation> flung forth a
         coin.
       </p>
       <p>
@@ -390,7 +390,7 @@ const WanderingRocks = ({openNote, currentNoteId, visitedNotes, addToVisited}) =
       </p>
       <p>
         A onelegged sailor crutched himself round MacConnell's corner, skirting
-        <Annotation annotationId="050047hokypoky" visited={visitedNotes.has("050047hokypoky")} annotationSelect={() => {openNote("050047hokypoky"); addToVisited("050047hokypoky")}} activeAnnotationId={currentNoteId}>Rabaiotti's icecream car</Annotation>, and jerked himself up Eccles street. Towards
+        <Annotation annotationId="050047hokypoky">Rabaiotti's icecream car</Annotation>, and jerked himself up Eccles street. Towards
         Larry O'Rourke, in shirtsleeves in his doorway, he growled unamiably:
       </p>
       <p>
@@ -433,7 +433,7 @@ const WanderingRocks = ({openNote, currentNoteId, visitedNotes, addToVisited}) =
       </p>
       <p>
         The gay sweet chirping whistling within went on a bar or two, ceased.
-        The blind of the window was drawn aside. <Annotation annotationId="040005seveneccles" visited={visitedNotes.has("040005seveneccles")} annotationSelect={() => {openNote("040005seveneccles"); addToVisited("040005seveneccles")}} activeAnnotationId={currentNoteId}>A card <i>Unfurnished Apartments</i>
+        The blind of the window was drawn aside. <Annotation annotationId="040005seveneccles">A card <i>Unfurnished Apartments</i>
         slipped from the sash</Annotation> and fell. <span data-edition="ed1961" data-page="225"></span>A plump bare generous arm shone, was
         seen, held forth from a white 
         <span data-edition="ed1939" data-page="165"> </span>
@@ -544,7 +544,7 @@ const WanderingRocks = ({openNote, currentNoteId, visitedNotes, addToVisited}) =
         Boody, breaking big chunks of bread into the yellow soup, added:
       </p>
       <p>
-        —{" "}<Annotation annotationId="040077ourfather" visited={visitedNotes.has("040077ourfather")} annotationSelect={() => {openNote("040077ourfather"); addToVisited("040077ourfather")}} activeAnnotationId={currentNoteId}>Our father who art not in heaven.</Annotation>
+        —{" "}<Annotation annotationId="040077ourfather">Our father who art not in heaven.</Annotation>
       </p>
       <p>
         Maggy, pouring yellow soup in Katey's bowl, exclaimed:
@@ -555,7 +555,7 @@ const WanderingRocks = ({openNote, currentNoteId, visitedNotes, addToVisited}) =
       </p>
       <p>
         A skiff, a crumpled throwaway, Elijah is coming, rode lightly down the
-        Liffey, under <Annotation annotationId="050006looplinebridge" visited={visitedNotes.has("050006looplinebridge")} annotationSelect={() => {openNote("050006looplinebridge"); addToVisited("050006looplinebridge")}} activeAnnotationId={currentNoteId}>Loopline bridge</Annotation>, shooting the rapids where water chafed
+        Liffey, under <Annotation annotationId="050006looplinebridge">Loopline bridge</Annotation>, shooting the rapids where water chafed
         <span data-edition="ed1986" data-page="186"></span>around the bridgepiers, sailing eastward past hulls and anchorchains,
         between the Customhouse old dock and George's quay.
       </p>
@@ -672,7 +672,7 @@ const WanderingRocks = ({openNote, currentNoteId, visitedNotes, addToVisited}) =
       </p>
       <p>
         Two carfuls of tourists passed slowly, their women sitting fore,
-        gripping the handrests. <Annotation annotationId="010024stranger" visited={visitedNotes.has("010024stranger")} annotationSelect={() => {openNote("010024stranger"); addToVisited("010024stranger")}} activeAnnotationId={currentNoteId}>Palefaces.</Annotation> Men's arms frankly round their
+        gripping the handrests. <Annotation annotationId="010024stranger">Palefaces.</Annotation> Men's arms frankly round their
         stunted forms. They looked from Trinity to the blind columned porch of
         the bank of Ireland where pigeons roocoocooed.
       </p>
@@ -702,7 +702,7 @@ const WanderingRocks = ({openNote, currentNoteId, visitedNotes, addToVisited}) =
         —{" "}<i>Ma, sul serio, eh?</i> Almidano Artifoni said.
       </p>
       <p>
-        <Annotation annotationId="010152linkedarm" visited={visitedNotes.has("010152linkedarm")} annotationSelect={() => {openNote("010152linkedarm"); addToVisited("010152linkedarm")}} activeAnnotationId={currentNoteId}>His heavy hand took Stephen's firmly. Human eyes.</Annotation> They gazed curiously
+        <Annotation annotationId="010152linkedarm">His heavy hand took Stephen's firmly. Human eyes.</Annotation> They gazed curiously
         an instant and turned quickly towards a Dalkey tram.
       </p>
       <p>
@@ -729,7 +729,7 @@ const WanderingRocks = ({openNote, currentNoteId, visitedNotes, addToVisited}) =
         *{" "}*
       </p>
       <p>
-        Miss Dunne hid the <Annotation annotationId="040043capelstreet" visited={visitedNotes.has("040043capelstreet")} annotationSelect={() => {openNote("040043capelstreet"); addToVisited("040043capelstreet")}} activeAnnotationId={currentNoteId}>Capel street library</Annotation> copy of <i>The Woman in White</i>
+        Miss Dunne hid the <Annotation annotationId="040043capelstreet">Capel street library</Annotation> copy of <i>The Woman in White</i>
         far back in her drawer and rolled a sheet of gaudy notepaper into her
         typewriter.
       </p>
@@ -801,7 +801,7 @@ const WanderingRocks = ({openNote, currentNoteId, visitedNotes, addToVisited}) =
       </p>
       <span data-edition="ed1932" data-page="206"></span>
       <p>
-        The <Annotation annotationId="150013matches" visited={visitedNotes.has("150013matches")} annotationSelect={() => {openNote("150013matches"); addToVisited("150013matches")}} activeAnnotationId={currentNoteId}>vesta</Annotation> in the clergyman's uplifted hand consumed itself in a long
+        The <Annotation annotationId="150013matches">vesta</Annotation> in the clergyman's uplifted hand consumed itself in a long
         soft flame and was let fall. At their feet its red speck died: and
         mouldy air closed round them.
       </p>
@@ -809,11 +809,11 @@ const WanderingRocks = ({openNote, currentNoteId, visitedNotes, addToVisited}) =
         —{" "}How interesting! a refined accent said in the gloom.
       </p>
       <p>
-        —{" "}Yes, sir, Ned Lambert said heartily. We are standing in <Annotation annotationId="100006marysabbey" visited={visitedNotes.has("100006marysabbey")} annotationSelect={() => {openNote("100006marysabbey"); addToVisited("100006marysabbey")}} activeAnnotationId={currentNoteId}>the historic
-        council chamber of saint Mary's abbey</Annotation> where <Annotation annotationId="030058pretenders" visited={visitedNotes.has("030058pretenders")} annotationSelect={() => {openNote("030058pretenders"); addToVisited("030058pretenders")}} activeAnnotationId={currentNoteId}>silken Thomas proclaimed
+        —{" "}Yes, sir, Ned Lambert said heartily. We are standing in <Annotation annotationId="100006marysabbey">the historic
+        council chamber of saint Mary's abbey</Annotation> where <Annotation annotationId="030058pretenders">silken Thomas proclaimed
         himself a rebel in 1534</Annotation>. This is the most historic spot in all Dublin.
         O'Madden Burke is going to write something about it one of these days.
-        <Annotation annotationId="020032theunion" visited={visitedNotes.has("020032theunion")} annotationSelect={() => {openNote("020032theunion"); addToVisited("020032theunion")}} activeAnnotationId={currentNoteId}>The old bank of Ireland was over the way till the time of the union</Annotation> and
+        <Annotation annotationId="020032theunion">The old bank of Ireland was over the way till the time of the union</Annotation> and
         the original jews' temple was here too before they built their synagogue
         over in Adelaide road. You were never here before, Jack, were you?
       </p>
@@ -871,7 +871,7 @@ const WanderingRocks = ({openNote, currentNoteId, visitedNotes, addToVisited}) =
       </p>
       <p>
         —{" "}The reverend Hugh C. Love, Rathcoffey. Present address: Saint
-        Michael's, Sallins. Nice young chap he is. He's writing a book about <Annotation annotationId="100003fitzgeralds" visited={visitedNotes.has("100003fitzgeralds")} annotationSelect={() => {openNote("100003fitzgeralds"); addToVisited("100003fitzgeralds")}} activeAnnotationId={currentNoteId}>the
+        Michael's, Sallins. Nice young chap he is. He's writing a book about <Annotation annotationId="100003fitzgeralds">the
         Fitzgeralds</Annotation> he told me. He's well up in history, faith.
       </p>
       <p>
@@ -886,7 +886,7 @@ const WanderingRocks = ({openNote, currentNoteId, visitedNotes, addToVisited}) =
         Ned Lambert cracked his fingers in the air.
       </p>
       <p>
-        —{" "}God! he cried. I forgot to tell him that one about <Annotation annotationId="100003fitzgeralds" visited={visitedNotes.has("100003fitzgeralds")} annotationSelect={() => {openNote("100003fitzgeralds"); addToVisited("100003fitzgeralds")}} activeAnnotationId={currentNoteId}>the earl of Kildare</Annotation>
+        —{" "}God! he cried. I forgot to tell him that one about <Annotation annotationId="100003fitzgeralds">the earl of Kildare</Annotation>
         after he set fire to Cashel cathedral. You know that one? <i>I'm bloody
         sorry I did it,</i> says he, <i>but I declare to God I thought the archbishop
         was inside.</i> He mightn't like it, though. What? God, I'll tell him
@@ -950,7 +950,7 @@ const WanderingRocks = ({openNote, currentNoteId, visitedNotes, addToVisited}) =
       <p>
         Lawyers of the past, haughty, pleading, beheld pass from the
         consolidated taxing office to Nisi Prius court Richie Goulding carrying
-        the <Annotation annotationId="030113richiegoulding" visited={visitedNotes.has("030113richiegoulding")} annotationSelect={() => {openNote("030113richiegoulding"); addToVisited("030113richiegoulding")}} activeAnnotationId={currentNoteId}>costbag of Goulding, Collis and Ward</Annotation> and heard rustling from the
+        the <Annotation annotationId="030113richiegoulding">costbag of Goulding, Collis and Ward</Annotation> and heard rustling from the
         admiralty division of king's bench to the court of appeal an elderly
         female with false teeth smiling incredulously and a black silk skirt of
         great amplitude.
@@ -1006,7 +1006,7 @@ const WanderingRocks = ({openNote, currentNoteId, visitedNotes, addToVisited}) =
         —{" "}Drain? Lenehan said. It was down a manhole.
       </p>
       <p>
-        They passed <Annotation annotationId="040076musichall" visited={visitedNotes.has("040076musichall")} annotationSelect={() => {openNote("040076musichall"); addToVisited("040076musichall")}} activeAnnotationId={currentNoteId}>Dan Lowry's musichall</Annotation> where Marie Kendall, charming
+        They passed <Annotation annotationId="040076musichall">Dan Lowry's musichall</Annotation> where Marie Kendall, charming
         soubrette, smiled on them from a poster a dauby smile.
       </p>
       <span data-edition="ed1939" data-page="170"> </span>
@@ -1072,7 +1072,7 @@ const WanderingRocks = ({openNote, currentNoteId, visitedNotes, addToVisited}) =
       </p>
       <p>
         —{" "}He's dead nuts on sales, M'Coy said. I was with him one day and he
-        bought a book from an old one in Liffey street for <Annotation annotationId="010019money" visited={visitedNotes.has("010019money")} annotationSelect={() => {openNote("010019money"); addToVisited("010019money")}} activeAnnotationId={currentNoteId}>two bob</Annotation>. There were
+        bought a book from an old one in Liffey street for <Annotation annotationId="010019money">two bob</Annotation>. There were
         fine plates in it worth double the money, the stars and the moon and
         comets with long tails. Astronomy it was about.
       </p>
@@ -1094,8 +1094,8 @@ const WanderingRocks = ({openNote, currentNoteId, visitedNotes, addToVisited}) =
       </p>
       <p>
         —{" "}There was a big spread out at Glencree reformatory, Lenehan said
-        eagerly. The annual dinner, you know. Boiled shirt affair. <Annotation annotationId="060033corporation" visited={visitedNotes.has("060033corporation")} annotationSelect={() => {openNote("060033corporation"); addToVisited("060033corporation")}} activeAnnotationId={currentNoteId}>The lord
-        mayor was there, Val Dillon it was</Annotation>, and sir Charles Cameron and <Annotation annotationId="060037dandawson" visited={visitedNotes.has("060037dandawson")} annotationSelect={() => {openNote("060037dandawson"); addToVisited("060037dandawson")}} activeAnnotationId={currentNoteId}>Dan
+        eagerly. The annual dinner, you know. Boiled shirt affair. <Annotation annotationId="060033corporation">The lord
+        mayor was there, Val Dillon it was</Annotation>, and sir Charles Cameron and <Annotation annotationId="060037dandawson">Dan
         Dawson spoke</Annotation> and there was music. Bartell d'Arcy sang and Benjamin
         Dollard...
       </p>
@@ -1106,7 +1106,7 @@ const WanderingRocks = ({openNote, currentNoteId, visitedNotes, addToVisited}) =
         —{" "}Did she? Lenehan said.
       </p>
       <p>
-        A card <i>Unfurnished Apartments</i> reappeared on the windowsash of <Annotation annotationId="040005seveneccles" visited={visitedNotes.has("040005seveneccles")} annotationSelect={() => {openNote("040005seveneccles"); addToVisited("040005seveneccles")}} activeAnnotationId={currentNoteId}>number 7
+        A card <i>Unfurnished Apartments</i> reappeared on the windowsash of <Annotation annotationId="040005seveneccles">number 7
         Eccles street</Annotation>.
       </p>
       <span data-edition="ed1922" data-page="224"> </span>
@@ -1130,10 +1130,10 @@ const WanderingRocks = ({openNote, currentNoteId, visitedNotes, addToVisited}) =
         —{" "}But wait till I tell you, he said. We had a midnight lunch too after
         all the jollification and when we sallied forth it was blue o'clock the
         morning after the night before. Coming home it was a gorgeous winter's
-        night on the <span data-edition="ed1986" data-page="192"></span><Annotation annotationId="010010mountains" visited={visitedNotes.has("010010mountains")} annotationSelect={() => {openNote("010010mountains"); addToVisited("010010mountains")}} activeAnnotationId={currentNoteId}>Featherbed Mountain</Annotation>. Bloom and Chris Callinan were <Annotation annotationId="050013jauntingcar" visited={visitedNotes.has("050013jauntingcar")} annotationSelect={() => {openNote("050013jauntingcar"); addToVisited("050013jauntingcar")}} activeAnnotationId={currentNoteId}>on one
+        night on the <span data-edition="ed1986" data-page="192"></span><Annotation annotationId="010010mountains">Featherbed Mountain</Annotation>. Bloom and Chris Callinan were <Annotation annotationId="050013jauntingcar">on one
         side of the car and I was with the wife on the other</Annotation>. We started singing
         glees <span data-edition="ed1932" data-page="210"></span>and duets: <i>Lo, the early beam of morning</i>. She was well primed
-        with a good load of Delahunt's port under her bellyband. <Annotation annotationId="170008precedingseries" visited={visitedNotes.has("170008precedingseries")} annotationSelect={() => {openNote("170008precedingseries"); addToVisited("170008precedingseries")}} activeAnnotationId={currentNoteId}>Every jolt the
+        with a good load of Delahunt's port under her bellyband. <Annotation annotationId="170008precedingseries">Every jolt the
         bloody car gave I had her bumping up against me. Hell's delights! She
         has a fine pair, God bless her.</Annotation> Like that.
       </p>
@@ -1171,7 +1171,7 @@ const WanderingRocks = ({openNote, currentNoteId, visitedNotes, addToVisited}) =
         rapidly. He glanced sideways in the sunlight at M'Coy.
       </p>
       <p>
-        —{" "}He's a cultured allroundman, Bloom is, he said seriously. <Annotation annotationId="040083hewasajew" visited={visitedNotes.has("040083hewasajew")} annotationSelect={() => {openNote("040083hewasajew"); addToVisited("040083hewasajew")}} activeAnnotationId={currentNoteId}>He's not one
+        —{" "}He's a cultured allroundman, Bloom is, he said seriously. <Annotation annotationId="040083hewasajew">He's not one
         of your common or garden... you know...</Annotation> There's a touch of the artist
         about old Bloom.
       </p>
@@ -1259,7 +1259,7 @@ const WanderingRocks = ({openNote, currentNoteId, visitedNotes, addToVisited}) =
         Mr Bloom read again: <i>The beautiful woman.</i>
       </p>
       <p>
-        <Annotation annotationId="040063happywarmth" visited={visitedNotes.has("040063happywarmth")} annotationSelect={() => {openNote("040063happywarmth"); addToVisited("040063happywarmth")}} activeAnnotationId={currentNoteId}>Warmth showered gently over him</Annotation>, cowing his flesh. Flesh yielded 
+        <Annotation annotationId="040063happywarmth">Warmth showered gently over him</Annotation>, cowing his flesh. Flesh yielded 
         <span data-edition="ed1922" data-page="226"> </span>
         amid rumpled clothes: whites of eyes swooning up. His nostrils arched
         themselves for prey. Melting breast ointments (<i>for him! For Raoul!</i>).
@@ -1453,7 +1453,7 @@ const WanderingRocks = ({openNote, currentNoteId, visitedNotes, addToVisited}) =
         Mr Dedalus thought and nodded.
       </p>
       <p>
-        —{" "}I will, he said gravely. I looked all along the gutter in <Annotation annotationId="060012liberatorsform" visited={visitedNotes.has("060012liberatorsform")} annotationSelect={() => {openNote("060012liberatorsform"); addToVisited("060012liberatorsform")}} activeAnnotationId={currentNoteId}>O'Connell
+        —{" "}I will, he said gravely. I looked all along the gutter in <Annotation annotationId="060012liberatorsform">O'Connell
         street</Annotation>. I'll try this one now.
       </p>
       <p>
@@ -1461,7 +1461,7 @@ const WanderingRocks = ({openNote, currentNoteId, visitedNotes, addToVisited}) =
       </p>
       <p>
         —{" "}Here, Mr Dedalus said, handing her two pennies. Get a <span data-edition="ed1961" data-page="238"></span>glass of milk
-        for yourself and a bun or a something. <Annotation annotationId="050049comehometoma" visited={visitedNotes.has("050049comehometoma")} annotationSelect={() => {openNote("050049comehometoma"); addToVisited("050049comehometoma")}} activeAnnotationId={currentNoteId}>I'll be home shortly.</Annotation>
+        for yourself and a bun or a something. <Annotation annotationId="050049comehometoma">I'll be home shortly.</Annotation>
       </p>
       <p>
         He put the other coins in his pocket and started to walk on.
@@ -1490,14 +1490,14 @@ const WanderingRocks = ({openNote, currentNoteId, visitedNotes, addToVisited}) =
         *{" "}*
       </p>
       <p>
-        <Annotation annotationId="100009jamessgate" visited={visitedNotes.has("100009jamessgate")} annotationSelect={() => {openNote("100009jamessgate"); addToVisited("100009jamessgate")}} activeAnnotationId={currentNoteId}>From the sundial towards James's gate</Annotation> walked <Annotation annotationId="050037tomkernan" visited={visitedNotes.has("050037tomkernan")} annotationSelect={() => {openNote("050037tomkernan"); addToVisited("050037tomkernan")}} activeAnnotationId={currentNoteId}>Mr Kernan, pleased with the
+        <Annotation annotationId="100009jamessgate">From the sundial towards James's gate</Annotation> walked <Annotation annotationId="050037tomkernan">Mr Kernan, pleased with the
         order he had booked for Pulbrook Robertson</Annotation>, boldly along James's street,
-        past Shackleton's offices. Got round him all right. How do you do, <Annotation annotationId="100009jamessgate" visited={visitedNotes.has("100009jamessgate")} annotationSelect={() => {openNote("100009jamessgate"); addToVisited("100009jamessgate")}} activeAnnotationId={currentNoteId}>Mr
+        past Shackleton's offices. Got round him all right. How do you do, <Annotation annotationId="100009jamessgate">Mr
         Crimmins</Annotation>? First rate, sir. I was afraid you might be up in your other
         establishment in Pimlico. How are things going? Just keeping alive.
         Lovely weather we're having. Yes, indeed. Good for the country. Those
         farmers are always grumbling. I'll just take a thimbleful of your best
-        gin, Mr Crimmins. A small gin, sir. Yes, sir. <Annotation annotationId="100008generalslocum" visited={visitedNotes.has("100008generalslocum")} annotationSelect={() => {openNote("100008generalslocum"); addToVisited("100008generalslocum")}} activeAnnotationId={currentNoteId}>Terrible affair that
+        gin, Mr Crimmins. A small gin, sir. Yes, sir. <Annotation annotationId="100008generalslocum">Terrible affair that
         General Slocum explosion. Terrible, 
         <span data-edition="ed1922" data-page="229"> </span>
         terrible! A thousand casualties. And
@@ -1536,7 +1536,7 @@ const WanderingRocks = ({openNote, currentNoteId, visitedNotes, addToVisited}) =
         street. Well 
         <span data-edition="ed1939" data-page="175"> </span>
         worth the half sovereign I gave Neary for it. Never built
-        under three guineas. Fits me down to the ground. Some <Annotation annotationId="050042kildareclub" visited={visitedNotes.has("050042kildareclub")} annotationSelect={() => {openNote("050042kildareclub"); addToVisited("050042kildareclub")}} activeAnnotationId={currentNoteId}>Kildare street
+        under three guineas. Fits me down to the ground. Some <Annotation annotationId="050042kildareclub">Kildare street
         club toff</Annotation> had it probably. John Mulligan, the manager of the Hibernian
         bank, gave me a very sharp eye yesterday on Carlisle bridge as if he
         remembered me.
@@ -1583,15 +1583,15 @@ const WanderingRocks = ({openNote, currentNoteId, visitedNotes, addToVisited}) =
       </p>
       <span data-edition="ed1986" data-page="197"></span>
       <p>
-        Mr Kernan turned and walked <Annotation annotationId="100009jamessgate" visited={visitedNotes.has("100009jamessgate")} annotationSelect={() => {openNote("100009jamessgate"); addToVisited("100009jamessgate")}} activeAnnotationId={currentNoteId}> down the slope of Watling street by
+        Mr Kernan turned and walked <Annotation annotationId="100009jamessgate"> down the slope of Watling street by
         the corner of Guinness's visitors' waitingroom. Outside the Dublin
-        Distillers Company's stores</Annotation> <Annotation annotationId="050013jauntingcar" visited={visitedNotes.has("050013jauntingcar")} annotationSelect={() => {openNote("050013jauntingcar"); addToVisited("050013jauntingcar")}} activeAnnotationId={currentNoteId}>an outside car</Annotation> without fare or jarvey stood,
+        Distillers Company's stores</Annotation> <Annotation annotationId="050013jauntingcar">an outside car</Annotation> without fare or jarvey stood,
         the reins knotted to the wheel. Damn dangerous thing. Some Tipperary
         bosthoon endangering the lives of the citizens. Runaway horse.
       </p>
       <p>
         Denis Breen with his tomes, weary of having waited an hour in John
-        Henry Menton's office, led his wife over O'Connell bridge, <Annotation annotationId="030113richiegoulding" visited={visitedNotes.has("030113richiegoulding")} annotationSelect={() => {openNote("030113richiegoulding"); addToVisited("030113richiegoulding")}} activeAnnotationId={currentNoteId}>bound for the
+        Henry Menton's office, led his wife over O'Connell bridge, <Annotation annotationId="030113richiegoulding">bound for the
         office of Messrs Collis and Ward</Annotation>.
       </p>
       <span data-edition="ed1961" data-page="240"></span>
@@ -1601,7 +1601,7 @@ const WanderingRocks = ({openNote, currentNoteId, visitedNotes, addToVisited}) =
       <p>
         Times of the troubles. Must ask Ned Lambert to lend me those
         reminiscences of sir Jonah Barrington. When you look back on it all
-        now in <Annotation annotationId="060030retrospective" visited={visitedNotes.has("060030retrospective")} annotationSelect={() => {openNote("060030retrospective"); addToVisited("060030retrospective")}} activeAnnotationId={currentNoteId}>a kind of retrospective arrangement</Annotation>. Gaming at Daly's. No
+        now in <Annotation annotationId="060030retrospective">a kind of retrospective arrangement</Annotation>. Gaming at Daly's. No
         cardsharping then. One of those fellows got his hand nailed to the table
         by a dagger. Somewhere here lord Edward Fitzgerald escaped from major
         Sirr. Stables behind Moira house.
@@ -1610,17 +1610,17 @@ const WanderingRocks = ({openNote, currentNoteId, visitedNotes, addToVisited}) =
         Damn good gin that was.
       </p>
       <p>
-        Fine dashing young nobleman. Good stock, of course. <Annotation annotationId="070018shamsquire" visited={visitedNotes.has("070018shamsquire")} annotationSelect={() => {openNote("070018shamsquire"); addToVisited("070018shamsquire")}} activeAnnotationId={currentNoteId}>That ruffian, that
+        Fine dashing young nobleman. Good stock, of course. <Annotation annotationId="070018shamsquire">That ruffian, that
         sham squire, with his violet gloves gave him away. Course they were
-        on the wrong side.</Annotation> <Annotation annotationId="100012evildays" visited={visitedNotes.has("100012evildays")} annotationSelect={() => {openNote("100012evildays"); addToVisited("100012evildays")}} activeAnnotationId={currentNoteId}>They rose in dark and evil days. Fine poem</Annotation> <span data-edition="ed1932" data-page="216"></span> <Annotation annotationId="100012evildays" visited={visitedNotes.has("100012evildays")} annotationSelect={() => {openNote("100012evildays"); addToVisited("100012evildays")}} activeAnnotationId={currentNoteId}> that
-        is: Ingram. They were gentlemen.</Annotation>  <Annotation annotationId="110007croppyboy" visited={visitedNotes.has("110007croppyboy")} annotationSelect={() => {openNote("110007croppyboy"); addToVisited("110007croppyboy")}} activeAnnotationId={currentNoteId}>Ben Dollard does sing that ballad
+        on the wrong side.</Annotation> <Annotation annotationId="100012evildays">They rose in dark and evil days. Fine poem</Annotation> <span data-edition="ed1932" data-page="216"></span> <Annotation annotationId="100012evildays"> that
+        is: Ingram. They were gentlemen.</Annotation>  <Annotation annotationId="110007croppyboy">Ben Dollard does sing that ballad
         touchingly. Masterly rendition.</Annotation>
       </p>
       <p>
-        <Annotation annotationId="110007croppyboy" visited={visitedNotes.has("110007croppyboy")} annotationSelect={() => {openNote("110007croppyboy"); addToVisited("110007croppyboy")}} activeAnnotationId={currentNoteId}><i>At the siege of Ross did my father fall.</i></Annotation>
+        <Annotation annotationId="110007croppyboy"><i>At the siege of Ross did my father fall.</i></Annotation>
       </p>
       <p>
-        A cavalcade in easy trot along <Annotation annotationId="100009jamessgate" visited={visitedNotes.has("100009jamessgate")} annotationSelect={() => {openNote("100009jamessgate"); addToVisited("100009jamessgate")}} activeAnnotationId={currentNoteId}>Pembroke quay</Annotation> passed, outriders leaping,
+        A cavalcade in easy trot along <Annotation annotationId="100009jamessgate">Pembroke quay</Annotation> passed, outriders leaping,
         leaping in their, in their saddles. Frockcoats. Cream sunshades.
       </p>
       <p>
@@ -1642,7 +1642,7 @@ const WanderingRocks = ({openNote, currentNoteId, visitedNotes, addToVisited}) =
         on dull 
         <span data-edition="ed1922" data-page="231"> </span>
         coils of bronze and silver, lozenges of cinnabar, on rubies,
-        leprous and <Annotation annotationId="010033epioinopaponton" visited={visitedNotes.has("010033epioinopaponton")} annotationSelect={() => {openNote("010033epioinopaponton"); addToVisited("010033epioinopaponton")}} activeAnnotationId={currentNoteId}>winedark stones</Annotation>.
+        leprous and <Annotation annotationId="010033epioinopaponton">winedark stones</Annotation>.
       </p>
       <p>
         Born all in the dark wormy earth, cold specks of fire, evil, lights
@@ -1664,13 +1664,13 @@ const WanderingRocks = ({openNote, currentNoteId, visitedNotes, addToVisited}) =
       <span data-edition="ed1986" data-page="198"></span>
       <p>
         And you who wrest old images from the burial earth? The brainsick words
-        of sophists: Antisthenes. A lore of drugs. <Annotation annotationId="030083nakedeve" visited={visitedNotes.has("030083nakedeve")} annotationSelect={() => {openNote("030083nakedeve"); addToVisited("030083nakedeve")}} activeAnnotationId={currentNoteId}>Orient and immortal wheat
+        of sophists: Antisthenes. A lore of drugs. <Annotation annotationId="030083nakedeve">Orient and immortal wheat
         standing from everlasting to everlasting.</Annotation>
       </p>
       <p>
-        Two old women fresh from their whiff of the briny trudged <Annotation annotationId="030015irishtown" visited={visitedNotes.has("030015irishtown")} annotationSelect={() => {openNote("030015irishtown"); addToVisited("030015irishtown")}} activeAnnotationId={currentNoteId}>through
-        Irishtown along London bridge road</Annotation>, <Annotation annotationId="030054swunglourdily" visited={visitedNotes.has("030054swunglourdily")} annotationSelect={() => {openNote("030054swunglourdily"); addToVisited("030054swunglourdily")}} activeAnnotationId={currentNoteId}>one with a sanded tired umbrella,
-        one with a midwife's bag</Annotation> in which eleven <Annotation annotationId="030080cockles" visited={visitedNotes.has("030080cockles")} annotationSelect={() => {openNote("030080cockles"); addToVisited("030080cockles")}} activeAnnotationId={currentNoteId}>cockles</Annotation> rolled.
+        Two old women fresh from their whiff of the briny trudged <Annotation annotationId="030015irishtown">through
+        Irishtown along London bridge road</Annotation>, <Annotation annotationId="030054swunglourdily">one with a sanded tired umbrella,
+        one with a midwife's bag</Annotation> in which eleven <Annotation annotationId="030080cockles">cockles</Annotation> rolled.
       </p>
       <p>
         The whirr of flapping leathern bands and hum of dynamos from the
@@ -1702,7 +1702,7 @@ const WanderingRocks = ({openNote, currentNoteId, visitedNotes, addToVisited}) =
       </p>
       <p>
         Tattered pages. <i>The Irish Beekeeper. Life and Miracles of the Curé of
-        Ars.  <Annotation annotationId="170019localities" visited={visitedNotes.has("170019localities")} annotationSelect={() => {openNote("170019localities"); addToVisited("170019localities")}} activeAnnotationId={currentNoteId}> Pocket Guide to Killarney.</Annotation></i>
+        Ars.  <Annotation annotationId="170019localities"> Pocket Guide to Killarney.</Annotation></i>
       </p>
       <p>
         I might find here one of my pawned schoolprizes. <i>Stephano Dedalo,
@@ -1728,7 +1728,7 @@ const WanderingRocks = ({openNote, currentNoteId, visitedNotes, addToVisited}) =
       <p>
         Who wrote this? Charms and invocations of the most blessed abbot Peter
         Salanka to all true believers divulged. As good as any other abbot's
-        charms, as <Annotation annotationId="030101calve" visited={visitedNotes.has("030101calve")} annotationSelect={() => {openNote("030101calve"); addToVisited("030101calve")}} activeAnnotationId={currentNoteId}>mumbling Joachim's. Down, baldynoddle, or we'll wool your
+        charms, as <Annotation annotationId="030101calve">mumbling Joachim's. Down, baldynoddle, or we'll wool your
         wool.</Annotation>
       </p>
       <p>
@@ -1782,7 +1782,7 @@ const WanderingRocks = ({openNote, currentNoteId, visitedNotes, addToVisited}) =
         —{" "}Some, Dilly said. We had to.
       </p>
       <p>
-        She is drowning. <Annotation annotationId="010094agenbite" visited={visitedNotes.has("010094agenbite")} annotationSelect={() => {openNote("010094agenbite"); addToVisited("010094agenbite")}} activeAnnotationId={currentNoteId}>Agenbite.</Annotation> Save her. Agenbite. All against us. She will
+        She is drowning. <Annotation annotationId="010094agenbite">Agenbite.</Annotation> Save her. Agenbite. All against us. She will
         drown me with her, eyes and hair. Lank coils of seaweed hair around me,
         my heart, my soul. Salt green death.
       </p>
@@ -1891,7 +1891,7 @@ const WanderingRocks = ({openNote, currentNoteId, visitedNotes, addToVisited}) =
       </p>
       <p>
         Cashel Boyle O'Connor Fitzmaurice Tisdall Farrell, murmuring,
-        glassyeyed, strode past <Annotation annotationId="050042kildareclub" visited={visitedNotes.has("050042kildareclub")} annotationSelect={() => {openNote("050042kildareclub"); addToVisited("050042kildareclub")}} activeAnnotationId={currentNoteId}>the Kildare street club</Annotation>.
+        glassyeyed, strode past <Annotation annotationId="050042kildareclub">the Kildare street club</Annotation>.
       </p>
       <span data-edition="ed1961" data-page="244"></span>
       <p>
@@ -1975,8 +1975,8 @@ const WanderingRocks = ({openNote, currentNoteId, visitedNotes, addToVisited}) =
       </p>
       <span data-edition="ed1961" data-page="245"></span>
       <p>
-        —{" "}The youngster will be all right, <Annotation annotationId="060034martincunningham" visited={visitedNotes.has("060034martincunningham")} annotationSelect={() => {openNote("060034martincunningham"); addToVisited("060034martincunningham")}} activeAnnotationId={currentNoteId}>Martin Cunningham</Annotation> said, as they
-        passed out of <Annotation annotationId="080013dublincastle" visited={visitedNotes.has("080013dublincastle")} annotationSelect={() => {openNote("080013dublincastle"); addToVisited("080013dublincastle")}} activeAnnotationId={currentNoteId}>the Castleyard gate</Annotation>.
+        —{" "}The youngster will be all right, <Annotation annotationId="060034martincunningham">Martin Cunningham</Annotation> said, as they
+        passed out of <Annotation annotationId="080013dublincastle">the Castleyard gate</Annotation>.
       </p>
       <p>
         The policeman touched his forehead.
@@ -1989,7 +1989,7 @@ const WanderingRocks = ({openNote, currentNoteId, visitedNotes, addToVisited}) =
         towards Lord Edward street.
       </p>
       <p>
-        <Annotation annotationId="110009bronzegold" visited={visitedNotes.has("110009bronzegold")} annotationSelect={() => {openNote("110009bronzegold"); addToVisited("110009bronzegold")}} activeAnnotationId={currentNoteId}>Bronze by gold, Miss Kennedy's head by Miss Douce's head, appeared above
+        <Annotation annotationId="110009bronzegold">Bronze by gold, Miss Kennedy's head by Miss Douce's head, appeared above
         the crossblind of the Ormond hotel.</Annotation>
       </p>
       <p>
@@ -2007,14 +2007,14 @@ const WanderingRocks = ({openNote, currentNoteId, visitedNotes, addToVisited}) =
         quickly down Cork hill.
       </p>
       <p>
-        <Annotation annotationId="060033corporation" visited={visitedNotes.has("060033corporation")} annotationSelect={() => {openNote("060033corporation"); addToVisited("060033corporation")}} activeAnnotationId={currentNoteId}>On the steps of the City hall Councillor Nannetti, descending, hailed
+        <Annotation annotationId="060033corporation">On the steps of the City hall Councillor Nannetti, descending, hailed
         Alderman Cowley and Councillor Abraham Lyon ascending.</Annotation>
       </p>
       <p>
-        <Annotation annotationId="080013dublincastle" visited={visitedNotes.has("080013dublincastle")} annotationSelect={() => {openNote("080013dublincastle"); addToVisited("080013dublincastle")}} activeAnnotationId={currentNoteId}>The castle car</Annotation> wheeled empty into upper Exchange street.
+        <Annotation annotationId="080013dublincastle">The castle car</Annotation> wheeled empty into upper Exchange street.
       </p>
       <p>
-        —{" "}Look here, Martin, John Wyse Nolan said, overtaking them at <Annotation annotationId="100007themail" visited={visitedNotes.has("100007themail")} annotationSelect={() => {openNote("100007themail"); addToVisited("100007themail")}} activeAnnotationId={currentNoteId}>the <i>Mail</i>
+        —{" "}Look here, Martin, John Wyse Nolan said, overtaking them at <Annotation annotationId="100007themail">the <i>Mail</i>
         office</Annotation>. I see Bloom put his name down for five shillings.
       </p>
       <p>
@@ -2043,8 +2043,8 @@ const WanderingRocks = ({openNote, currentNoteId, visitedNotes, addToVisited}) =
         —{" "}Righto, Martin Cunningham said. Here goes.
       </p>
       <p>
-        Outside <i>la Maison Claire</i> Blazes Boylan waylaid <Annotation annotationId="050038bobdoran" visited={visitedNotes.has("050038bobdoran")} annotationSelect={() => {openNote("050038bobdoran"); addToVisited("050038bobdoran")}} activeAnnotationId={currentNoteId}>Jack Mooney's
-        brother-in-law, humpy, tight</Annotation>, making for <Annotation annotationId="030060theliberties" visited={visitedNotes.has("030060theliberties")} annotationSelect={() => {openNote("030060theliberties"); addToVisited("030060theliberties")}} activeAnnotationId={currentNoteId}>the liberties</Annotation>.
+        Outside <i>la Maison Claire</i> Blazes Boylan waylaid <Annotation annotationId="050038bobdoran">Jack Mooney's
+        brother-in-law, humpy, tight</Annotation>, making for <Annotation annotationId="030060theliberties">the liberties</Annotation>.
       </p>
       <p>
         John Wyse Nolan fell back with Mr Power, while Martin Cunningham 
@@ -2086,7 +2086,7 @@ const WanderingRocks = ({openNote, currentNoteId, visitedNotes, addToVisited}) =
       </p>
       <p>
         Hell open to christians they were having, Jimmy Henry said pettishly,
-        about their damned Irish language. <Annotation annotationId="060033corporation" visited={visitedNotes.has("060033corporation")} annotationSelect={() => {openNote("060033corporation"); addToVisited("060033corporation")}} activeAnnotationId={currentNoteId}>Where was the marshal, he wanted
+        about their damned Irish language. <Annotation annotationId="060033corporation">Where was the marshal, he wanted
         to know, to keep order in the council chamber. And old Barlow the
         macebearer laid up with asthma, no mace on the table, nothing in order,
         no quorum even, and Hutchinson, the lord mayor, in Llandudno and little
@@ -2203,7 +2203,7 @@ const WanderingRocks = ({openNote, currentNoteId, visitedNotes, addToVisited}) =
         Dedalus on <i>Hamlet.</i>
       </p>
       <p>
-        Haines opened his <Annotation annotationId="090003hyde" visited={visitedNotes.has("090003hyde")} annotationSelect={() => {openNote("090003hyde"); addToVisited("090003hyde")}} activeAnnotationId={currentNoteId}>newbought book</Annotation>.
+        Haines opened his <Annotation annotationId="090003hyde">newbought book</Annotation>.
       </p>
       <span data-edition="ed1922" data-page="238"> </span>
       <p>
@@ -2282,7 +2282,7 @@ const WanderingRocks = ({openNote, currentNoteId, visitedNotes, addToVisited}) =
         street past 
         <span data-edition="ed1939" data-page="182"> </span>
         <span data-edition="ed1922" data-page="239"> </span>
-        Benson's ferry, and by <Annotation annotationId="030071threemaster" visited={visitedNotes.has("030071threemaster")} annotationSelect={() => {openNote("030071threemaster"); addToVisited("030071threemaster")}} activeAnnotationId={currentNoteId}>the threemasted schooner <i>Rosevean</i>
+        Benson's ferry, and by <Annotation annotationId="030071threemaster">the threemasted schooner <i>Rosevean</i>
         from Bridgwater with bricks</Annotation>.
       </p>
       <p>
@@ -2345,7 +2345,7 @@ const WanderingRocks = ({openNote, currentNoteId, visitedNotes, addToVisited}) =
         <span data-edition="ed1922" data-page="240"> </span>
         and putting up their props. From the sidemirrors two mourning
         Masters Dignam gaped silently. Myler Keogh, Dublin's pet lamb, will
-        meet sergeantmajor Bennett, the <Annotation annotationId="010013barracks" visited={visitedNotes.has("010013barracks")} annotationSelect={() => {openNote("010013barracks"); addToVisited("010013barracks")}} activeAnnotationId={currentNoteId}>Portobello</Annotation> bruiser, for a purse of fifty
+        meet sergeantmajor Bennett, the <Annotation annotationId="010013barracks">Portobello</Annotation> bruiser, for a purse of fifty
         sovereigns. Gob, that'd be a good pucking match to see. Myler Keogh,
         that's the chap sparring out to him with the green sash. Two bar
         entrance, soldiers half price. I could easy do a bunk on ma. Master
@@ -2354,7 +2354,7 @@ const WanderingRocks = ({openNote, currentNoteId, visitedNotes, addToVisited}) =
         turned to the right and on his right Master Dignam turned, his cap awry,
         his collar sticking up. Buttoning it down, his chin lifted, he saw the
         image of Marie Kendall, charming soubrette, beside the two puckers. <span data-edition="ed1932" data-page="225"></span>One
-        of them mots <Annotation annotationId="090012brogue" visited={visitedNotes.has("090012brogue")} annotationSelect={() => {openNote("090012brogue"); addToVisited("090012brogue")}} activeAnnotationId={currentNoteId}>that do be</Annotation> in the packets of fags Stoer smokes that his old
+        of them mots <Annotation annotationId="090012brogue">that do be</Annotation> in the packets of fags Stoer smokes that his old
         fellow welted hell out of him for one time he found out.
       </p>
       <p>
@@ -2395,7 +2395,7 @@ const WanderingRocks = ({openNote, currentNoteId, visitedNotes, addToVisited}) =
         Pa was inside it and ma crying in the parlour and uncle Barney telling
         the men how to get it round the bend. A big coffin it was, and high and
         heavylooking. How was that? The last night pa was boosed he was standing
-        on the landing there <Annotation annotationId="050049comehometoma" visited={visitedNotes.has("050049comehometoma")} annotationSelect={() => {openNote("050049comehometoma"); addToVisited("050049comehometoma")}} activeAnnotationId={currentNoteId}>bawling out for his boots to go out to Tunney's for
+        on the landing there <Annotation annotationId="050049comehometoma">bawling out for his boots to go out to Tunney's for
         to boose more</Annotation> and he looked butty and short in his shirt. Never see him
         again. Death, that is. Pa is dead. My father is dead. He told me to be
         a good son to ma. I couldn't hear the other things he said but I saw
@@ -2403,7 +2403,7 @@ const WanderingRocks = ({openNote, currentNoteId, visitedNotes, addToVisited}) =
         <span data-edition="ed1922" data-page="241"> </span>
         trying to say it better. Poor pa. That was
         Mr Dignam, my father. I hope he is in <span data-edition="ed1961" data-page="251"></span>purgatory now because he went to
-        confession to <Annotation annotationId="040027conroy" visited={visitedNotes.has("040027conroy")} annotationSelect={() => {openNote("040027conroy"); addToVisited("040027conroy")}} activeAnnotationId={currentNoteId}>Father Conroy</Annotation> on Saturday night.
+        confession to <Annotation annotationId="040027conroy">Father Conroy</Annotation> on Saturday night.
       </p>
       <p>
         *<br/>
@@ -2417,7 +2417,7 @@ const WanderingRocks = ({openNote, currentNoteId, visitedNotes, addToVisited}) =
       </p>
       <p>
         The cavalcade passed out by the lower gate of Phoenix park saluted <span data-edition="ed1932" data-page="226"></span>by
-        obsequious policemen and proceeded <Annotation annotationId="180007kingsbridge" visited={visitedNotes.has("180007kingsbridge")} annotationSelect={() => {openNote("180007kingsbridge"); addToVisited("180007kingsbridge")}} activeAnnotationId={currentNoteId}>past Kingsbridge</Annotation> along the northern
+        obsequious policemen and proceeded <Annotation annotationId="180007kingsbridge">past Kingsbridge</Annotation> along the northern
         quays. The viceroy was most cordially greeted on his way through the
         metropolis. At Bloody bridge Mr Thomas Kernan beyond the river greeted
         him vainly from afar Between Queen's and Whitworth bridges lord Dudley's
@@ -2425,19 +2425,19 @@ const WanderingRocks = ({openNote, currentNoteId, visitedNotes, addToVisited}) =
         L., M. A., who stood on Arran quay outside Mrs M. E. White's, the
         pawnbroker's, at the corner of Arran street west stroking his nose with
         his forefinger, undecided whether he should arrive at Phibsborough
-        more quickly by a triple change of tram or by <Annotation annotationId="050013jauntingcar" visited={visitedNotes.has("050013jauntingcar")} annotationSelect={() => {openNote("050013jauntingcar"); addToVisited("050013jauntingcar")}} activeAnnotationId={currentNoteId}>hailing a car</Annotation> or on foot
+        more quickly by a triple change of tram or by <Annotation annotationId="050013jauntingcar">hailing a car</Annotation> or on foot
         through Smithfield, Constitution hill and Broadstone terminus. In the
         porch of Four Courts Richie Goulding with the costsbag of Goulding,
         Collis and Ward saw him with surprise. Past Richmond bridge at the
         doorstep of the office of Reuben J Dodd, solicitor, agent for the
         Patriotic Insurance Company, an elderly female about to enter changed
         her plan and retracing her steps by King's windows smiled credulously
-        on the representative of His Majesty. <Annotation annotationId="030039sewage" visited={visitedNotes.has("030039sewage")} annotationSelect={() => {openNote("030039sewage"); addToVisited("030039sewage")}} activeAnnotationId={currentNoteId}>From its sluice in Wood quay wall
+        on the representative of His Majesty. <Annotation annotationId="030039sewage">From its sluice in Wood quay wall
         under Tom Devan's office Poddle river hung out in </Annotation>
         <span data-edition="ed1939" data-page="184"> </span>
-        <Annotation annotationId="030039sewage" visited={visitedNotes.has("030039sewage")} annotationSelect={() => {openNote("030039sewage"); addToVisited("030039sewage")}} activeAnnotationId={currentNoteId}>fealty a tongue of
+        <Annotation annotationId="030039sewage">fealty a tongue of
         liquid sewage.</Annotation> Above the crossblind of the Ormond hotel, gold by bronze,
-        Miss Kennedy's head by Miss Douce's head watched and admired. <Annotation annotationId="080027greenhouses" visited={visitedNotes.has("080027greenhouses")} annotationSelect={() => {openNote("080027greenhouses"); addToVisited("080027greenhouses")}} activeAnnotationId={currentNoteId}>On Ormond
+        Miss Kennedy's head by Miss Douce's head watched and admired. <Annotation annotationId="080027greenhouses">On Ormond
         quay Mr Simon Dedalus, steering his way from the greenhouse for the
         subsheriff's office, stood still in midstreet and brought his hat low.
         His Excellency graciously returned Mr Dedalus' greeting.</Annotation> From Cahill's
@@ -2471,7 +2471,7 @@ const WanderingRocks = ({openNote, currentNoteId, visitedNotes, addToVisited}) =
         French primer, saw sunshades spanned and wheelspokes spinning in the
         glare. John Henry Menton, filling the doorway of Commercial Buildings,
         stared from winebig oyster eyes, holding a fat gold hunter watch not
-        looked at in his fat left hand not feeling it. <Annotation annotationId="100001kingbilly" visited={visitedNotes.has("100001kingbilly")} annotationSelect={() => {openNote("100001kingbilly"); addToVisited("100001kingbilly")}} activeAnnotationId={currentNoteId}>Where the foreleg of King
+        looked at in his fat left hand not feeling it. <Annotation annotationId="100001kingbilly">Where the foreleg of King
         Billy's horse pawed the air Mrs Breen plucked her hastening husband
         back from under the hoofs of the outriders.</Annotation> She shouted in his ear the
         tidings. Understanding, he shifted his tomes to his left breast
@@ -2482,7 +2482,7 @@ const WanderingRocks = ({openNote, currentNoteId, visitedNotes, addToVisited}) =
         Pigott's music warerooms Mr Denis J Maginni, professor of dancing &amp;c,
         gaily apparelled, gravely walked, outpassed by a viceroy and unobserved.
         By the provost's wall came jauntily Blazes Boylan, stepping in tan <span data-edition="ed1961" data-page="253"></span>shoes
-        and <Annotation annotationId="100005skyblueclocks" visited={visitedNotes.has("100005skyblueclocks")} annotationSelect={() => {openNote("100005skyblueclocks"); addToVisited("100005skyblueclocks")}} activeAnnotationId={currentNoteId}>socks with skyblue clocks</Annotation> to the refrain of <Annotation annotationId="100004yorkshiregirl" visited={visitedNotes.has("100004yorkshiregirl")} annotationSelect={() => {openNote("100004yorkshiregirl"); addToVisited("100004yorkshiregirl")}} activeAnnotationId={currentNoteId}><i>My girl's a Yorkshire
+        and <Annotation annotationId="100005skyblueclocks">socks with skyblue clocks</Annotation> to the refrain of <Annotation annotationId="100004yorkshiregirl"><i>My girl's a Yorkshire
         girl</i></Annotation>.
       </p>
       <p>
@@ -2524,11 +2524,11 @@ const WanderingRocks = ({openNote, currentNoteId, visitedNotes, addToVisited}) =
         drove with his following towards Lower Mount street. He passed a blind
         stripling opposite Broadbent's. In Lower Mount street a pedestrian in a
         brown macintosh, eating dry bread, passed swiftly and unscathed across
-        the viceroy's path. At <Annotation annotationId="060016canals" visited={visitedNotes.has("060016canals")} annotationSelect={() => {openNote("060016canals"); addToVisited("060016canals")}} activeAnnotationId={currentNoteId}>the Royal Canal bridge</Annotation>, <Annotation annotationId="060003eugenestratton" visited={visitedNotes.has("060003eugenestratton")} annotationSelect={() => {openNote("060003eugenestratton"); addToVisited("060003eugenestratton")}} activeAnnotationId={currentNoteId}>from his hoarding,
+        the viceroy's path. At <Annotation annotationId="060016canals">the Royal Canal bridge</Annotation>, <Annotation annotationId="060003eugenestratton">from his hoarding,
         Mr Eugene Stratton</Annotation>, his blub lips agrin, bade all comers welcome to
         Pembroke township. At Haddington road corner two sanded women halted
-        themselves, <Annotation annotationId="030054swunglourdily" visited={visitedNotes.has("030054swunglourdily")} annotationSelect={() => {openNote("030054swunglourdily"); addToVisited("030054swunglourdily")}} activeAnnotationId={currentNoteId}>an umbrella and a bag in which eleven cockles rolled to view
-        with wonder the lord mayor</Annotation> and lady <span data-edition="ed1961" data-page="254"></span>mayoress <Annotation annotationId="060033corporation" visited={visitedNotes.has("060033corporation")} annotationSelect={() => {openNote("060033corporation"); addToVisited("060033corporation")}} activeAnnotationId={currentNoteId}>without his golden chain</Annotation>.
+        themselves, <Annotation annotationId="030054swunglourdily">an umbrella and a bag in which eleven cockles rolled to view
+        with wonder the lord mayor</Annotation> and lady <span data-edition="ed1961" data-page="254"></span>mayoress <Annotation annotationId="060033corporation">without his golden chain</Annotation>.
         On Northumberland and Landsdowne roads His Excellency acknowledged
         punctually salutes from rare male walkers, the salute of two small
         schoolboys at the garden gate of the house said to have been admired

--- a/src/index.js
+++ b/src/index.js
@@ -3,11 +3,14 @@ import ReactDOM from 'react-dom';
 import './index.css';
 import App from './App';
 import reportWebVitals from './reportWebVitals';
+import store from './app/store';
+import { Provider } from 'react-redux'
+
 
 ReactDOM.render(
-  <React.StrictMode>
+  <Provider store={store}>
     <App />
-  </React.StrictMode>,
+  </Provider>,
   document.getElementById('root')
 );
 

--- a/src/index.js
+++ b/src/index.js
@@ -8,9 +8,11 @@ import { Provider } from 'react-redux'
 
 
 ReactDOM.render(
-  <Provider store={store}>
-    <App />
-  </Provider>,
+  <React.StrictMode>
+    <Provider store={store}>
+      <App />
+    </Provider>
+  </React.StrictMode>,
   document.getElementById('root')
 );
 


### PR DESCRIPTION
Migrate state to redux store. There is some unserialisable state in the redux store (`Set` type tracking opened notes and React `Function` component type in current chapter slice). This should be changed to use a reference to the chapter id in the latter case and, in the former case, I'm not entirely sure what the cleanest pattern would be. 